### PR TITLE
Add test_x3s lint runner

### DIFF
--- a/tools/test_x3s.py
+++ b/tools/test_x3s.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import subprocess, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+def run(cmd): 
+  print('>', ' '.join(cmd))
+  p = subprocess.run(cmd, cwd=ROOT)
+  if p.returncode:
+    sys.exit(p.returncode)
+
+if __name__ == '__main__':
+  run([sys.executable, 'tools/x3s_lint.py'])
+


### PR DESCRIPTION
## Summary
- add `tools/test_x3s.py` to invoke the X3S linter from the repository root

## Plan
- provide a simple wrapper script for `tools/x3s_lint.py`

## Checklist
- [ ] `python tools/test_x3s.py` *(fails: can't open file 'tools/x3s_lint.py')*

## Testing
- `python tools/test_x3s.py` *(fails: can't open file 'tools/x3s_lint.py')*

------
https://chatgpt.com/codex/tasks/task_e_68c5ebe7c6d88326b29ba038328ce2d3