### PR TITLE
Add flow control command reference

### DIFF
--- a/docs/flow-control-commands.md
+++ b/docs/flow-control-commands.md
@@ -1,0 +1,20 @@
+# Flow Control Commands
+
+This reference covers flow control commands available in X3TC scripting. Each entry shows the basic syntax.
+
+- `<RefObj> begin task <Var/Number> with script <Script Name> and priority <Var/Number>: arg1=<Value0> arg2=<Value1> arg3=<Value2> arg4=<Value3> arg5=<Value4>`
+- `<RetVar/IF> <RefObj> call named script: script=<Var/String>, <Value>, <Value>, <Value>, <Value>, <Value>`
+- `<RetVar/IF/START> <RefObj> call script <Script Name> : [ arg1=<Value> arg2=<Value> ... arga=<Value> ]`
+- `START <RefObj> command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
+- `START <RefObj> delayed command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
+- `endsub`
+- `gosub <Label Name>:`
+- `goto label <Label Name>:`
+- `<RefObj> interrupt task <Var/Number> with script <Script Name> and priority <Var/Number>: arg1=<Value0> arg2=<Value1> arg3=<Value2> arg4=<Value3>`
+- `<RefObj> interrupt with script <Script Name> and priority <Var/Number>`
+- `<RefObj> interrupt with script <Script Name> and priority <Var/Number>: arg1=<Value> arg2=<Value> arg3=<Value> arg4=<Value>`
+- `<RefObj> launch named script: task=<Var/Number> scriptname=<Var/String> prio=<Var/Number>, <Value>, <Value>, <Value>, <Value>, <Value>`
+- `<RetVar/IF> wait <Var/Number> ms`
+- `<RetVar/IF> wait randomly from <Var/Number> to <Var/Number> ms`
+- `START <RefObj> wing command <Var/Wing Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
+


### PR DESCRIPTION
## Summary
- document X3TC flow control commands with syntax examples

## Testing
- `python tools/test_x3s.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ec4075c0832699feba3016685216