### PR TITLE
Add setup plugin script and support variable page IDs

### DIFF
--- a/src/scripts/setup.plugin.slx.x3s
+++ b/src/scripts/setup.plugin.slx.x3s
@@ -1,0 +1,66 @@
+* ******************************************************************************
+* SCRIPT NAME: setup.plugin.slx
+* DESCRIPTION: SLX Station Logistics X3  (setup + AL plugin registration + loop guard)
+* AUTHOR:      Brandon              DATE: 8 September 2025
+* ******************************************************************************
+
+
+$Ver.Major = 1
+$Ver.Minor = 0
+$Ver.Patch = 0
+
+$PageId = 9055
+
+* A combined integer is handy for comparison, e.g. v1.2.3 =
+* |Maj|Min|Pch|
+* |001|002|003|
+$Ver.Internal = ($Ver.Major * 1000000) + ($Ver.Minor * 1000) + $Ver.Patch
+
+$Config.Ver.Major = 0
+$Config.Ver.Minor = 1
+$Config.Ver.Patch = 2
+$Config.Ver.Internal = 3
+$Config.PageId = 4
+$Config.Debug.Enabled = 5
+$Config.Debug.Verbosity = 6
+$Config.Debug.Target = 7
+$Config.Required.Ware = 8
+$Config.Auto.Rename = 9
+$Config.Blacklist = 10
+$Config.Monitor.Task = 11
+$Config.Trade.Threshold = 12
+$Config.All.Wares = 13
+$Config.Trade.Illegal.Wares = 14
+$Config.Races = 15
+$Config.Illegal.Wares = 16
+$Config.Refuel.Percent = 17
+$Config.Global.Balance = 18
+$Config.Trade.Cache = 19
+$Config.Equip = 20
+$Config.Alert.Sound = 21
+
+load text: id=$PageId
+
+$section = read text: page=$PageId id=101
+$txt = read text: page=$PageId id=102
+
+skip if $section
+$section = 'SLX'
+
+skip if $txt
+$txt = 'Open SLX'
+
+$st = get global variable: name='slx.stations'
+if not $st
+$st = array alloc: size=0
+set global variable: name='slx.stations' value=$st
+end
+
+= [THIS]-> call script 'plugin.slx.Wares' : argument1=null
+
+* Register AL plugin for SLX
+al engine: register script='al.plugin.slx'
+al engine: set plugin 'al.plugin.slx' description to 'SLX Station Logistics'
+al engine: set plugin 'al.plugin.slx' timer interval to 30 s
+
+return null

--- a/tools/x3s_lint.py
+++ b/tools/x3s_lint.py
@@ -18,7 +18,7 @@ ROOT = Path(__file__).resolve().parents[1]
 SRC  = ROOT / "src" / "scripts"
 
 LINE_PATTERNS = [
-  re.compile(r"^load text:\s*id=\d+$", re.I),
+  re.compile(r"^load text:\s*id=(\d+|\$[A-Za-z0-9_.]+)$", re.I),
   re.compile(r"^al engine:\s*register script='[^']+'$", re.I),
   re.compile(r"^al engine:\s*set plugin '[^']+' description to '.*'$", re.I),
   re.compile(r"^al engine:\s*set plugin '[^']+' timer interval to \d+\s*s$", re.I),
@@ -103,7 +103,7 @@ def lint_file(path: Path) -> list[str]:
     errors.append(f"{path.name}:{opener.line_no}: '{opener.kind}' not closed with 'end'")
 
   # setup rule
-  if setup_like and not any(re.match(r"^load text:\s*id=\d+$", l, re.I) for _, l in body):
+  if setup_like and not any(re.match(r"^load text:\s*id=(\d+|\$[A-Za-z0-9_.]+)$", l, re.I) for _, l in body):
     errors.append(f"{path.name}: setup script missing 'load text: id=<...>'")
 
   # emit


### PR DESCRIPTION
## Summary
- add `setup.plugin.slx` setup script that loads its text page, seeds globals, and registers the SLX AL plugin
- allow `load text: id=$var` in the X3S linter so setup scripts can use variable page IDs

## Testing
- `python tools/test_x3s.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5edf4d2548326a3dc02f25503e374