### PR TITLE
Learn from known-good .x3s and update linter

### DIFF
--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -1,0 +1,6 @@
+# X3S Language
+
+## New Statements Recognized
+- **write.log**: `write to log file $DebugID append=[FALSE] value=$txt`
+- **dec**: `dec $s`
+- **remove.array.elem**: `remove element from array $config.Array at index $s`

--- a/tools/fixtures/known_good/plugin.LI.FDN.Setup.x3s
+++ b/tools/fixtures/known_good/plugin.LI.FDN.Setup.x3s
@@ -1,0 +1,58 @@
+* Author: Logain Abler
+* -----------------------------------------------------------------------------------
+* setup handles the srart and stop actions for FDN
+
+* Expected values:
+* - dock
+
+* Returns values:
+* - N/A
+
+* To Do - N/A
+
+* Version: 1.0
+* Date: 23/05/2012
+* Tested: 23/05/2012
+* -----------------------------------------------------------------------------------
+
+* Fetch values saved in the AL Plugin global variable:
+$al.Settings = get global variable: name='al.LI.FDN.event'
+if $al.Settings
+$status = $al.Settings[0]
+$PageID = $al.Settings[1]
+$DebugID = 0 + $PageID
+else
+return null
+end
+* -----------------------------------------------------------------------------------
+
+* Create debug log
+$txt = 'FDN Debug Log:'
+write to log file $DebugID append=[FALSE] value=$txt
+
+* Setup
+if $status == [TRUE]
+* add fdn menu to config
+$section = read text: page=$PageID id=101
+$txt = read text: page=$PageID id=102
+= [THIS]-> call script 'plugin.config.addscript' : argument1=$txt argument2=null argument3='plugin.LI.FDN.Main.Menu' argument4=[FALSE] argument5=$section argument6=null
+* -----------------------------------------------------------------------------------
+else
+* remove fdn from config
+$config.Array = get global variable: name='config.scripts'
+if $config.Array
+$s = size of array $config.Array
+while $s > 0
+dec $s
+$script.Array = $config.Array[$s]
+$script = $script.Array[0]
+$menu = read text: page=$PageID id=102
+if $script == $menu
+remove element from array $config.Array at index $s
+end
+end
+end
+end
+
+return null
+

--- a/tools/fixtures/should_fail/missing_wait.x3s
+++ b/tools/fixtures/should_fail/missing_wait.x3s
@@ -1,0 +1,5 @@
+* while loop without wait should fail
+$i = 0
+while $i < 10
+inc $i
+end

--- a/tools/test_x3s.py
+++ b/tools/test_x3s.py
@@ -3,12 +3,21 @@ import subprocess, sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-def run(cmd): 
+
+def run(cmd):
   print('>', ' '.join(cmd))
   p = subprocess.run(cmd, cwd=ROOT)
   if p.returncode:
     sys.exit(p.returncode)
 
+def run_fail(cmd):
+  print('>', ' '.join(cmd))
+  p = subprocess.run(cmd, cwd=ROOT)
+  if p.returncode == 0:
+    sys.exit(1)
+
 if __name__ == '__main__':
   run([sys.executable, 'tools/x3s_lint.py'])
+  run([sys.executable, 'tools/x3s_lint.py', 'tools/fixtures/known_good'])
+  run_fail([sys.executable, 'tools/x3s_lint.py', 'tools/fixtures/should_fail'])
 

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -1,0 +1,69 @@
+{
+  "patterns": [
+    {
+      "name": "load.text",
+      "regex": "^load text:\\s*id=(\\d+|\\$[A-Za-z0-9_.]+)$",
+      "examples": ["load text: id=9055"]
+    },
+    {
+      "name": "al.register",
+      "regex": "^al engine:\\s*register script='[^']+'$",
+      "examples": ["al engine: register script='al.plugin.slx'"]
+    },
+    {
+      "name": "al.description",
+      "regex": "^al engine:\\s*set plugin '[^']+' description to '.*'$",
+      "examples": ["al engine: set plugin 'al.plugin.slx' description to 'SLX Station Logistics'"]
+    },
+    {
+      "name": "al.timer",
+      "regex": "^al engine:\\s*set plugin '[^']+' timer interval to \\d+\\s*s$",
+      "examples": ["al engine: set plugin 'al.plugin.slx' timer interval to 30 s"]
+    },
+    {
+      "name": "stop.task",
+      "regex": "^\\[THIS]->stop task \\d+$",
+      "examples": ["[THIS]->stop task 0"]
+    },
+    {
+      "name": "start.task",
+      "regex": "^start task \\d+\\s+with script='[^']+'\\s+on=\\[THIS\\]$",
+      "examples": ["start task 123 with script='plugin.example' on=[THIS]"]
+    },
+    {
+      "name": "call.script",
+      "regex": "^=?\\s*\\[THIS]->\\s*call script '[^']+'( : .*)?$",
+      "examples": ["= [THIS]-> call script 'plugin.config.addscript' : argument1=$txt"]
+    },
+    {
+      "name": "wait",
+      "regex": "^=?\\s*wait \\d+\\s*ms$",
+      "examples": ["wait 1000 ms"]
+    },
+    {
+      "name": "set.global",
+      "regex": "^set global variable:\\s*name='[^']+'\\s*value=.*$",
+      "examples": ["set global variable: name='g.slx.foo' value=$bar"]
+    },
+    {
+      "name": "return",
+      "regex": "^return (null|value .+)$",
+      "examples": ["return null"]
+    },
+    {
+      "name": "write.log",
+      "regex": "^write to log file \\$[A-Za-z0-9_.]+ append=\\[(TRUE|FALSE)\\] value=(\\$[A-Za-z0-9_.]+|'[^']+')$",
+      "examples": ["write to log file $DebugID append=[FALSE] value=$txt"]
+    },
+    {
+      "name": "dec",
+      "regex": "^dec \\$[A-Za-z0-9_.]+$",
+      "examples": ["dec $s"]
+    },
+    {
+      "name": "remove.array.elem",
+      "regex": "^remove element from array \\$[A-Za-z0-9_.]+ at index \\$[A-Za-z0-9_.]+$",
+      "examples": ["remove element from array $config.Array at index $s"]
+    }
+  ]
+}


### PR DESCRIPTION
## Plan
- allow reusable lint patterns
- learn new statements from known-good scripts
- test positive and negative fixtures

## Changes
- load regex allowlist from `tools/x3s_rules.json`
- support decrement-driven finite loops in wait check
- expose directory arguments in `x3s_lint.py`
- add fixtures and update tests to lint them
- document new statement families

## Test Results
- `python tools/x3s_lint.py`
- `python tools/x3s_lint.py tools/fixtures/known_good`
- `python tools/x3s_lint.py tools/fixtures/should_fail` *(fails: while-block has no 'wait')*
- `python tools/test_x3s.py`

## Pattern List
- `write.log`
- `dec`
- `remove.array.elem`

## Safety Checks
- control-flow stack validation
- wait requirement for loops without proven progress
- setup scripts must load text


------
https://chatgpt.com/codex/tasks/task_e_68c5eeaa837083269f5f97f74842a9c4