### PR TITLE
Learn from known-good .x3s and update our linter (no XML build)

### DIFF
--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -4,3 +4,8 @@
 - **write.log**: `write to log file $DebugID append=[FALSE] value=$txt`
 - **dec**: `dec $s`
 - **remove.array.elem**: `remove element from array $config.Array at index $s`
+- **skip.if**: `skip if $section`
+- **al.description.var**: `al engine: set plugin $al.PluginID description to $plugin.description`
+- **al.timer.var**: `al engine: set plugin $al.PluginID timer interval to 25 s`
+- **set.global.var**: `set global variable: name=$al.PluginID value=$al.Settings`
+- **return.var**: `return $al.Ret`

--- a/tools/fixtures/known_good/al.LI.FDN.event.x3s
+++ b/tools/fixtures/known_good/al.LI.FDN.event.x3s
@@ -1,0 +1,52 @@
+* Auther: Logain Abler
+* --------------------
+
+$PageID = 9910
+
+$al.Settings = get global variable: name=$al.PluginID
+if not $al.Settings
+$al.Settings = array alloc: size=30
+$al.Settings[0] = [FALSE]
+$al.Settings[1] = $PageID
+$al.Settings[2] = null
+$factory.array = array alloc: size=0
+$al.Settings[3] = $factory.array
+$dock.array = array alloc: size=0
+$al.Settings[4] = $dock.array
+$al.Settings[5] = null
+$is.dymanic = array alloc: size=10
+$is.dymanic[0] = [TRUE]
+$is.dymanic[1] = [TRUE]
+$is.dymanic[2] = [TRUE]
+$al.Settings[6] = $is.dymanic
+$al.Settings[7] = null
+set global variable: name=$al.PluginID value=$al.Settings
+end
+
+$al.Ret = null
+if $al.Event == 'init' OR $al.Event == 'reinit'
+
+$plugin.description = sprintf: pageid=$PageID textid=100, null, null, null, null, null
+al engine: set plugin $al.PluginID description to $plugin.description
+al engine: set plugin $al.PluginID timer interval to 25 s
+
+= [THIS]-> call script 'plugin.LI.FDN.Setup' :
+
+else if $al.Event == 'start'
+$al.Settings[0] = [TRUE]
+= [THIS]-> call script 'plugin.LI.FDN.Setup' :
+
+else if $al.Event == 'stop'
+$al.Settings[0] = [FALSE]
+= [THIS]-> call script 'plugin.LI.FDN.Setup' :
+
+else if $al.Event == 'timer'
+if $al.Settings[0]
+= [THIS]-> call script 'plugin.LI.FDN.Supply.Start' :
+end
+else if $al.Event == 'isenabled'
+$al.Ret = $al.Settings[0]
+end
+
+return $al.Ret
+

--- a/tools/test_x3s.py
+++ b/tools/test_x3s.py
@@ -17,7 +17,12 @@ def run_fail(cmd):
     sys.exit(1)
 
 if __name__ == '__main__':
-  run([sys.executable, 'tools/x3s_lint.py'])
+  # lint project scripts
+  run([sys.executable, 'tools/x3s_lint.py', 'src/scripts'])
+
+  # lint known-good fixtures
   run([sys.executable, 'tools/x3s_lint.py', 'tools/fixtures/known_good'])
+
+  # ensure safety checks still trigger
   run_fail([sys.executable, 'tools/x3s_lint.py', 'tools/fixtures/should_fail'])
 

--- a/tools/x3s_lint.py
+++ b/tools/x3s_lint.py
@@ -72,6 +72,9 @@ def lint_file(path: Path) -> list[str]:
     low = line.strip().lower()
     if low.startswith("if "):
       stack.append(Block("if", ln))
+    elif low.startswith("else if "):
+      if not stack or stack[-1].kind != "if":
+        errors.append(f"{path.name}:{ln}: 'else if' without matching 'if'")
     elif low == "else":
       if not stack or stack[-1].kind != "if":
         errors.append(f"{path.name}:{ln}: 'else' without matching 'if'")
@@ -104,9 +107,9 @@ def lint_file(path: Path) -> list[str]:
 
     # line-shape validation (warn on unknown shapes)
     recognizable = any(pat.match(line) for pat in LINE_PATTERNS)
-    if not recognizable and not (low.startswith("if ") or low == "else" or low == "end" or low.startswith("while ")):
+    if not recognizable and not (low.startswith("if ") or low.startswith("else if ") or low == "else" or low == "end" or low.startswith("while ")):
       # Allow variable assignments and general calls as free-form to reduce false positives
-      if not re.match(r"^\$[A-Za-z0-9_.]+(\s*=|->)", line) and "call script" not in low:
+      if not re.match(r"^\$[A-Za-z0-9_.]+(\[[^\]]+\])?(\s*=|->)", line) and "call script" not in low:
         warnings.append(f"{path.name}:{ln}: unrecognized line (check syntax): {line}")
 
   if stack:

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -64,6 +64,31 @@
       "name": "remove.array.elem",
       "regex": "^remove element from array \\$[A-Za-z0-9_.]+ at index \\$[A-Za-z0-9_.]+$",
       "examples": ["remove element from array $config.Array at index $s"]
+    },
+    {
+      "name": "skip.if",
+      "regex": "^skip if \\$[A-Za-z0-9_.]+$",
+      "examples": ["skip if $section"]
+    },
+    {
+      "name": "al.description.var",
+      "regex": "^al engine:\\s*set plugin \\$[A-Za-z0-9_.]+ description to \\$[A-Za-z0-9_.]+$",
+      "examples": ["al engine: set plugin $al.PluginID description to $plugin.description"]
+    },
+    {
+      "name": "al.timer.var",
+      "regex": "^al engine:\\s*set plugin \\$[A-Za-z0-9_.]+ timer interval to \\d+\\s*s$",
+      "examples": ["al engine: set plugin $al.PluginID timer interval to 25 s"]
+    },
+    {
+      "name": "set.global.var",
+      "regex": "^set global variable:\\s*name=\\$[A-Za-z0-9_.]+\\s*value=\\$[A-Za-z0-9_.]+$",
+      "examples": ["set global variable: name=$al.PluginID value=$al.Settings"]
+    },
+    {
+      "name": "return.var",
+      "regex": "^return \\$[A-Za-z0-9_.]+$",
+      "examples": ["return $al.Ret"]
     }
   ]
 }


### PR DESCRIPTION
## Plan
- Allow additional statement shapes observed in known-good scripts.
- Keep structural safety checks while broadening regex allowlist.
- Add fixtures to confirm both positive and negative lint outcomes.

## Changes
- Recognize `else if` and array index assignments in the linter.
- Added allowlist patterns for `skip if`, variable-based AL plugin calls, dynamic global vars, and variable returns.
- Documented new statement shapes and expanded tests.
- Added FDN event script as a known-good fixture.

## Test Results
- `python tools/x3s_lint.py`
- `python tools/test_x3s.py`

## Pattern List
- skip.if
- al.description.var
- al.timer.var
- set.global.var
- return.var

## Safety Checks
- Control-flow stack (if/else/end, while) maintained.
- While loops still require `wait` or decrement.
- Setup scripts still checked for `load text: id=<page>`.


------
https://chatgpt.com/codex/tasks/task_e_68c5f1e7345083268c3578878752eaae