### PR TITLE
Convert mod fixtures to per-mod x3s

### DIFF
--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -20,4 +20,5 @@
 
 Known-good mod fixtures live under `tools/fixtures/known_good/<mod_name>`. Each mod
 provides `src/scripts/*.x3s` as the canonical source along with any `t/` text pages
-or optional `director/` XML. These fixtures are used by the test suite.
+or optional `director/` XML. These fixtures are generated from `tools/fixtures/mods/<mod_name>`
+via `python tools/convert_mods.py` and are used by the test suite.

--- a/tools/fixtures/known_good/FDN/README.md
+++ b/tools/fixtures/known_good/FDN/README.md
@@ -1,8 +1,9 @@
-Generated from mods/FDN on 2025-09-14
+# FDN (fixtures)
 
-Scripts converted: 28
-Text pages copied: 1
-Skipped files:
-- plugin.LI.FDN.Main.Menu.xml (lint failed)
-- plugin.LI.FDN.Menu.DC.Details_D.xml (lint failed)
-- plugin.LI.FDN.Menu.Dock.Details_D.xml (lint failed)
+Generated from `mods/FDN` on 2025-09-14 00:41:13Z.
+
+## Summary
+- Scripts converted: 31
+- Scripts skipped:  0
+- Text pages copied: 1
+- Director copied:   no

--- a/tools/fixtures/known_good/FDN/src/scripts/al.LI.FDN.event.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/al.LI.FDN.event.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/al.LI.FDN.event.xml
+
 * Auther: Logain Abler
 * --------------------
 

--- a/tools/fixtures/known_good/FDN/src/scripts/al.plugin.LI.FDN.register.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/al.plugin.LI.FDN.register.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/al.plugin.LI.FDN.register.xml
+
 $PageID = 9910
 load text: id=$PageID
 

--- a/tools/fixtures/known_good/FDN/src/scripts/lib.BW.isAP.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/lib.BW.isAP.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/lib.BW.isAP.xml
+
 * BW: ===============================
 * Test for AP.
 * BW: ===============================

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Buy.Ware.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Buy.Ware.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Buy.Ware.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This script is called by LI.FDN.Supply.Factory

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Cleanup.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Cleanup.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Cleanup.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * this script clears the global values used for dynamic menus

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Config.Menu.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Config.Menu.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Config.Menu.xml
+
 * Auther: Logain Abler
 * --------------------
 * This is the main menu for FDN and has 3 dynamic viewa

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Format.Name.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Format.Name.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Format.Name.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This script fromats object names for the menu

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Main.Menu.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Main.Menu.x3s
@@ -1,0 +1,590 @@
+#name: plugin.LI.FDN.Main.Menu
+#lang: 44
+#origin_mod: FDN
+#source: mods/FDN/scripts/plugin.LI.FDN.Main.Menu.xml
+
+* Auth0r: Logain Abler
+* --------------------
+* This is the main menu for FDN and has 3 dynamic viewa
+* Menu View 1 = Distribution Centre Details (default)
+* Menu View 2 = Factory View
+* Menu View 3 = Dock View - REMOVED
+* Menu View 4 = Factory Details
+* Menu View 5 = Dock Details
+* Menu View 6 = Ware Details
+* Menu View 7 = Config
+* Menu is called from pludin manager
+
+* Returns TBC
+* Date: 17/05/2012 - v1.0
+* Tested: TBC
+
+
+* Get AL settings
+
+$al.Settings = get global variable: name='al.LI.FDN.event'
+if $al.Settings
+$PageID = $al.Settings[1]
+$dc = $al.Settings[2]
+$factory.array = $al.Settings[3]
+else
+return null
+end
+
+* if AP use AP menus
+$is.AP = null -> call script lib.BW.isAP :
+
+$return = null
+$called.by = null
+$factory.show.array = null
+$menu.view = 1
+
+* Start Menu
+while [TRUE]
+$cap = null
+$trade = null
+$dc = $al.Settings[2]
+$is.dynamic = $al.Settings[6]
+
+$txt = = read text: page=$PageID id=102
+$menu = = create custom menu array: heading=$txt
+
+if $menu.view == 1 OR $menu.view == 2 OR $menu.view == 3
+gosub Menu.View.Header.Sub:
+end
+
+if not $dc
+$menu.view = 7
+gosub Config.View.Sub:
+else
+* Build Menu Body
+if $menu.view == 1
+gosub DC.Details.View.Sub:
+else if $menu.view == 2
+gosub Factory.List.View.Sub:
+else if $menu.view == 4
+gosub Factory.Details.View.Sub:
+else if $menu.view == 5
+gosub Dock.Details.View.Sub:
+else if $menu.view == 6
+gosub Ware.Details.View.Sub:
+else if $menu.view == 7
+gosub Config.View.Sub:
+end
+end
+
+$al.Settings[5] = $menu.view
+set global variable: name='al.LI.FDN.event' value=$al.Settings
+
+add section to custom menu: $menu
+
+* Call Menu View for Footer
+gosub Menu.View.Footer.Sub:
+
+
+* Start of return
+if $return == -1
+if $menu.view == 1 OR $menu.view == 2 OR $menu.view == 3
+$al.Settings[5] = null
+set global variable: name='al.LI.FDN.event' value=$al.Settings
+START  = null -> call script plugin.LI.FDN.Cleanup :
+return null
+else if not $dc
+START  = null -> call script plugin.LI.FDN.Cleanup :
+return null
+else
+
+if $menu.view == 3
+$menu.view = 1
+else if $menu.view == 4
+$menu.view = 2
+else if $menu.view == 5
+$menu.view = 2
+else if $menu.view == 6
+$menu.view = $called.by
+else if $menu.view == 7
+$menu.view = 1
+end
+end
+
+else if is datatyp[ $return ] == DATATYPE_ARRAY
+$command = $return[0]
+$value = $return[1]
+
+if $command == 'remote.cap'
+$menu.view = 6
+$ware = $return[2]
+$cap = [TRUE]
+gosub Ware.User.Input.Sub:
+
+else if $command == 'maintain.cap'
+$menu.view = 6
+$ware = $return[2]
+$cap = [TRUE]
+gosub Ware.User.Input.Sub:
+
+else if $command == 'can.buy'
+$menu.view = 6
+$ware = $return[2]
+gosub Ware.User.Input.Sub:
+
+else if $command == 'surplus'
+$menu.view = 6
+$ware = $return[2]
+gosub Ware.User.Input.Sub:
+
+else if $command == 'buy.at'
+$menu.view = 6
+$ware = $return[2]
+$trade = [TRUE]
+gosub Ware.User.Input.Sub:
+
+else if $command == 'sell.cap'
+$menu.view = 6
+$ware = $return[2]
+$cap = [TRUE]
+gosub Ware.User.Input.Sub:
+
+else if $command == 'sell.at'
+$menu.view = 6
+$ware = $return[2]
+$trade = [TRUE]
+gosub Ware.User.Input.Sub:
+
+else if $command == 'move.ware'
+$menu.view = 6
+$ware = $return[2]
+$dummy = null -> call script plugin.LI.FDN.Move.Ware : ware=$ware  source=$value
+
+else if $command == 'to.physical'
+$menu.view = 6
+$ware = $return[2]
+gosub Regroom.Ware.Sub:
+
+else if $command == 'to.virtual'
+$menu.view = 6
+$ware = $return[2]
+gosub Regroom.Ware.Sub:
+
+else if $command == 'remove.ware'
+$menu.view = $called.by
+$ware = $return[2]
+gosub Remove.Ware.Sub:
+
+else if $command == 'add.ware'
+gosub Add.Ware.Sub:
+
+else if $command == 'open.factory'
+$menu.view = 4
+
+else if $command == 'add.dc'
+$al.Settings[2] = $value
+set global variable: name='al.LI.FDN.event' value=$al.Settings
+$menu.view = 7
+
+else if $command == 'change.dc'
+$al.Settings[2] = $value
+set global variable: name='al.LI.FDN.event' value=$al.Settings
+$menu.view = 7
+
+else if $command == 'open.dock'
+$menu.view = 5
+
+else if $command == 'open.ware'
+$called.by = $menu.view
+$ware = $return[2]
+$menu.view = 6
+
+* these are used for TC menu - not required for AP
+
+else if $command == 'show.factory'
+$check = $factory.show.array[$value]
+if $check == 1
+$factory.show.array[$value] = 2
+else
+$factory.show.array[$value] = 1
+end
+
+else if $command == 'show.type.dc'
+$pointer = = read text: page=$PageID id=4004
+$show.type.array = $dc  ->  get local variable: name=$pointer
+$check = $show.type.array[$value]
+if $check == 1
+$show.type.array[$value] = 2
+else
+$show.type.array[$value] = 1
+end
+$dc  ->  set local variable: name=$pointer value=$show.type.array
+
+else if $command == 'show.type.dock'
+$count = $return[1][0]
+$value = $return[1][1]
+$pointer = = read text: page=$PageID id=4003
+$show.type.array = $value  ->  get local variable: name=$pointer
+$check = $show.type.array[$count]
+if $check == 1
+$show.type.array[$count] = 2
+else
+$show.type.array[$count] = 1
+end
+$value  ->  set local variable: name=$pointer value=$show.type.array
+
+
+else if $command == 'product'
+$pointer = = read text: page=$PageID id=4001
+$settings.array = $value  ->  get local variable: name=$pointer
+if $settings.array[0]
+$settings.array[0] = null
+else
+$settings.array[0] = 1
+end
+$value  ->  set local variable: name=$pointer value=$settings.array
+
+else if $command == 'resource'
+$pointer = = read text: page=$PageID id=4001
+$settings.array = $value  ->  get local variable: name=$pointer
+if $settings.array[1]
+$settings.array[1] = null
+else
+$settings.array[1] = 1
+end
+$value  ->  set local variable: name=$pointer value=$settings.array
+
+end
+
+$al.Settings[5] = $menu.view
+set global variable: name='al.LI.FDN.event' value=$al.Settings
+else
+
+if $return == 'dynamic.dc'
+if $is.dynamic[0]
+$is.dynamic[0] = null
+else
+$is.dynamic[0] = 1
+end
+
+else if $return == 'dynamic.dock'
+if $is.dynamic[2]
+$is.dynamic[2] = null
+else
+$is.dynamic[2] = 1
+end
+
+else if $return == 'dynamic.dock.list'
+if $is.dynamic[1]
+$is.dynamic[1] = null
+else
+$is.dynamic[1] = 1
+
+end
+else if $return == 'debug'
+if $al.Settings[7]
+$al.Settings[7] = null
+else
+$al.Settings[7] = 1
+
+end
+else if $return == 'auto'
+if $al.Settings[9]
+$al.Settings[9] = null
+else
+$al.Settings[9] = 1
+end
+
+else if $return == 'open.config'
+$menu.view = 7
+
+else if $return == 'product.all.on'
+$cmd.opt1 = 1
+$cmd.opt2 = 1
+gosub Global.Factory.Sub:
+
+else if $return == 'product.all.off'
+$cmd.opt1 = 1
+$cmd.opt2 = 2
+gosub Global.Factory.Sub:
+
+else if $return == 'resource.all.on'
+$cmd.opt1 = 2
+$cmd.opt2 = 1
+gosub Global.Factory.Sub:
+
+else if $return == 'resource.all.off'
+$cmd.opt1 = 2
+$cmd.opt2 = 2
+gosub Global.Factory.Sub:
+
+else if $return == 'open.dc.menu'
+$menu.view = 4
+$al.Settings[5] = $menu.view
+set global variable: name='al.LI.FDN.event' value=$al.Settings
+
+else if $return == 'switch.menu'
+if $menu.view == 1
+$menu.view = 2
+else
+$menu.view = 1
+end
+
+else if $return == 'master.reset'
+$txt = = read text: page=$PageID id=186
+$confirm = null  ->  get user input: type=Var/Boolean, title=$txt
+if $confirm == [TRUE]
+ = null -> call script plugin.LI.FDN.Reset :
+return null
+end
+end
+end
+end
+
+return null
+
+
+Ware.User.Input.Sub:
+$pointer = = sprintf: pageid=$PageID textid=4000, $ware, null, null, null, null
+$ware.settings = $value  ->  get local variable: name=$pointer
+
+if $command == 'can.buy'
+if $ware.settings[3]
+$ware.settings[3] = null
+else
+$ware.settings[3] = 1
+end
+
+else if $command == 'surplus'
+if $ware.settings[7]
+$ware.settings[7] = null
+else
+$ware.settings[7] = 1
+end
+
+else
+
+if $cap
+$txt = = sprintf: pageid=$PageID textid=182, $ware, null, null, null, null
+$amount = null  ->  get user input: type=Var/Number, title=$txt
+if is datatyp[ $amount ] == DATATYPE_NULL
+endsub
+else
+if $amount >= 0
+if $command == 'remote.cap'
+$ware.settings[1] = $amount
+else if $command == 'maintain.cap'
+$ware.settings[2] = $amount
+else if $command == 'sell.cap'
+$ware.settings[5] = $amount
+end
+else
+if $command == 'remote.cap'
+$ware.settings[1] = null
+else if $command == 'maintain.cap'
+$ware.settings[2] = null
+else if $command == 'sell.cap'
+$ware.settings[5] = null
+end
+end
+end
+end
+
+if $trade
+$min = = get min price of ware $ware
+$min.txt = = convert number $min to string
+$avg = = get average price of ware $ware
+$avg.txt = = convert number $avg to string
+$max = = get max price of ware $ware
+$max.txt = = convert number $max to string
+
+$txt = = sprintf: pageid=$PageID textid=183, $min.txt, $avg.txt, $max.txt, null, null
+$amount = null  ->  get user input: type=Var/Number, title=$txt
+if not is datatyp[ $amount ] == DATATYPE_NULL
+if $amount >= $min AND $amount <= $max
+if $command == 'buy.at'
+$ware.settings[4] = $amount
+else if $command == 'sell.at'
+$ware.settings[6] = $amount
+end
+end
+end
+end
+end
+
+$value  ->  set local variable: name=$pointer value=$ware.settings
+endsub
+
+
+
+DC.Details.View.Sub:
+* Menu View 1 = DC Details
+START  = null -> call script plugin.LI.FDN.Menu.DC.Details_D :
+if $is.AP == [TRUE]
+$menu = null -> call script plugin.LI.FDN.Menu.AP.DC.Details : menu=$menu
+else
+$menu = null -> call script plugin.LI.FDN.Menu.DC.Details : menu=$menu
+end
+endsub
+
+
+Factory.List.View.Sub:
+* Menu View 2 = Factory List
+if $is.AP == [TRUE]
+$menu = null -> call script plugin.LI.FDN.Menu.AP.Factory.List : menu=$menu
+else
+if $factory.show.array == null
+$return.array = null -> call script plugin.LI.FDN.Menu.Factory.List : menu=$menu  factory.show.array=null
+else
+$return.array = null -> call script plugin.LI.FDN.Menu.Factory.List : menu=$menu  factory.show.array=$factory.show.array
+end
+$menu = $return.array[0]
+$factory.show.array = $return.array[1]
+end
+endsub
+
+
+Factory.Details.View.Sub:
+* Menu View 4 = Factory Details
+$menu = null -> call script plugin.LI.FDN.Menu.Factory.Details : menu=$menu  value=$value
+endsub
+
+
+Dock.Details.View.Sub:
+* Menu View 5 = Dock Details
+START  = null -> call script plugin.LI.FDN.Menu.Dock.Details_D : value=$value
+if $is.AP == [TRUE]
+$menu = null -> call script plugin.LI.FDN.Menu.AP.Dock.Details : menu=$menu  value=$value
+else
+$menu = null -> call script plugin.LI.FDN.Menu.Dock.Details : menu=$menu  value=$value
+end
+endsub
+
+
+Ware.Details.View.Sub:
+* Menu View 6 = Ware Details
+$menu = null -> call script plugin.LI.FDN.Menu.Ware.Details : menu=$menu  value=$value  ware=$ware
+endsub
+
+
+Config.View.Sub:
+* Menu View 6 = Ware Details
+$menu = null -> call script plugin.LI.FDN.Config.Menu : menu=$menu
+endsub
+
+
+Add.Ware.Sub:
+$txt = = read text: page=$PageID id=197
+$ware = null  ->  get user input: type=Var/Ware, title=$txt
+$pointer = = sprintf: pageid=$PageID textid=4000, $ware, null, null, null, null
+$ware.array = $value  ->  get local variable: name=$pointer
+if not $ware.array
+$amount = $value  ->  get amount of ware $ware in cargo bay
+if not $amount > 0
+ = null -> call script plugin.LI.FDN.Update.Ware : ware=$ware  amount=null  station=$value  action='create'
+end
+end
+endsub
+
+
+Regroom.Ware.Sub:
+$pointer = = sprintf: pageid=$PageID textid=4000, $ware, null, null, null, null
+$ware.array = $value  ->  get local variable: name=$pointer
+$virtual = $ware.array[0]
+
+if $command == 'to.virtual'
+$amount = $value  ->  get amount of ware $ware in cargo bay
+$virtual = $virtual + $amount
+$ware.array[0] = $virtual
+$remove = - $amount
+ = $value  ->  add $remove units of $ware
+else
+$amount = $value  ->  get free amount of ware $ware in cargo bay
+if $virtual <= $amount
+ = $value  ->  add $virtual units of $ware
+$ware.array[0] = 0
+else
+ = $value  ->  add $amount units of $ware
+$virtual = $virtual - $amount
+$ware.array[0] = $virtual
+end
+end
+$value  ->  set local variable: name=$pointer value=$ware.array
+endsub
+
+
+Remove.Ware.Sub:
+$pointer = = sprintf: pageid=$PageID textid=4000, $ware, null, null, null, null
+$value  ->  set local variable: name=$pointer value=null
+$value  ->  remove product from factory or dock: $ware
+endsub
+
+
+Global.Factory.Sub:
+$s = size of array $factory.array
+while $s > 0
+dec $s =
+$factory = $factory.array[$s]
+$pointer = = read text: page=$PageID id=4001
+$settings.array = $factory  ->  get local variable: name=$pointer
+if $cmd.opt1 == 1
+if $cmd.opt2 == 1
+$settings.array[0] = 1
+else
+$settings.array[0] = null
+end
+
+else
+if $cmd.opt2 == 1
+$settings.array[1] = 1
+else
+$settings.array[1] = null
+end
+end
+$factory  ->  set local variable: name=$pointer value=$settings.array
+end
+endsub
+
+
+Menu.View.Header.Sub:
+$txt = = read text: page=$PageID id=110
+add custom menu heading to array $menu: title=$txt
+if $menu.view == 1
+$txt = = read text: page=$PageID id=112
+else if $menu.view == 2
+$txt = = read text: page=$PageID id=111
+else if $menu.view == 4
+$txt = $dc
+else if $menu.view == 5
+$txt = $value
+else if $menu.view == 6
+$txt = $value
+else if $menu.view == 7
+$txt = = read text: page=$PageID id=103
+end
+$pre.txt = = read text: page=$PageID id=114
+$txt = $pre.txt + $txt
+add custom menu item to array $menu: text=$txt returnvalue='switch.menu'
+add section to custom menu: $menu
+endsub
+
+
+Menu.View.Footer.Sub:
+if $menu.view == 1
+$txt = = read text: page=$PageID id=111
+else if $menu.view == 2
+$txt = = read text: page=$PageID id=112
+else if $menu.view == 7
+$txt = = read text: page=$PageID id=103
+else
+$txt = = read text: page=$PageID id=133
+end
+if $menu.view == 1 OR $menu.view == 2 OR $menu.view == 5
+$return = open custom info menu: title=$txt description=null option array=$menu maxoptions=2
+else
+$return = open custom menu: title=$txt description=null option array=$menu
+end
+endsub
+
+return null
+
+
+
+
+

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.AP.DC.Details.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.AP.DC.Details.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Menu.AP.DC.Details.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This script builds the DC Details Menu and retuns the array back to the Main Menu

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.AP.Dock.Details.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.AP.Dock.Details.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Menu.AP.Dock.Details.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This script builds the Dock Details Menu and retuns the array back to the Main Menu

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.AP.Factory.List.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.AP.Factory.List.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Menu.AP.Factory.List.xml
+
 $al.Settings = get global variable: name='al.LI.FDN.event'
 if $al.Settings
 $PageID = $al.Settings[1]

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.DC.Details.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.DC.Details.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Menu.DC.Details.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This script builds the DC Details Menu and retuns the array back to the Main Menu

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.DC.Details_D.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.DC.Details_D.x3s
@@ -1,0 +1,169 @@
+#name: plugin.LI.FDN.Menu.DC.Details_D
+#lang: 44
+#origin_mod: FDN
+#source: mods/FDN/scripts/plugin.LI.FDN.Menu.DC.Details_D.xml
+
+* Author: Logain Abler
+* -----------------------------------------------------------------------------------
+* This script builds and updates the global refs that hold the updated values for
+* plugin.LI.FDN.Menu.DC.Details
+
+* Expected values:
+* - N/A the DC is recovered from the AL Plugin global variable
+
+* Returns values:
+* - N/A created and updateds global variables for dymanic menu
+
+* Version: 1.0
+* Date: 22/05/2012
+* Tested: 22/05/2012
+* -----------------------------------------------------------------------------------
+
+* Fetch values saved in the AL Plugin global variable:
+* - Page ID
+* - Designated DC
+* - open.menu - this is used to check if the LI.FDN.Menu.DC.Details is open
+* - is.dynamic - flags if the menu is dynamic
+* open.menu - value is 1
+$al.Settings = get global variable: name='al.LI.FDN.event'
+if $al.Settings
+$PageID = $al.Settings[1]
+$dc = $al.Settings[2]
+$open.menu = $al.Settings[5]
+$is.dynamic = $al.Settings[6][0]
+end
+* -----------------------------------------------------------------------------------
+
+* The ID code of the DC is used as a reference in naming the global variable
+$id = $dc  ->  get ID code
+* -----------------------------------------------------------------------------------
+* Get a list of tradeable wares for the DC
+$ware.array = $dc  ->  get tradeable ware array from station
+* -----------------------------------------------------------------------------------
+
+* Call the Sub which created the global variable used for the dynamic menu
+gosub Write.Menu.Global.Sub:
+* -----------------------------------------------------------------------------------
+
+* Only call the while loop for update if there is a DC
+if $dc
+
+* If dynamic start While Loop
+if $is.dynamic
+* While loop which runs whilst the LI.FDN.Menu.DC.Details menu is open
+* open.mene as stored in the AL Plugin global variable
+while [TRUE]
+* -----------------------------------------------------------------------------------
+
+* wait
+ = wait randomly from 1000 to 1500 ms
+* -----------------------------------------------------------------------------------
+
+* If the checks in this section fail exit the while loop
+* Check FDN plugin status
+skip if $al.Settings[0]
+return null
+* -----------------------------------------------------------------------------------
+
+* Check if DC menu is open - Value should be 1 and is set in plugin.LI.FDN.Main.Menu
+$open.menu = $al.Settings[5]
+skip if $open.menu == 1
+return null
+* -----------------------------------------------------------------------------------
+
+* Call the Sub which updates the global variable used for the dynamic menu
+gosub Update.Menu.Global.Sub:
+* -----------------------------------------------------------------------------------
+end
+end
+end
+return null
+* -----------------------------------------------------------------------------------
+
+* This is the Sub which created the global variable used for the dynamic menu up
+* sorted.ware.array format [Ware Type][sorted Ware array for for the Ware Type]
+Write.Menu.Global.Sub:
+
+* credits
+$pointer = = sprintf: pageid=$PageID textid=5001, $id, null, null, null, null
+$txt = = read text: page=$PageID id=146
+$temp.array = = array alloc: size=4
+$temp.array[0] = 1
+$temp.array[1] = $txt
+$temp.array[2] = -1
+$credits = $dc  ->  get money
+$credits = = convert number $credits to string
+$credits = = sprintf: pageid=$PageID textid=202, $credits, null, null, null, null
+$temp.array[3] = $credits
+set global variable: name=$pointer value=$temp.array
+* -----------------------------------------------------------------------------------
+
+$s = size of array $ware.array
+while $s > 0
+dec $s =
+$ware = $ware.array[$s]
+* -----------------------------------------------------------------------------------
+
+* Calls script plugin.LI.FDN.Wares.Summary which returns a formated array
+* For the ware
+$ware.summary = [THIS] -> call script plugin.LI.FDN.Wares.Summary : station=$dc  ware=$ware
+* -----------------------------------------------------------------------------------
+
+* Create and update the global variable for the dynamic menu
+* DC ID code and Ware are used to create unique global variable
+$pointer = = sprintf: pageid=$PageID textid=5000, $id, $ware, null, null, null
+set global variable: name=$pointer value=$ware.summary
+* -----------------------------------------------------------------------------------
+end
+endsub
+* -----------------------------------------------------------------------------------
+
+* This is the Sub which update the global variable created by Write.Menu.Global.Sub
+Update.Menu.Global.Sub:
+
+* credits
+$pointer = = sprintf: pageid=$PageID textid=5001, $id, null, null, null, null
+$array = get global variable: name=$pointer
+$credits = $dc  ->  get money
+$credits = = convert number $credits to string
+$credits = = sprintf: pageid=$PageID textid=202, $credits, null, null, null, null
+$array[3] = $credits
+* -----------------------------------------------------------------------------------
+
+$s = size of array $ware.array
+while $s > 0
+dec $s =
+$ware = $ware.array[$s]
+* -----------------------------------------------------------------------------------
+
+* Calls script plugin.LI.FDN.Wares.Summary which returns a formated array
+* For the ware
+$ware.summary = [THIS] -> call script plugin.LI.FDN.Wares.Summary : station=$dc  ware=$ware
+* -----------------------------------------------------------------------------------
+
+* FIRST - extract the values from the ware.summary array
+$txt = $ware.summary[0][1]
+$remote = $ware.summary[0][3]
+$buy.at = $ware.summary[0][5]
+$sell.cap = $ware.summary[0][7]
+$sell.at = $ware.summary[0][9]
+$storage = $ware.summary[0][11]
+* -----------------------------------------------------------------------------------
+
+* SECOND - Update the values in the global variable
+$pointer = = sprintf: pageid=$PageID textid=5000, $id, $ware, null, null, null
+$ware.detail.array = get global variable: name=$pointer
+$ware.detail.array[0][1] = $txt
+$ware.detail.array[0][3] = $remote
+$ware.detail.array[0][5] = $buy.at
+$ware.detail.array[0][7] = $sell.cap
+$ware.detail.array[0][9] = $sell.at
+$ware.detail.array[0][11] = $storage
+* -----------------------------------------------------------------------------------
+end
+endsub
+* -----------------------------------------------------------------------------------
+return null
+
+
+

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.Dock.Details.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.Dock.Details.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Menu.Dock.Details.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This script builds the Dock Details Menu and retuns the array back to the Main Menu

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.Dock.Details_D.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.Dock.Details_D.x3s
@@ -1,0 +1,157 @@
+#name: plugin.LI.FDN.Menu.Dock.Details_D
+#lang: 44
+#origin_mod: FDN
+#source: mods/FDN/scripts/plugin.LI.FDN.Menu.Dock.Details_D.xml
+
+* Author: Logain Abler
+* -----------------------------------------------------------------------------------
+* This script builds and updates the global refs that hold the updated values for
+* plugin.LI.FDN.Menu.DC.Details
+
+* Expected values:
+* - N/A the DC is recovered from the AL Plugin global variable
+
+* Returns values:
+* - N/A created and updateds global variables for dymanic menu
+
+* Version: 1.0
+* Date: 22/05/2012
+* Tested: 22/05/2012
+* -----------------------------------------------------------------------------------
+
+* Fetch values saved in the AL Plugin global variable:
+* - Page ID
+* - open.menu - this is used to check if the LI.FDN.Menu.Dock.Details is open
+* - is.dynamic - flags if the menu is dynamic
+* open.menu  - value is 5
+$al.Settings = get global variable: name='al.LI.FDN.event'
+if $al.Settings
+$PageID = $al.Settings[1]
+$open.menu = $al.Settings[5]
+$is.dynamic = $al.Settings[6][1]
+end
+* -----------------------------------------------------------------------------------
+
+* The ID code of the Dock is used as a reference in naming the global variable
+$id = $value  ->  get ID code
+* Get a list of tradeable wares for the Dock
+$ware.array = $value  ->  get tradeable ware array from station
+* -----------------------------------------------------------------------------------
+
+* Call the Sub which created the global variable used for the dynamic menu
+gosub Write.Menu.Global.Sub:
+* -----------------------------------------------------------------------------------
+
+* While loop which runs whilst the LI.FDN.Menu.Dock.Details menu is open
+* open.mene as stored in the AL Plugin global variable
+if $is.dynamic
+while [TRUE]
+* wait
+ = wait randomly from 1000 to 5000 ms
+* -----------------------------------------------------------------------------------
+* If the checks in this section fail exit the while loop
+* Check FDN plugin status
+skip if $al.Settings[0]
+return null
+* -----------------------------------------------------------------------------------
+
+* Check if Dock menu is open - Value should be 1 and is set in plugin.LI.FDN.Main.Menu
+$open.menu = $al.Settings[5]
+skip if $open.menu == 5
+return null
+end
+* -----------------------------------------------------------------------------------
+
+* Call the Sub which updates the global variable used for the dynamic menu
+gosub Update.Menu.Global.Sub:
+* -----------------------------------------------------------------------------------
+end
+return null
+* -----------------------------------------------------------------------------------
+
+* This is the Sub which created the global variable used for the dynamic menu up
+* sorted.ware.array format [Ware Type][sorted Ware array for for the Ware Type]
+Write.Menu.Global.Sub:
+
+* credits
+$pointer = = sprintf: pageid=$PageID textid=5001, $id, null, null, null, null
+$txt = = read text: page=$PageID id=146
+$temp.array = = array alloc: size=4
+$temp.array[0] = 1
+$temp.array[1] = $txt
+$temp.array[2] = -1
+$credits = $value  ->  get money
+$credits = = convert number $credits to string
+$credits = = sprintf: pageid=$PageID textid=202, $credits, null, null, null, null
+$temp.array[3] = $credits
+set global variable: name=$pointer value=$temp.array
+* -----------------------------------------------------------------------------------
+
+$s = size of array $ware.array
+while $s > 0
+dec $s =
+$ware = $ware.array[$s]
+* -----------------------------------------------------------------------------------
+
+* Calls script plugin.LI.FDN.Wares.Summary which returns a formated array
+* For the ware
+$ware.summary = [THIS] -> call script plugin.LI.FDN.Wares.Summary : station=$value  ware=$ware
+* -----------------------------------------------------------------------------------
+
+* Create and update the global variable for the dynamic menu
+* Dock ID code and Ware are used to create unique global variable
+$pointer = = sprintf: pageid=$PageID textid=5000, $id, $ware, null, null, null
+set global variable: name=$pointer value=$ware.summary
+* -----------------------------------------------------------------------------------
+end
+endsub
+* -----------------------------------------------------------------------------------
+
+* This is the Sub which update the global variable created by Write.Menu.Global.Sub
+Update.Menu.Global.Sub:
+
+* credits
+$pointer = = sprintf: pageid=$PageID textid=5001, $id, null, null, null, null
+$array = get global variable: name=$pointer
+$credits = $value  ->  get money
+$credits = = convert number $credits to string
+$credits = = sprintf: pageid=$PageID textid=202, $credits, null, null, null, null
+$array[3] = $credits
+* -----------------------------------------------------------------------------------
+
+$s = size of array $ware.array
+while $s > 0
+dec $s =
+$ware = $ware.array[$s]
+* -----------------------------------------------------------------------------------
+
+* Calls script plugin.LI.FDN.Wares.Summary which returns a formated array
+* For the ware
+$ware.summary = [THIS] -> call script plugin.LI.FDN.Wares.Summary : station=$value  ware=$ware
+* -----------------------------------------------------------------------------------
+
+* This is the section that update the values held in the global variable
+* FIRST - extract the values from the ware.summary array
+$txt = $ware.summary[0][1]
+$maintain = $ware.summary[0][3]
+$sell.cap = $ware.summary[0][5]
+$sell.at = $ware.summary[0][7]
+$storage = $ware.summary[0][9]
+* -----------------------------------------------------------------------------------
+
+* SECOND - Upadate the values in the global variable
+$pointer = = sprintf: pageid=$PageID textid=5001, $id, $ware, null, null, null
+$ware.detail.array = get global variable: name=$pointer
+$ware.detail.array[0][1] = $txt
+$ware.detail.array[0][3] = $maintain
+$ware.detail.array[0][5] = $sell.cap
+$ware.detail.array[0][7] = $sell.at
+$ware.detail.array[0][9] = $storage
+* -----------------------------------------------------------------------------------
+end
+endsub
+* -----------------------------------------------------------------------------------
+return null
+
+
+

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.Factory.Details.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.Factory.Details.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Menu.Factory.Details.xml
+
 $al.Settings = get global variable: name='al.LI.FDN.event'
 if $al.Settings
 $PageID = $al.Settings[1]

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.Factory.List.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.Factory.List.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Menu.Factory.List.xml
+
 $al.Settings = get global variable: name='al.LI.FDN.event'
 if $al.Settings
 $PageID = $al.Settings[1]

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.Ware.Details.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Menu.Ware.Details.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Menu.Ware.Details.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This is the script for the ware details menu and magament of all ware related

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Move.Ware.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Move.Ware.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Move.Ware.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * this script handles the user inputs for moving wares

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Reset.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Reset.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Reset.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * this script resets all FDN locally stored values

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Sector.Array.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Sector.Array.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Sector.Array.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This script is used to return a list of sectors that will show in FDN menus

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Sell.Ware.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Sell.Ware.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Sell.Ware.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This script is called by LI.FDN.Supply.Factory

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Setup.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Setup.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Setup.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * setup handles the srart and stop actions for FDN

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Sort.Wares.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Sort.Wares.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Sort.Wares.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This script sorts wares into their main type

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Supply.Dock.Check.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Supply.Dock.Check.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Supply.Dock.Check.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This script is called by LI.FDN.Menu.Supply.Start script if there is a valid

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Supply.Dock.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Supply.Dock.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Supply.Dock.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This script is called by LI.FDN.Menu.Supply.Dock.Check

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Supply.Factory.Check.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Supply.Factory.Check.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Supply.Factory.Check.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This script is called by LI.FDN.Menu.Supply.Start script if there is a valid

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Supply.Factory.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Supply.Factory.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Supply.Factory.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This script is called by LI.FDN.Supply.Factory.Check

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Supply.Start.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Supply.Start.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Supply.Start.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This script ic called by the AL Plugin timer event and starts the supply cycle

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Update.Ware.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Update.Ware.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Update.Ware.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Wares.Summary.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Wares.Summary.x3s
@@ -2,6 +2,7 @@
 #lang: 44
 #origin_mod: FDN
 #source: mods/FDN/scripts/plugin.LI.FDN.Wares.Summary.xml
+
 * Author: Logain Abler
 * -----------------------------------------------------------------------------------
 * This formats the warea fro the DC and Dock menus

--- a/tools/fixtures/known_good/OKTraders1_7_1/README.md
+++ b/tools/fixtures/known_good/OKTraders1_7_1/README.md
@@ -1,0 +1,9 @@
+# OKTraders1_7_1 (fixtures)
+
+Generated from `mods/OKTraders1_7_1` on 2025-09-14 00:41:13Z.
+
+## Summary
+- Scripts converted: 11
+- Scripts skipped:  0
+- Text pages copied: 8
+- Director copied:   no

--- a/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/!init.glen.trade.ok.x3s
+++ b/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/!init.glen.trade.ok.x3s
@@ -1,0 +1,18 @@
+#name: !init.glen.trade.ok
+#lang: 44
+#origin_mod: OKTraders1_7_1
+#source: mods/OKTraders1_7_1/scripts/!init.glen.trade.ok.xml
+
+
+			* ******************************************************************************
+
+			* OK Trade
+
+			*  Existence of this script sets the game to modified allowing OK Trade to work
+
+			* ******************************************************************************
+
+
+			return
+			 
+			null

--- a/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.action.x3s
+++ b/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.action.x3s
@@ -1,0 +1,7666 @@
+#name: glen.trade.ok.action
+#lang: 44
+#origin_mod: OKTraders1_7_1
+#source: mods/OKTraders1_7_1/scripts/glen.trade.ok.action.xml
+
+
+			* ******************************************************************************
+
+			* OK Trade
+
+			*  Action routines
+
+			* ******************************************************************************
+
+
+			$Comp
+			 
+			=
+			 
+			'Action'
+
+
+			$Config
+			 
+			=
+			 
+			get
+			 
+			global
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+
+			skip
+			 
+			if
+			 
+			$Config
+
+			return
+			 
+			null
+
+
+			* Config settings used in this script.
+
+			$Config.Debug.Enabled
+			 
+			=
+			 
+			5
+
+			$Config.All.Wares
+			 
+			=
+			 
+			13
+
+			$Config.Global.Balance
+			 
+			=
+			 
+			18
+
+			$Config.Equip
+			 
+			=
+			 
+			20
+
+
+			* Mission types.
+
+			$Mission.Type.None
+			 
+			=
+			 
+			0
+
+			$Mission.Type.Buy
+			 
+			=
+			 
+			1
+
+			$Mission.Type.Sell
+			 
+			=
+			 
+			2
+
+			$Mission.Type.Move.Station
+			 
+			=
+			 
+			3
+
+
+			* Published state entries
+
+			$State.Version
+			 
+			=
+			 
+			0
+
+			$State.Mission
+			 
+			=
+			 
+			1
+
+			$State.Dest
+			 
+			=
+			 
+			2
+
+			$State.Ware
+			 
+			=
+			 
+			3
+
+			$State.Price
+			 
+			=
+			 
+			4
+
+			$State.Balance
+			 
+			=
+			 
+			7
+
+
+			* Library functions
+
+			$Lib.Get.Topup.Jump.Energy
+			 
+			=
+			 
+			3
+
+			$Lib.Check.Cmd.Enabled
+			 
+			=
+			 
+			6
+
+			$Lib.Can.Trade.Ware
+			 
+			=
+			 
+			8
+
+			$Lib.Test.Buys.Infinite.Wares
+			 
+			=
+			 
+			14
+
+			$Lib.Find.Station
+			 
+			=
+			 
+			16
+
+			$Lib.Get.Amount.For.Sale
+			 
+			=
+			 
+			24
+
+			$Lib.Get.Amount.To.Buy
+			 
+			=
+			 
+			25
+
+			$Lib.Get.Repair.Cost
+			 
+			=
+			 
+			29
+
+			$Lib.Get.Reserved.Amount
+			 
+			=
+			 
+			30
+
+			$Lib.BigInt.Add
+			 
+			=
+			 
+			33
+
+			$Lib.Check.Dest2
+			 
+			=
+			 
+			37
+
+
+			$Lib.Generic.Get.Minimum
+			 
+			=
+			 
+			1
+
+			$Lib.Generic.Clone.Array
+			 
+			=
+			 
+			3
+
+
+			* State functions
+
+			$Lib.State.Fetch
+			 
+			=
+			 
+			0
+
+			$Lib.State.Publish
+			 
+			=
+			 
+			1
+
+			$Lib.State.Get.Excludes
+			 
+			=
+			 
+			4
+
+
+			$Lib.Config.Get.Stock.Limit.Free
+			 
+			=
+			 
+			3
+
+			$Lib.Config.Get.Stock.Limit.Tradeable
+			 
+			=
+			 
+			4
+
+
+			* Options
+
+			$Cmd.Move.Station
+			 
+			=
+			 
+			1
+
+			$Cmd.Buy.Ware
+			 
+			=
+			 
+			2
+
+			$Cmd.Sell.Ware
+			 
+			=
+			 
+			3
+
+			$Cmd.Offload.Wares
+			 
+			=
+			 
+			4
+
+			$Cmd.Load.Jumpdrive.Energy
+			 
+			=
+			 
+			5
+
+			$Cmd.None
+			 
+			=
+			 
+			6
+
+			$Cmd.Repair
+			 
+			=
+			 
+			7
+
+			$Cmd.Launch.Countermeasures
+			 
+			=
+			 
+			8
+
+			$Cmd.Equip
+			 
+			=
+			 
+			9
+
+			$Internal.Move.Station
+			 
+			=
+			 
+			100
+
+			$Internal.Buy.Ware
+			 
+			=
+			 
+			102
+
+			$Internal.Sell.Ware
+			 
+			=
+			 
+			103
+
+
+			* Equipping config
+
+			$Config.Equip.Ver
+			 
+			=
+			 
+			0
+
+			$Config.Equip.Lasers
+			 
+			=
+			 
+			1
+
+			$Config.Equip.Shields
+			 
+			=
+			 
+			2
+
+			$Config.Equip.Missiles
+			 
+			=
+			 
+			3
+
+			$Config.Equip.Drones
+			 
+			=
+			 
+			4
+
+			$Config.Equip.DockingComputer
+			 
+			=
+			 
+			5
+
+			$Config.Equip.Jumpdrive
+			 
+			=
+			 
+			6
+
+			$Config.Equip.Triplex
+			 
+			=
+			 
+			7
+
+			$Config.Equip.Rudder
+			 
+			=
+			 
+			8
+
+			$Config.Equip.CargoLifeSupport
+			 
+			=
+			 
+			9
+
+			$Config.Equip.Duplex
+			 
+			=
+			 
+			10
+
+
+			$Homebase.Start
+			 
+			=
+			 
+			[HOMEBASE]
+
+			$rc
+			 
+			=
+			 
+			null
+
+
+			* ******************************************************************************
+
+			* Options
+
+			* ******************************************************************************
+
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Cmd.None
+
+			gosub
+			 
+			Cmd.None
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Cmd.Move.Station
+
+			gosub
+			 
+			Cmd.Move.Station
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Cmd.Buy.Ware
+
+			gosub
+			 
+			Cmd.Buy.Ware
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Cmd.Sell.Ware
+
+			gosub
+			 
+			Cmd.Sell.Ware
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Cmd.Offload.Wares
+
+			gosub
+			 
+			Cmd.Offload.Wares
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Cmd.Load.Jumpdrive.Energy
+
+			gosub
+			 
+			Cmd.Load.Jumpdrive.Energy
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Cmd.Repair
+
+			gosub
+			 
+			Cmd.Repair
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Cmd.Launch.Countermeasures
+
+			gosub
+			 
+			Cmd.Launch.Countermeasures
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Cmd.Equip
+
+			gosub
+			 
+			Cmd.Equip
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Internal.Move.Station
+
+			gosub
+			 
+			Action.Move.Station
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Internal.Buy.Ware
+
+			gosub
+			 
+			Buy.Ware
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Internal.Sell.Ware
+
+			gosub
+			 
+			Sell.Ware
+			:
+
+			else
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			0
+			 
+			fmt
+			=
+			'Unknown function %s'
+			 
+			arg1
+			=
+			$Func
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+
+			return
+			 
+			$rc
+
+
+			* ******************************************************************************
+
+			* Cmd.None
+
+			*  Do nothing
+
+			* ******************************************************************************
+
+			Cmd.None
+			:
+
+			[THIS]
+			->
+			 
+			set
+			 
+			command
+			:
+			 
+			[COMMAND_NONE]
+
+			[THIS]
+			->
+			 
+			set
+			 
+			destination
+			 
+			to
+			 
+			null
+
+			[THIS]
+			->
+			 
+			set
+			 
+			wanted
+			 
+			ware
+			 
+			count
+			 
+			to
+			 
+			null
+
+			[THIS]
+			->
+			 
+			set
+			 
+			wanted
+			 
+			ware
+			 
+			to
+			 
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Cmd.Move.Station
+
+			*  Move to station
+
+			* ******************************************************************************
+
+			Cmd.Move.Station
+			:
+
+			$Dest
+			 
+			=
+			 
+			$Arg1
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Cmd.Move.Station: Dest=%s'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			while
+			 
+			1
+
+
+			if
+			 
+			[HOMEBASE]
+			 
+			AND
+			 
+			$Dest
+			 
+			==
+			 
+			[HOMEBASE]
+
+			[THIS]
+			->
+			 
+			set
+			 
+			command
+			:
+			 
+			[COMMAND_RETURN_HOME]
+
+			break
+
+			end
+
+
+			if
+			 
+			$Dest
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Dock]
+
+			[THIS]
+			->
+			 
+			set
+			 
+			command
+			:
+			 
+			[COMMAND_RESUPPLY]
+
+			break
+
+			end
+
+
+			if
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Jumpdrive}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			$Dest
+			->
+			 
+			uses
+			 
+			ware
+			 
+			{Energy Cells}
+			 
+			as
+			 
+			product
+
+			[THIS]
+			->
+			 
+			set
+			 
+			command
+			:
+			 
+			[COMMAND_REFUEL]
+
+			break
+
+			end
+
+			end
+
+
+			if
+			 
+			$Dest
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Shipyard]
+
+			[THIS]
+			->
+			 
+			set
+			 
+			command
+			:
+			 
+			[COMMAND_MOVE_REPAIR]
+
+			break
+
+			end
+
+
+			[THIS]
+			->
+			 
+			set
+			 
+			command
+			:
+			 
+			[COMMAND_DOCKAT]
+
+			break
+
+			end
+
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Internal.Move.Station
+			 
+			Arg1
+			=
+			$Dest
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Cmd.Move.Station: Dest=%s, rc=%s'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			$rc
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.None
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Cmd.Buy.Ware
+
+			*  Buy ware and return home or sell at dest2
+
+			* ******************************************************************************
+
+			Cmd.Buy.Ware
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Ware
+			 
+			=
+			 
+			$Arg1
+
+			$Dest
+			 
+			=
+			 
+			$Arg2
+
+			$Dest2
+			 
+			=
+			 
+			$Arg3
+
+			$Price
+			 
+			=
+			 
+			$Arg4
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			is
+			 
+			datatype
+			[
+			$Price
+			]
+			 
+			==
+			 
+			[DATATYPE_NULL]
+
+			$Price
+			 
+			=
+			 
+			$Dest
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+
+			$Amount
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Amount.To.Buy
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Dest
+			 
+			Arg3
+			=
+			$Dest2
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Cmd.Buy.Ware: Dest=%s, Dest2=%s, Ware=%s, Price=%s, Amount=%s'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			$Dest2
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Price
+			 
+			arg5
+			=
+			$Amount
+
+
+			while
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			$Amount
+
+			break
+
+
+			[THIS]
+			->
+			 
+			set
+			 
+			command
+			:
+			 
+			[COMMAND_GET_WARE]
+			  
+			target
+			=
+			$Ware
+			 
+			target2
+			=
+			$Dest
+			 
+			par1
+			=
+			null
+			 
+			par2
+			=
+			null
+
+			[THIS]
+			->
+			 
+			set
+			 
+			wanted
+			 
+			ware
+			 
+			count
+			 
+			to
+			 
+			$Amount
+
+			[THIS]
+			->
+			 
+			set
+			 
+			wanted
+			 
+			ware
+			 
+			to
+			 
+			$Ware
+
+
+			skip
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Internal.Move.Station
+			 
+			Arg1
+			=
+			$Dest
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			break
+
+			skip
+			 
+			if
+			 
+			[DOCKEDAT]
+			 
+			==
+			 
+			$Dest
+
+			break
+
+
+			gosub
+			 
+			Sanity.Check
+			:
+
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Cmd.Load.Jumpdrive.Energy
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+
+			* Because time has passed recalculate dest2 and trade amount
+
+			if
+			 
+			[HOMEBASE]
+			 
+			==
+			 
+			null
+			 
+			AND
+			 
+			$Dest2
+
+			$Dest2
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Check.Dest2
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			not
+			 
+			$Dest2
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Cmd.Buy.Ware: No dest2, abort purchase.'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+			$Amount
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Amount.To.Buy
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Dest
+			 
+			Arg3
+			=
+			$Dest2
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			$Amount
+
+			break
+
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Internal.Buy.Ware
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Amount
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Cmd.Buy.Ware: Ware=%s, Dest=%s, rc=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Dest
+			 
+			arg3
+			=
+			$rc
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			* Advance to next stage of mission
+
+			if
+			 
+			$rc
+
+			if
+			 
+			[HOMEBASE]
+
+			$Equipping
+			 
+			=
+			 
+			is
+			 
+			upgrade
+			:
+			 
+			ware
+			=
+			$Ware
+
+			skip
+			 
+			if
+			 
+			$Equipping
+
+			$Equipping
+			 
+			=
+			 
+			is
+			 
+			inventory
+			:
+			 
+			ware
+			=
+			$Ware
+
+			skip
+			 
+			if
+			 
+			$Equipping
+
+			$Equipping
+			 
+			=
+			 
+			is
+			 
+			equipment
+			:
+			 
+			ware
+			=
+			$Ware
+
+
+			if
+			 
+			$Equipping
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.None
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			else
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.Move.Station
+			 
+			Arg2
+			=
+			[HOMEBASE]
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			end
+
+
+			else
+			 
+			if
+			 
+			$Dest2
+			->
+			 
+			exists
+
+			$Price
+			 
+			=
+			 
+			$Dest2
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.Sell
+			 
+			Arg2
+			=
+			$Dest2
+			 
+			Arg3
+			=
+			$Ware
+			 
+			Arg4
+			=
+			$Price
+			 
+			Arg5
+			=
+			null
+
+			else
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.None
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			end
+
+			else
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.None
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			end
+
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Cmd.Sell.Ware
+
+			*  Sell ware
+
+			* ******************************************************************************
+
+			Cmd.Sell.Ware
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Ware
+			 
+			=
+			 
+			$Arg1
+
+			$Dest
+			 
+			=
+			 
+			$Arg2
+
+
+			$Amount
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Amount.For.Sale
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Price
+			 
+			=
+			 
+			$Dest
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+
+			$Buys.Infinite
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Test.Buys.Infinite.Wares
+			 
+			Arg1
+			=
+			[THIS]
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			$Dest
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+
+			if
+			 
+			[HOMEBASE]
+			 
+			AND
+			 
+			[DOCKEDAT]
+			 
+			==
+			 
+			[HOMEBASE]
+
+			* Load ware if at homebase
+
+			$p1
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$p2
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Stock.Limit.Tradeable
+			 
+			Arg1
+			=
+			[HOMEBASE]
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$p3
+			 
+			=
+			 
+			null
+
+			* If the target station buys infinite amounts of ware then disregard how much
+
+			* apparent free space it has.
+
+			if
+			 
+			not
+			 
+			$Buys.Infinite
+
+			$p3
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Stock.Limit.Free
+			 
+			Arg1
+			=
+			$Dest
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$p3
+			 
+			=
+			 
+			$p3
+			 
+			-
+			 
+			$Amount
+
+			skip
+			 
+			if
+			 
+			$p3
+			 
+			>
+			 
+			0
+
+			$p3
+			 
+			=
+			 
+			0
+
+			end
+
+			$Amount.Topup
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Get.Minimum
+			 
+			Arg1
+			=
+			$p1
+			 
+			Arg2
+			=
+			$p2
+			 
+			Arg3
+			=
+			$p3
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			if
+			 
+			$Amount.Topup
+			 
+			>
+			 
+			0
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Cmd.Sell.Ware: loading %s units of %s'
+			 
+			arg1
+			=
+			$Amount.Topup
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			=
+			 
+			[THIS]
+			->
+			 
+			load
+			 
+			$Amount.Topup
+			 
+			units
+			 
+			of
+			 
+			$Ware
+
+			$Amount
+			 
+			=
+			 
+			$Amount
+			 
+			+
+			 
+			$Amount.Topup
+
+			end
+
+			end
+
+
+			while
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			$Amount
+
+			break
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Cmd.Sell.Ware: Dest=%s, Ware=%s, Price=%s, Amount=%s'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			$Price
+			 
+			arg4
+			=
+			$Amount
+			 
+			arg5
+			=
+			null
+
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.Sell
+			 
+			Arg2
+			=
+			$Dest
+			 
+			Arg3
+			=
+			$Ware
+			 
+			Arg4
+			=
+			$Price
+			 
+			Arg5
+			=
+			null
+
+			[THIS]
+			->
+			 
+			set
+			 
+			command
+			:
+			 
+			[COMMAND_SELL_WARE]
+			  
+			target
+			=
+			$Ware
+			 
+			target2
+			=
+			$Dest
+			 
+			par1
+			=
+			null
+			 
+			par2
+			=
+			null
+
+			[THIS]
+			->
+			 
+			set
+			 
+			wanted
+			 
+			ware
+			 
+			count
+			 
+			to
+			 
+			$Amount
+
+			[THIS]
+			->
+			 
+			set
+			 
+			wanted
+			 
+			ware
+			 
+			to
+			 
+			$Ware
+
+
+			skip
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Internal.Move.Station
+			 
+			Arg1
+			=
+			$Dest
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			break
+
+
+			gosub
+			 
+			Sanity.Check
+			:
+
+
+			* Because time has passed, recalculate the amount to sell
+
+			$Amount
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Amount.For.Sale
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			not
+			 
+			$Buys.Infinite
+
+			$Amount.Dest
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Stock.Limit.Free
+			 
+			Arg1
+			=
+			$Dest
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Amount
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Get.Minimum
+			 
+			Arg1
+			=
+			$Amount
+			 
+			Arg2
+			=
+			$Amount.Dest
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			end
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Internal.Sell.Ware
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Amount
+			 
+			Arg3
+			=
+			$Buys.Infinite
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Cmd.Load.Jumpdrive.Energy
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+
+			break
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Cmd.Sell.Ware: Ware=%s, Dest=%s, rc=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Dest
+			 
+			arg3
+			=
+			$rc
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.None
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Cmd.Offload.Wares
+
+			*  Sell or unload any wares the station has room for. At the homebase this
+
+			*  cleans up a variety of sins like failed missions, not enough room to unload
+
+			*  all wares ealier on, unloading wares that were already on board and so forth.
+
+			* ******************************************************************************
+
+			Cmd.Offload.Wares
+			:
+
+			$Skip.Ware
+			 
+			=
+			 
+			$Arg1
+
+			if
+			 
+			[DOCKEDAT]
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Station]
+
+			$All.Wares
+			 
+			=
+			 
+			$Config
+			[
+			$Config.All.Wares
+			]
+
+			$Wares.Station
+			 
+			=
+			 
+			[DOCKEDAT]
+			->
+			 
+			get
+			 
+			tradeable
+			 
+			ware
+			 
+			array
+			 
+			from
+			 
+			station
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares.Station
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ware
+			 
+			=
+			 
+			$Wares.Station
+			[
+			$idx
+			]
+
+
+			* Avoid selling tunings and equipment
+
+			if
+			 
+			not
+			 
+			find
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			:
+			 
+			$All.Wares
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Cmd.Offload.Wares: Ware %s not in global wares list'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			continue
+
+			end
+
+
+			* When not docked at a homebase then only offload wares the station buys
+
+			if
+			 
+			[DOCKEDAT]
+			 
+			!=
+			 
+			[HOMEBASE]
+
+			skip
+			 
+			if
+			 
+			[DOCKEDAT]
+			->
+			 
+			can
+			 
+			buy
+			 
+			ware
+			 
+			$Ware
+
+			continue
+
+			end
+
+
+			* Avoid selling ware back to station we just bought it from
+
+			if
+			 
+			$Ware
+			 
+			==
+			 
+			$Skip.Ware
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Cmd.Offload.Wares: Not selling ware %s as we just bought it from here'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			continue
+
+			end
+
+
+			$p1
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Amount.For.Sale
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			[DOCKEDAT]
+			 
+			==
+			 
+			[HOMEBASE]
+
+			* At homebase have the trader unload what it can regardless of stock limits to avoid taking trader cargo space
+
+			$p2
+			 
+			=
+			 
+			[DOCKEDAT]
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			else
+
+			$p2
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Stock.Limit.Free
+			 
+			Arg1
+			=
+			[DOCKEDAT]
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			end
+
+
+			$Amount
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Get.Minimum
+			 
+			Arg1
+			=
+			$p1
+			 
+			Arg2
+			=
+			$p2
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			if
+			 
+			$Amount
+			 
+			>
+			 
+			0
+
+			if
+			 
+			[DOCKEDAT]
+			 
+			==
+			 
+			[HOMEBASE]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			unload
+			 
+			$Amount
+			 
+			units
+			 
+			of
+			 
+			$Ware
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Cmd.Offload.Wares: Unloaded %s units of %s'
+			 
+			arg1
+			=
+			$Amount
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			else
+
+			$Buys.Infinite
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Test.Buys.Infinite.Wares
+			 
+			Arg1
+			=
+			[THIS]
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			$Dest
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Internal.Sell.Ware
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Amount
+			 
+			Arg3
+			=
+			$Buys.Infinite
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			end
+
+			end
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Cmd.Load.Jumpdrive.Energy
+
+			*  Top up jumpdrive energy
+
+			* ******************************************************************************
+
+			Cmd.Load.Jumpdrive.Energy
+			:
+
+			skip
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Jumpdrive}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			endsub
+
+
+			skip
+			 
+			if
+			 
+			[DOCKEDAT]
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Station]
+
+			endsub
+
+
+			$Owner
+			 
+			=
+			 
+			[DOCKEDAT]
+			->
+			 
+			get
+			 
+			owner
+			 
+			race
+
+			if
+			 
+			$Owner
+			 
+			!=
+			 
+			[Player]
+
+			skip
+			 
+			if
+			 
+			[DOCKEDAT]
+			->
+			 
+			uses
+			 
+			ware
+			 
+			{Energy Cells}
+			 
+			as
+			 
+			product
+
+			endsub
+
+			end
+
+
+			* Don't apply minimum stock limit to refuelling. If min stock level is gigantic this would
+
+			* mean traders never have any jump energy while building up to that level.
+
+			$p1
+			 
+			=
+			 
+			[DOCKEDAT]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Energy Cells}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			skip
+			 
+			if
+			 
+			$p1
+
+			endsub
+
+
+			$p2
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Topup.Jump.Energy
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$min
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Get.Minimum
+			 
+			Arg1
+			=
+			$p1
+			 
+			Arg2
+			=
+			$p2
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			$min
+			 
+			>
+			 
+			0
+
+			endsub
+
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Internal.Buy.Ware
+			 
+			Arg1
+			=
+			{Energy Cells}
+			 
+			Arg2
+			=
+			$min
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Cmd.Repair
+
+			*  Repair if at shipyard
+
+			* ******************************************************************************
+
+			Cmd.Repair
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			while
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			[DOCKEDAT]
+
+			break
+
+			skip
+			 
+			if
+			 
+			[DOCKEDAT]
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Shipyard]
+
+			break
+
+			$Hull.Percent
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			hull
+			 
+			percent
+
+			skip
+			 
+			if
+			 
+			$Hull.Percent
+			 
+			<
+			 
+			100
+
+			break
+
+			$Cost
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Repair.Cost
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Funds
+			 
+			=
+			 
+			get
+			 
+			player
+			 
+			money
+
+			skip
+			 
+			if
+			 
+			$Funds
+			 
+			>
+			 
+			$Cost
+
+			break
+
+			if
+			 
+			$Funds
+			 
+			>
+			 
+			$Cost
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Cmd.Repair: Repaired ship for %s credits from %s percent hull'
+			 
+			arg1
+			=
+			$Cost
+			 
+			arg2
+			=
+			$Hull.Percent
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$Cost
+			 
+			=
+			 
+			$Cost
+			 
+			*
+			 
+			-1
+
+			add
+			 
+			money
+			 
+			to
+			 
+			player
+			:
+			 
+			$Cost
+
+			$Max
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			max
+			 
+			hull
+
+			[THIS]
+			->
+			 
+			set
+			 
+			hull
+			 
+			to
+			 
+			$Max
+
+			end
+
+			break
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Cmd.Launch.Countermeasures
+
+			*  Launch countermeasures
+
+			* ******************************************************************************
+
+			Cmd.Launch.Countermeasures
+			:
+
+			$Threats
+			 
+			=
+			 
+			$Arg1
+
+			$Missiles
+			 
+			=
+			 
+			$Threats
+			[
+			1
+			]
+
+			$Enemies
+			 
+			=
+			 
+			$Threats
+			[
+			2
+			]
+
+
+			* Launch fighter drones
+
+			if
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Enemies
+
+			$a
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Fighter Drone}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$b
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Fighter Drone MKII}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$c
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Keris}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$Available.Drones
+			 
+			=
+			 
+			$a
+			 
+			+
+			 
+			$b
+			 
+			+
+			 
+			$c
+
+			if
+			 
+			$Available.Drones
+			 
+			>
+			 
+			0
+
+			* Find ships that already have a drone attacking them
+
+			$Drones
+			 
+			=
+			 
+			find
+			 
+			ship
+			:
+			 
+			sector
+			=
+			[SECTOR]
+			 
+			class
+			 
+			or
+			 
+			type
+			=
+			[Fighter Drone]
+			 
+			race
+			=
+			[OWNER]
+			 
+			flags
+			=
+			[Find.Multiple]
+			 
+			refobj
+			=
+			null
+			 
+			maxdist
+			=
+			null
+			 
+			maxnum
+			=
+			100
+			 
+			refpos
+			=
+			null
+
+			$Drone.Targets
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Drones
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Drone
+			 
+			=
+			 
+			$Drones
+			[
+			$idx
+			]
+
+			$Target
+			 
+			=
+			 
+			$Drone
+			->
+			 
+			get
+			 
+			attack
+			 
+			target
+
+			skip
+			 
+			if
+			 
+			$Target
+			->
+			 
+			exists
+
+			$Target
+			 
+			=
+			 
+			$Drone
+			->
+			 
+			get
+			 
+			command
+			 
+			target
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Target
+			->
+			 
+			exists
+
+			append
+			 
+			$Target
+			 
+			to
+			 
+			array
+			 
+			$Drone.Targets
+
+			end
+
+
+			* Get targets not being attacked by drones
+
+			$Targets
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Enemies
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Enemy
+			 
+			=
+			 
+			$Enemies
+			[
+			$idx
+			]
+
+			skip
+			 
+			if
+			 
+			find
+			 
+			$Enemy
+			 
+			in
+			 
+			array
+			:
+			 
+			$Drone.Targets
+
+			append
+			 
+			$Enemy
+			 
+			to
+			 
+			array
+			 
+			$Targets
+
+			end
+
+
+			* Determine number of drones per target
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Targets
+
+			$Drones.Per.Enemy
+			 
+			=
+			 
+			$Available.Drones
+			 
+			/
+			 
+			$idx
+
+			skip
+			 
+			if
+			 
+			$Drones.Per.Enemy
+			 
+			>
+			 
+			0
+
+			$Drones.Per.Enemy
+			 
+			=
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			$Drones.Per.Enemy
+			 
+			<
+			 
+			4
+
+			$Drones.Per.Enemy
+			 
+			=
+			 
+			3
+
+
+			* Send drones to targets
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Enemy
+			 
+			=
+			 
+			$Targets
+			[
+			$idx
+			]
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Cmd.Launch.Countermeasures: Launching %s drones at %s'
+			 
+			arg1
+			=
+			$Drones.Per.Enemy
+			 
+			arg2
+			=
+			$Enemy
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			* Send drones 1 at a time as this command will send less than desired
+
+			* if running out of 1 type of drone before breaking into another.
+
+			$Amount
+			 
+			=
+			 
+			$Drones.Per.Enemy
+
+			while
+			 
+			$Amount
+
+			dec
+			 
+			$Amount
+
+			=
+			 
+			[THIS]
+			->
+			 
+			launch
+			 
+			1
+			 
+			fight
+			 
+			drones
+			:
+			 
+			protect
+			 
+			me
+			 
+			or
+			 
+			attack
+			 
+			target
+			=
+			$Enemy
+
+			end
+
+
+			$Available.Drones
+			 
+			=
+			 
+			$Available.Drones
+			 
+			-
+			 
+			$Drones.Per.Enemy
+
+			skip
+			 
+			if
+			 
+			$Available.Drones
+			 
+			>=
+			 
+			$Drones.Per.Enemy
+
+			$Drones.Per.Enemy
+			 
+			=
+			 
+			$Available.Drones
+
+			skip
+			 
+			if
+			 
+			$Available.Drones
+			 
+			>
+			 
+			0
+
+			break
+
+			end
+
+			end
+
+
+			end
+
+
+			* Launch missiles
+
+			$Tmp
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			compatible
+			 
+			missile
+			 
+			array
+			 
+			from
+			 
+			cargobay
+
+			if
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Tmp
+
+			$Fired
+			 
+			=
+			 
+			0
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Enemies
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Target
+			 
+			=
+			 
+			$Enemies
+			[
+			$idx
+			]
+
+			if
+			 
+			$Target
+			->
+			 
+			exists
+
+			if
+			 
+			not
+			 
+			$Target
+			->
+			 
+			find
+			 
+			nearest
+			 
+			missile
+			 
+			aiming
+			 
+			to
+			 
+			me
+
+			$Missile
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			!lib.get.best.missile.fortarget
+			 
+			:
+			 
+			Target
+			=
+			$Target
+			 
+			set.timediff
+			=
+			0
+
+			if
+			 
+			$Missile
+
+			$Fired
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			fire
+			 
+			missile
+			 
+			$Missile
+			 
+			on
+			 
+			$Target
+
+			if
+			 
+			$Fired
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Cmd.Launch.Countermeasures: Fired a %s at %s'
+			 
+			arg1
+			=
+			$Missile
+			 
+			arg2
+			=
+			$Target
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+			end
+
+			end
+
+			end
+
+
+			if
+			 
+			not
+			 
+			$Fired
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Missiles
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Target
+			 
+			=
+			 
+			$Missiles
+			[
+			$idx
+			]
+
+			if
+			 
+			$Target
+			->
+			 
+			exists
+
+			if
+			 
+			not
+			 
+			$Target
+			->
+			 
+			find
+			 
+			nearest
+			 
+			missile
+			 
+			aiming
+			 
+			to
+			 
+			me
+
+			$Missile
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			!lib.get.best.missile.fortarget
+			 
+			:
+			 
+			Target
+			=
+			$Target
+			 
+			set.timediff
+			=
+			0
+
+			if
+			 
+			$Missile
+
+			if
+			 
+			[THIS]
+			->
+			 
+			fire
+			 
+			missile
+			 
+			$Missile
+			 
+			on
+			 
+			$Target
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Cmd.Launch.Countermeasures: Fired a %s at %s'
+			 
+			arg1
+			=
+			$Missile
+			 
+			arg2
+			=
+			$Target
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+			end
+
+			end
+
+			end
+
+			end
+
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Cmd.Equip:
+
+			*  Buy things we need
+
+			* ******************************************************************************
+
+			Cmd.Equip
+			:
+
+			$Equip.Config
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Equip
+			]
+
+
+			while
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			[DOCKEDAT]
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Dock]
+
+			break
+
+
+			* $Owner = [DOCKEDAT]->get owner race
+
+			* skip if $Owner != [Player]
+
+			* break
+
+
+			if
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Missiles
+			]
+
+			$Wares
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			compatible
+			 
+			missile
+			 
+			array
+
+			else
+
+			$Wares
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			end
+
+
+			if
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Drones
+			]
+
+			append
+			 
+			{Fighter Drone}
+			 
+			to
+			 
+			array
+			 
+			$Wares
+
+			append
+			 
+			{Fighter Drone MKII}
+			 
+			to
+			 
+			array
+			 
+			$Wares
+
+			append
+			 
+			{Keris}
+			 
+			to
+			 
+			array
+			 
+			$Wares
+
+			end
+
+
+			if
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Jumpdrive
+			]
+
+			append
+			 
+			{Jumpdrive}
+			 
+			to
+			 
+			array
+			 
+			$Wares
+
+			end
+
+
+			if
+			 
+			$Equip.Config
+			[
+			$Config.Equip.DockingComputer
+			]
+
+			append
+			 
+			{Docking Computer}
+			 
+			to
+			 
+			array
+			 
+			$Wares
+
+			end
+
+
+			if
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Duplex
+			]
+
+			* Don't buy duplex if we have triplex already
+
+			skip
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Triplex Scanner}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			append
+			 
+			{Duplex Scanner}
+			 
+			to
+			 
+			array
+			 
+			$Wares
+
+			end
+
+
+			if
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Triplex
+			]
+
+			append
+			 
+			{Triplex Scanner}
+			 
+			to
+			 
+			array
+			 
+			$Wares
+
+			end
+
+
+			append
+			 
+			{Engine Tuning}
+			 
+			to
+			 
+			array
+			 
+			$Wares
+
+
+			if
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Rudder
+			]
+
+			append
+			 
+			{Rudder Optimisation}
+			 
+			to
+			 
+			array
+			 
+			$Wares
+
+			end
+
+
+			if
+			 
+			$Equip.Config
+			[
+			$Config.Equip.CargoLifeSupport
+			]
+
+			append
+			 
+			{Cargo Lifesupport System}
+			 
+			to
+			 
+			array
+			 
+			$Wares
+
+			end
+
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ware
+			 
+			=
+			 
+			$Wares
+			[
+			$idx
+			]
+
+			if
+			 
+			[DOCKEDAT]
+			->
+			 
+			can
+			 
+			sell
+			 
+			ware
+			 
+			$Ware
+
+			if
+			 
+			[THIS]
+			->
+			 
+			can
+			 
+			buy
+			 
+			ware
+			 
+			$Ware
+			 
+			at
+			 
+			station
+			 
+			[DOCKEDAT]
+
+			$Max
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Reserved.Amount
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Cur
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$p1
+			 
+			=
+			 
+			$Max
+			 
+			-
+			 
+			$Cur
+
+			$p2
+			 
+			=
+			 
+			[DOCKEDAT]
+			->
+			 
+			get
+			 
+			true
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$p3
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$Wanted
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Get.Minimum
+			 
+			Arg1
+			=
+			$p1
+			 
+			Arg2
+			=
+			$p2
+			 
+			Arg3
+			=
+			$p3
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			if
+			 
+			$Wanted
+			 
+			>
+			 
+			0
+
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Can.Trade.Ware
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Mission.Type.Buy
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Amount
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Internal.Buy.Ware
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Wanted
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Cmd.Equip: Bought and equipped %s units of %s'
+			 
+			arg1
+			=
+			$Amount
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			end
+
+			end
+
+			end
+
+			end
+
+
+			if
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Shields
+			]
+
+			* Dock sells best shield
+
+			$Best.Shield
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			max.
+			 
+			shield
+			 
+			type
+			 
+			that
+			 
+			can
+			 
+			be
+			 
+			installed
+
+			$Bays
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			number
+			 
+			of
+			 
+			shield
+			 
+			bays
+
+			$Have
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Best.Shield
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			skip
+			 
+			if
+			 
+			$Have
+			 
+			<=
+			 
+			$Bays
+
+			$Have
+			 
+			=
+			 
+			$Bays
+
+			if
+			 
+			[DOCKEDAT]
+			->
+			 
+			can
+			 
+			sell
+			 
+			ware
+			 
+			$Best.Shield
+
+			if
+			 
+			[THIS]
+			->
+			 
+			can
+			 
+			buy
+			 
+			ware
+			 
+			$Best.Shield
+			 
+			at
+			 
+			station
+			 
+			[DOCKEDAT]
+
+			if
+			 
+			$Have
+			 
+			<
+			 
+			$Bays
+
+			$Wanted
+			 
+			=
+			 
+			$Bays
+			 
+			-
+			 
+			$Have
+
+			$Avail
+			 
+			=
+			 
+			[DOCKEDAT]
+			->
+			 
+			get
+			 
+			true
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Best.Shield
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$Free
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Best.Shield
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$Wanted
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Get.Minimum
+			 
+			Arg1
+			=
+			$Wanted
+			 
+			Arg2
+			=
+			$Avail
+			 
+			Arg3
+			=
+			$Free
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			if
+			 
+			$Wanted
+
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Can.Trade.Ware
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Mission.Type.Buy
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Bought
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Internal.Buy.Ware
+			 
+			Arg1
+			=
+			$Best.Shield
+			 
+			Arg2
+			=
+			$Wanted
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Cmd.Equip: Bought %s units of best shield %s. Had=%s, Bought=%s'
+			 
+			arg1
+			=
+			$Wanted
+			 
+			arg2
+			=
+			$Best.Shield
+			 
+			arg3
+			=
+			$Have
+			 
+			arg4
+			=
+			$Bought
+			 
+			arg5
+			=
+			null
+
+			$Have
+			 
+			=
+			 
+			$Have
+			 
+			+
+			 
+			$Bought
+
+			end
+
+			end
+
+			end
+
+			end
+
+			end
+
+
+			* Requip to best shield
+
+			$Installed
+			 
+			=
+			 
+			0
+
+			$idx
+			 
+			=
+			 
+			$Bays
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Shield
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			shield
+			 
+			type
+			 
+			in
+			 
+			bay
+			 
+			$idx
+
+			skip
+			 
+			if
+			 
+			$Shield
+			 
+			!=
+			 
+			$Best.Shield
+
+			inc
+			 
+			$Installed
+
+			end
+
+			if
+			 
+			$Installed
+			 
+			<
+			 
+			$Have
+
+			$Tmp
+			 
+			=
+			 
+			$Have
+			 
+			*
+			 
+			-1
+
+			=
+			 
+			[THIS]
+			->
+			 
+			add
+			 
+			$Tmp
+			 
+			units
+			 
+			of
+			 
+			$Best.Shield
+
+			=
+			 
+			[THIS]
+			->
+			 
+			install
+			 
+			$Have
+			 
+			units
+			 
+			of
+			 
+			$Best.Shield
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Cmd.Equip: Installed %s out of max %s bays of best shield %s'
+			 
+			arg1
+			=
+			$Have
+			 
+			arg2
+			=
+			$Bays
+			 
+			arg3
+			=
+			$Best.Shield
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			end
+
+
+			break
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Action.Move.Station
+
+			*  Move to station
+
+			* ******************************************************************************
+
+			Action.Move.Station
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Dest
+			 
+			=
+			 
+			$Arg1
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Action.Move.Station: Dest=%s'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			while
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			$Dest
+			->
+			 
+			exists
+
+			break
+
+			skip
+			 
+			if
+			 
+			$Dest
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Station]
+
+			break
+
+			if
+			 
+			[ENVIRONMENT]
+			 
+			==
+			 
+			$Dest
+
+			$rc
+			 
+			=
+			 
+			1
+
+			break
+
+			end
+
+			[THIS]
+			->
+			 
+			set
+			 
+			destination
+			 
+			to
+			 
+			$Dest
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			!move.movetostation
+			 
+			:
+			 
+			targetstation
+			=
+			$Dest
+
+			[THIS]
+			->
+			 
+			set
+			 
+			destination
+			 
+			to
+			 
+			null
+
+
+			skip
+			 
+			if
+			 
+			[ENVIRONMENT]
+			 
+			!=
+			 
+			$Dest
+
+			$rc
+			 
+			=
+			 
+			1
+
+			break
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Action.Move.Station: Dest=%s, rc=%s'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			$rc
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Buy.Ware
+
+			*  Buy a quanity of ware
+
+			* ******************************************************************************
+
+			Buy.Ware
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Ware
+			 
+			=
+			 
+			$Arg1
+
+			$Amount
+			 
+			=
+			 
+			$Arg2
+
+
+			skip
+			 
+			if
+			 
+			[DOCKEDAT]
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Station]
+
+			endsub
+
+
+			if
+			 
+			[HOMEBASE]
+			 
+			==
+			 
+			[DOCKEDAT]
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			load
+			 
+			$Amount
+			 
+			units
+			 
+			of
+			 
+			$Ware
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Buy.Ware: Dock=%s (homebase), Ware=%s, Wanted=%s, Loaded=%s'
+			 
+			arg1
+			=
+			[DOCKEDAT]
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			$Amount
+			 
+			arg4
+			=
+			$rc
+			 
+			arg5
+			=
+			null
+
+			else
+
+			$Price
+			 
+			=
+			 
+			[DOCKEDAT]
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			buy
+			 
+			$Amount
+			 
+			units
+			 
+			of
+			 
+			$Ware
+			 
+			to
+			 
+			a
+			 
+			max.
+			 
+			price
+			 
+			of
+			 
+			$Price
+			 
+			cr
+
+
+			* Free traders track the balance of their trades
+
+			if
+			 
+			not
+			 
+			[HOMEBASE]
+
+			$State
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Fetch
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Trader.Balance
+			 
+			=
+			 
+			$State
+			[
+			$State.Balance
+			]
+
+			$Global.Balance
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Global.Balance
+			]
+
+			$Cost
+			 
+			=
+			 
+			$Price
+			 
+			*
+			 
+			$rc
+			 
+			*
+			 
+			-1
+
+
+			$Tmp
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.BigInt.Add
+			 
+			Arg1
+			=
+			$Trader.Balance
+			 
+			Arg2
+			=
+			$Cost
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$State
+			[
+			$State.Balance
+			]
+			 
+			=
+			 
+			$Tmp
+
+			$Tmp
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.BigInt.Add
+			 
+			Arg1
+			=
+			$Global.Balance
+			 
+			Arg2
+			=
+			$Cost
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Config
+			[
+			$Config.Global.Balance
+			]
+			 
+			=
+			 
+			$Tmp
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Buy.Ware: Dock=%s, Ware=%s, Wanted=%s, Bought=%s, Price.Unit=%s'
+			 
+			arg1
+			=
+			[DOCKEDAT]
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			$Amount
+			 
+			arg4
+			=
+			$rc
+			 
+			arg5
+			=
+			$Price
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Sell.Ware
+
+			*  Sell a quanity of ware
+
+			* ******************************************************************************
+
+			Sell.Ware
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Ware
+			 
+			=
+			 
+			$Arg1
+
+			$Amount
+			 
+			=
+			 
+			$Arg2
+
+			$Buys.Infinite
+			 
+			=
+			 
+			$Arg3
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			is
+			 
+			datatype
+			[
+			$Buys.Infinite
+			]
+			 
+			==
+			 
+			[DATATYPE_NULL]
+
+			$Buys.Infinite
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Test.Buys.Infinite.Wares
+			 
+			Arg1
+			=
+			[THIS]
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			[DOCKEDAT]
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+
+			if
+			 
+			[DOCKEDAT]
+
+			$Price
+			 
+			=
+			 
+			[DOCKEDAT]
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+
+			if
+			 
+			$Buys.Infinite
+
+			$Sold
+			 
+			=
+			 
+			1
+
+			while
+			 
+			$Sold
+
+			$Free
+			 
+			=
+			 
+			[DOCKEDAT]
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			skip
+			 
+			if
+			 
+			$Free
+
+			break
+
+			$Sold
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			sell
+			 
+			$Free
+			 
+			units
+			 
+			of
+			 
+			$Ware
+
+			$rc
+			 
+			=
+			 
+			$rc
+			 
+			+
+			 
+			$Sold
+
+			end
+
+			else
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			sell
+			 
+			$Amount
+			 
+			units
+			 
+			of
+			 
+			$Ware
+
+			end
+
+
+			* Free traders track the balance of their trades
+
+			if
+			 
+			not
+			 
+			[HOMEBASE]
+
+			$State
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Fetch
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Trader.Balance
+			 
+			=
+			 
+			$State
+			[
+			$State.Balance
+			]
+
+			$Global.Balance
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Global.Balance
+			]
+
+			$Profit
+			 
+			=
+			 
+			$Price
+			 
+			*
+			 
+			$rc
+
+
+			$Tmp
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.BigInt.Add
+			 
+			Arg1
+			=
+			$Trader.Balance
+			 
+			Arg2
+			=
+			$Profit
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$State
+			[
+			$State.Balance
+			]
+			 
+			=
+			 
+			$Tmp
+
+			$Tmp
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.BigInt.Add
+			 
+			Arg1
+			=
+			$Global.Balance
+			 
+			Arg2
+			=
+			$Profit
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Config
+			[
+			$Config.Global.Balance
+			]
+			 
+			=
+			 
+			$Tmp
+
+			end
+
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Sell.Ware: Dest=%s, Ware=%s, Wanted=%s, Sold=%s'
+			 
+			arg1
+			=
+			[DOCKEDAT]
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			$Amount
+			 
+			arg4
+			=
+			$rc
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Sanity.Check
+
+			*  Called after performing an action to check if we should bail out
+
+			* ******************************************************************************
+
+			Sanity.Check
+			:
+
+			$Cmd.Enabled
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Check.Cmd.Enabled
+			 
+			Arg1
+			=
+			[THIS]
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			not
+			 
+			$Cmd.Enabled
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Sanity.Check: Lib.Check.Cmd.Enabled returned 0'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			return
+			 
+			null
+
+			end
+
+
+			if
+			 
+			[HOMEBASE]
+			 
+			!=
+			 
+			$Homebase.Start
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Sanity.Check: Homebase has changed since script started'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			return
+			 
+			null
+
+			end
+
+
+			* Config can be replaced on downgrade or removed at uninstall
+
+			$Config
+			 
+			=
+			 
+			get
+			 
+			global
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+
+			skip
+			 
+			if
+			 
+			$Config
+
+			return
+			 
+			null
+
+			endsub
+
+
+			return
+			 
+			null

--- a/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.cmd.x3s
+++ b/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.cmd.x3s
@@ -1,0 +1,5086 @@
+#name: glen.trade.ok.cmd
+#lang: 44
+#origin_mod: OKTraders1_7_1
+#source: mods/OKTraders1_7_1/scripts/glen.trade.ok.cmd.xml
+
+
+			* ******************************************************************************
+
+			* OK Trade
+
+			*  The main command script with the trading loop
+
+			* ******************************************************************************
+
+
+			$Comp
+			 
+			=
+			 
+			'Cmd'
+
+
+			set
+			 
+			script
+			 
+			command
+			:
+			 
+			[GLEN_OK_TRADE]
+
+
+			$Config
+			 
+			=
+			 
+			get
+			 
+			global
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+
+			skip
+			 
+			if
+			 
+			$Config
+
+			return
+			 
+			null
+
+
+			$Homebase.Start
+			 
+			=
+			 
+			[HOMEBASE]
+
+
+			* Config array members
+
+			$Config.Ver.Internal
+			 
+			=
+			 
+			3
+
+			$Config.PageId
+			 
+			=
+			 
+			4
+
+			$Config.Debug.Enabled
+			 
+			=
+			 
+			5
+
+			$Config.All.Wares
+			 
+			=
+			 
+			13
+
+			$Config.Refuel.Percent
+			 
+			=
+			 
+			17
+
+			$Config.Equip
+			 
+			=
+			 
+			20
+
+
+			$Ver.Internal
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			$PageId
+			 
+			=
+			 
+			$Config
+			[
+			$Config.PageId
+			]
+
+
+			* Ware entry members
+
+			$Ware.Entry.Ware
+			 
+			=
+			 
+			0
+
+			$Ware.Entry.Mode
+			 
+			=
+			 
+			1
+
+
+			* Mission types. Maps from Ware.Entry.Mode
+
+			$Mission.Type.None
+			 
+			=
+			 
+			0
+
+			$Mission.Type.Buy
+			 
+			=
+			 
+			1
+
+			$Mission.Type.Sell
+			 
+			=
+			 
+			2
+
+			$Mission.Type.Move.Station
+			 
+			=
+			 
+			3
+
+
+			* State contents
+
+			$State.Version
+			 
+			=
+			 
+			0
+
+			$State.Mission
+			 
+			=
+			 
+			1
+
+			$State.Dest
+			 
+			=
+			 
+			2
+
+			$State.Ware
+			 
+			=
+			 
+			3
+
+			$State.Price
+			 
+			=
+			 
+			4
+
+			$State.Ware.Entries
+			 
+			=
+			 
+			5
+
+			$State.Fleeing
+			 
+			=
+			 
+			6
+
+			$State.Balance
+			 
+			=
+			 
+			7
+
+			$State.Trade.Mode
+			 
+			=
+			 
+			8
+
+			$State.Tether.Sector
+			 
+			=
+			 
+			9
+
+			$State.Tether.Range
+			 
+			=
+			 
+			10
+
+			$State.Ver.Cmd
+			 
+			=
+			 
+			11
+
+			$State.Ver.Monitor
+			 
+			=
+			 
+			12
+
+			$State.Last.Mission
+			 
+			=
+			 
+			13
+
+			$State.Last.Dest
+			 
+			=
+			 
+			14
+
+			$State.Last.Ware
+			 
+			=
+			 
+			15
+
+			$State.Dest2
+			 
+			=
+			 
+			16
+
+
+			$Trade.Mode.Normal
+			 
+			=
+			 
+			0
+
+			$Trade.Mode.Economy
+			 
+			=
+			 
+			1
+
+			$Trade.Mode.Player
+			 
+			=
+			 
+			2
+
+
+			* Defined to avoid warnings, compiler doesn't follow gosubs
+
+			$Mission.Type
+			 
+			=
+			 
+			$Mission.Type.None
+
+			$Last.Mission
+			 
+			=
+			 
+			$Mission.Type.None
+
+			$Mission.Dest
+			 
+			=
+			 
+			null
+
+			$Mission.Dest2
+			 
+			=
+			 
+			null
+
+			$Mission.Ware
+			 
+			=
+			 
+			null
+
+			$Mission.Price
+			 
+			=
+			 
+			null
+
+			$State
+			 
+			=
+			 
+			null
+
+
+			* Whether the cmd script should resume an existing mission
+
+			$Directive.Type.Start
+			 
+			=
+			 
+			0
+
+			$Directive.Type.Resume
+			 
+			=
+			 
+			1
+
+
+			* Library functions
+
+			$Lib.Restart.Cmd
+			 
+			=
+			 
+			1
+
+			$Lib.Check.Cmd.Enabled
+			 
+			=
+			 
+			6
+
+			$Lib.Can.Trade.Ware
+			 
+			=
+			 
+			8
+
+			$Lib.Find.Shipyard
+			 
+			=
+			 
+			11
+
+			$Lib.Test.Buys.Infinite.Wares
+			 
+			=
+			 
+			14
+
+			$Lib.Restart.Monitor
+			 
+			=
+			 
+			15
+
+			$Lib.Find.Station
+			 
+			=
+			 
+			16
+
+			$Lib.Get.Tradeable.Wares
+			 
+			=
+			 
+			19
+
+			$Lib.Get.Best.Ware.To.Buy
+			 
+			=
+			 
+			20
+
+			$Lib.Get.Best.Ware.To.Sell
+			 
+			=
+			 
+			23
+
+			$Lib.Get.Amount.For.Sale
+			 
+			=
+			 
+			24
+
+			$Lib.Get.Needs.Refuel
+			 
+			=
+			 
+			26
+
+			$Lib.Get.Refuel.Dest
+			 
+			=
+			 
+			27
+
+			$Lib.Get.Repair.Cost
+			 
+			=
+			 
+			29
+
+			$Lib.Get.Eco.Mission
+			 
+			=
+			 
+			36
+
+
+			$Lib.Generic.Clone.Array
+			 
+			=
+			 
+			3
+
+
+			* State functions
+
+			$Lib.State.Fetch
+			 
+			=
+			 
+			0
+
+			$Lib.State.Publish
+			 
+			=
+			 
+			1
+
+			$Lib.State.Get.Excludes
+			 
+			=
+			 
+			4
+
+			$Lib.State.Check.Competition
+			 
+			=
+			 
+			5
+
+
+			* Action functions
+
+			$Cmd.Move.Station
+			 
+			=
+			 
+			1
+
+			$Cmd.Buy.Ware
+			 
+			=
+			 
+			2
+
+			$Cmd.Sell.Ware
+			 
+			=
+			 
+			3
+
+			$Cmd.Offload.Wares
+			 
+			=
+			 
+			4
+
+			$Cmd.Load.Jumpdrive.Energy
+			 
+			=
+			 
+			5
+
+			$Cmd.None
+			 
+			=
+			 
+			6
+
+			$Cmd.Repair
+			 
+			=
+			 
+			7
+
+			$Cmd.Equip
+			 
+			=
+			 
+			9
+
+
+			* Find flags
+
+			$Find.Ignore.Competition
+			 
+			=
+			 
+			1
+
+			$Find.Force.Best.Price
+			 
+			=
+			 
+			2
+
+			$Find.Equipping
+			 
+			=
+			 
+			4
+
+			$Find.Eco
+			 
+			=
+			 
+			8
+
+
+			* Equipping config
+
+			$Config.Equip.Ver
+			 
+			=
+			 
+			0
+
+			$Config.Equip.Lasers
+			 
+			=
+			 
+			1
+
+			$Config.Equip.Shields
+			 
+			=
+			 
+			2
+
+			$Config.Equip.Missiles
+			 
+			=
+			 
+			3
+
+			$Config.Equip.Drones
+			 
+			=
+			 
+			4
+
+			$Config.Equip.DockingComputer
+			 
+			=
+			 
+			5
+
+			$Config.Equip.Jumpdrive
+			 
+			=
+			 
+			6
+
+			$Config.Equip.Triplex
+			 
+			=
+			 
+			7
+
+			$Config.Equip.Rudder
+			 
+			=
+			 
+			8
+
+
+			$Equip.Config
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Equip
+			]
+
+
+			$Null
+			 
+			=
+			 
+			null
+
+
+			* Enable auto jumping to avoid having to manually enable it on traders
+
+			[THIS]
+			->
+			 
+			autojump
+			 
+			minimum
+			 
+			jumps
+			=
+			 
+			0
+
+			[THIS]
+			->
+			 
+			set
+			 
+			autojump
+			 
+			active
+			:
+			 
+			1
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Start: Directive=%s, Version=%s'
+			 
+			arg1
+			=
+			$Directive
+			 
+			arg2
+			=
+			$Ver.Internal
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			gosub
+			 
+			State.Get
+			:
+
+			$State
+			[
+			$State.Ver.Cmd
+			]
+			 
+			=
+			 
+			$Ver.Internal
+
+
+			if
+			 
+			$Directive
+			 
+			==
+			 
+			$Directive.Type.Start
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.None
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			end
+
+
+			* ******************************************************************************
+
+			* Main loop
+
+			* ******************************************************************************
+
+			while
+			 
+			1
+
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			$Energy
+			 
+			=
+			 
+			[THIS]
+			->
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Energy Cells}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Cmd: Directive=%s, Mission.Type=%s, Environment=%s, Energy=%s'
+			 
+			arg1
+			=
+			$Directive
+			 
+			arg2
+			=
+			$Mission.Type
+			 
+			arg3
+			=
+			[ENVIRONMENT]
+			 
+			arg4
+			=
+			$Energy
+			 
+			arg5
+			=
+			null
+
+			end
+
+
+			gosub
+			 
+			Sanity.Check
+			:
+
+			gosub
+			 
+			State.Get
+			:
+
+
+			* Start the monitor script if it's not already running
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Restart.Monitor
+			 
+			Arg1
+			=
+			[THIS]
+			 
+			Arg2
+			=
+			0
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+
+			$Action.Performed
+			 
+			=
+			 
+			0
+
+
+			if
+			 
+			[DOCKEDAT]
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Station]
+
+			* Clear fleeing state when docked to avoid getting stuck
+
+			$State
+			[
+			$State.Fleeing
+			]
+			 
+			=
+			 
+			null
+
+			gosub
+			 
+			Offload.Wares
+			:
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			[DOCKEDAT]
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Shipyard]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Cmd.Repair
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Cmd.Equip
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			$Mission.Type
+			 
+			!=
+			 
+			$Mission.Type.None
+
+			gosub
+			 
+			Select.Mission
+			:
+
+			skip
+			 
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.None
+
+			gosub
+			 
+			Perform.Mission
+			:
+
+
+			* When an action is performed this updates the displayed command. When idle,
+
+			* re-display the OK Trade command.
+
+			[THIS]
+			->
+			 
+			set
+			 
+			command
+			:
+			 
+			[GLEN_OK_TRADE]
+			  
+			target
+			=
+			null
+			 
+			target2
+			=
+			null
+			 
+			par1
+			=
+			null
+			 
+			par2
+			=
+			null
+
+			[THIS]
+			->
+			 
+			set
+			 
+			destination
+			 
+			to
+			 
+			null
+
+			[THIS]
+			->
+			 
+			set
+			 
+			wanted
+			 
+			ware
+			 
+			count
+			 
+			to
+			 
+			null
+
+			[THIS]
+			->
+			 
+			set
+			 
+			wanted
+			 
+			ware
+			 
+			to
+			 
+			null
+
+
+			if
+			 
+			$Action.Performed
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Short wait'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			=
+			 
+			wait
+			 
+			randomly
+			 
+			from
+			 
+			2000
+			 
+			to
+			 
+			4000
+			 
+			ms
+
+			else
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Long wait'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			=
+			 
+			wait
+			 
+			randomly
+			 
+			from
+			 
+			6000
+			 
+			to
+			 
+			12000
+			 
+			ms
+
+			end
+
+			end
+
+
+			* ******************************************************************************
+
+			* Sanity.Check
+
+			*  Called on entry and after yielding execution. Checks the script should still
+
+			*  be running, and whether it needs to restart due to upgrade.
+
+			* ******************************************************************************
+
+			$Ware.Entries
+			 
+			=
+			 
+			null
+
+			Sanity.Check
+			:
+
+			$Cmd.Enabled
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Check.Cmd.Enabled
+			 
+			Arg1
+			=
+			[THIS]
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			not
+			 
+			$Cmd.Enabled
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Sanity.Check: Lib.Check.Cmd.Enabled returned 0'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			return
+			 
+			null
+
+			end
+
+
+			if
+			 
+			[HOMEBASE]
+			 
+			!=
+			 
+			$Homebase.Start
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Sanity.Check: Homebase has changed since script started'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			return
+			 
+			null
+
+			end
+
+
+			if
+			 
+			[HOMEBASE]
+
+			if
+			 
+			not
+			 
+			is
+			 
+			datatype
+			[
+			$Ware.Entries
+			]
+			 
+			==
+			 
+			[DATATYPE_ARRAY]
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Sanity.Check: Homebase specified but no ware entries'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			return
+			 
+			null
+
+			end
+
+
+			if
+			 
+			not
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Ware.Entries
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Sanity.Check: Ware entry array is empty'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			return
+			 
+			null
+
+			end
+
+			end
+
+
+			* Config can be replaced on downgrade or removed at uninstall
+
+			$Config
+			 
+			=
+			 
+			get
+			 
+			global
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+
+			skip
+			 
+			if
+			 
+			$Config
+
+			return
+			 
+			null
+
+			$Equip.Config
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Equip
+			]
+
+
+			$Ver.New
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			if
+			 
+			$Ver.Internal
+			 
+			!=
+			 
+			$Ver.New
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Sanity.Check: Version changed from %s to %s.'
+			 
+			arg1
+			=
+			$Ver.Internal
+			 
+			arg2
+			=
+			$Ver.New
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			START
+			 
+			$Null
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Restart.Cmd
+			 
+			Arg1
+			=
+			[THIS]
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			return
+			 
+			null
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Perform.Mission
+
+			*  Perform the selected mission
+
+			* ******************************************************************************
+
+			Perform.Mission
+			:
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Perform.Mission: type=%s, dest=%s, ware=%s, price=%s, cur=%s'
+			 
+			arg1
+			=
+			$Mission.Type
+			 
+			arg2
+			=
+			$Mission.Dest
+			 
+			arg3
+			=
+			$Mission.Ware
+			 
+			arg4
+			=
+			$Mission.Price
+			 
+			arg5
+			=
+			[SECTOR]
+
+
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Move.Station
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.Move.Station
+			 
+			Arg2
+			=
+			$Mission.Dest
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			else
+			 
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.Buy
+			 
+			Arg2
+			=
+			$Mission.Dest
+			 
+			Arg3
+			=
+			$Mission.Ware
+			 
+			Arg4
+			=
+			$Mission.Price
+			 
+			Arg5
+			=
+			$Mission.Dest2
+
+			else
+			 
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Sell
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.Sell
+			 
+			Arg2
+			=
+			$Mission.Dest
+			 
+			Arg3
+			=
+			$Mission.Ware
+			 
+			Arg4
+			=
+			$Mission.Price
+			 
+			Arg5
+			=
+			null
+
+			else
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.None
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			[DOCKEDAT]
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Station]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Cmd.Load.Jumpdrive.Energy
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+
+			* Check if we can make it to dest or need refuel
+
+			if
+			 
+			$Mission.Type
+			 
+			!=
+			 
+			$Mission.Type.None
+			 
+			AND
+			 
+			$Mission.Dest
+
+			* Check if we must refuel based on ability to jump both to dest then to an energy source
+
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Needs.Refuel
+			 
+			Arg1
+			=
+			$Mission.Dest
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Station
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Refuel.Dest
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			$Station
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Perform.Mission: Need to refuel, dest=%s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$Mission.Type
+			 
+			=
+			 
+			$Mission.Type.Move.Station
+
+			$Mission.Dest
+			 
+			=
+			 
+			$Station
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.Move.Station
+			 
+			Arg2
+			=
+			$Mission.Dest
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			else
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Perform.Mission: Need to fuel but nowhere to go'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			end
+
+			end
+
+
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Move.Station
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Cmd.Move.Station
+			 
+			Arg1
+			=
+			$Mission.Dest
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			else
+			 
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Cmd.Buy.Ware
+			 
+			Arg1
+			=
+			$Mission.Ware
+			 
+			Arg2
+			=
+			$Mission.Dest
+			 
+			Arg3
+			=
+			$Mission.Dest2
+			 
+			Arg4
+			=
+			$Mission.Price
+			 
+			Arg5
+			=
+			null
+
+			else
+			 
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Sell
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Cmd.Sell.Ware
+			 
+			Arg1
+			=
+			$Mission.Ware
+			 
+			Arg2
+			=
+			$Mission.Dest
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			else
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Cmd.None
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			end
+
+
+			gosub
+			 
+			Sanity.Check
+			:
+
+
+			skip
+			 
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.None
+
+			$Action.Performed
+			 
+			=
+			 
+			1
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Perform.Mission: exit'
+			 
+			arg1
+			=
+			$Mission.Type
+			 
+			arg2
+			=
+			$Mission.Dest
+			 
+			arg3
+			=
+			$Mission.Ware
+			 
+			arg4
+			=
+			$Mission.Price
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Select.Mission
+
+			*  Select a mission for the trader to perform
+
+			* ******************************************************************************
+
+			Select.Mission
+			:
+
+			$Mission.Type
+			 
+			=
+			 
+			$Mission.Type.None
+
+			$Mission.Dest
+			 
+			=
+			 
+			null
+
+			$Mission.Dest2
+			 
+			=
+			 
+			null
+
+			$Mission.Ware
+			 
+			=
+			 
+			null
+
+			$Mission.Price
+			 
+			=
+			 
+			null
+
+
+			while
+			 
+			1
+
+
+			* Buy engine tunings
+
+			if
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Engine Tuning}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Can.Trade.Ware
+			 
+			Arg1
+			=
+			{Engine Tuning}
+			 
+			Arg2
+			=
+			$Mission.Type.Buy
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Get.Excludes
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Flags
+			 
+			=
+			 
+			(
+			$Find.Ignore.Competition
+			 
+			|
+			 
+			$Find.Equipping
+			)
+
+			$Station
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Find.Station
+			 
+			Arg1
+			=
+			{Engine Tuning}
+			 
+			Arg2
+			=
+			$Mission.Type.Buy
+			 
+			Arg3
+			=
+			$Excludes
+			 
+			Arg4
+			=
+			[SECTOR]
+			 
+			Arg5
+			=
+			$Flags
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			$Station
+
+			$Mission.Type
+			 
+			=
+			 
+			$Mission.Type.Move.Station
+
+			$Mission.Dest
+			 
+			=
+			 
+			$Station
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Select.Mission: Buying engine tunings at %s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+			end
+
+
+			* Buy a jumpdrive
+
+			if
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Jumpdrive
+			]
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Jumpdrive}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Can.Trade.Ware
+			 
+			Arg1
+			=
+			{Jumpdrive}
+			 
+			Arg2
+			=
+			$Mission.Type.Buy
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Get.Excludes
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Flags
+			 
+			=
+			 
+			(
+			$Find.Ignore.Competition
+			 
+			|
+			 
+			$Find.Equipping
+			)
+
+			$Station
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Find.Station
+			 
+			Arg1
+			=
+			{Jumpdrive}
+			 
+			Arg2
+			=
+			$Mission.Type.Buy
+			 
+			Arg3
+			=
+			$Excludes
+			 
+			Arg4
+			=
+			[SECTOR]
+			 
+			Arg5
+			=
+			$Flags
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			$Station
+
+			$Mission.Type
+			 
+			=
+			 
+			$Mission.Type.Move.Station
+
+			$Mission.Dest
+			 
+			=
+			 
+			$Station
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Select.Mission: Equipping a jumpdrive at %s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+			end
+
+			end
+
+
+			* Disabled for now. See how it fares without.
+
+			* Check if we must refuel based on percentage of energy reserve remaining
+
+			* if [THIS]-> call script 'glen.trade.ok.lib' : Func=$Lib.Get.Needs.Refuel Arg1=null Arg2=null Arg3=null Arg4=null Arg5=null
+
+			* $Mission.Dest = [THIS]-> call script 'glen.trade.ok.lib' : Func=$Lib.Get.Refuel.Dest Arg1=null Arg2=null Arg3=null Arg4=null Arg5=null
+
+			* if $Mission.Dest
+
+			* skip if not $Config[$Config.Debug.Enabled]
+
+			* = [THIS]-> call script 'glen.trade.ok.trace' : comp=$Comp lvl=5 fmt='Select.Mission: Refuel at %s' arg1=$Mission.Dest arg2=null arg3=null arg4=null arg5=null
+
+			* $Mission.Type = $Mission.Type.Move.Station
+
+			* break
+
+			* else
+
+			* skip if not $Config[$Config.Debug.Enabled]
+
+			* = [THIS]-> call script 'glen.trade.ok.trace' : comp=$Comp lvl=5 fmt='Select.Mission: Need to refuel but nowhere to go' arg1=null arg2=null arg3=null arg4=null arg5=null
+
+			* end
+
+			* end
+
+
+			* Repair
+
+			$Hull.Percent
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			hull
+			 
+			percent
+
+			if
+			 
+			$Hull.Percent
+			 
+			<
+			 
+			100
+
+			$Shipyard
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Find.Shipyard
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			$Shipyard
+
+
+			$Cost
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Repair.Cost
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Funds
+			 
+			=
+			 
+			get
+			 
+			player
+			 
+			money
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			[HOMEBASE]
+
+			$Funds
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			money
+
+			if
+			 
+			$Funds
+			 
+			>
+			 
+			$Cost
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Select.Mission: Going for repairs at %s'
+			 
+			arg1
+			=
+			$Mission.Dest
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$Mission.Type
+			 
+			=
+			 
+			$Mission.Type.Move.Station
+
+			$Mission.Dest
+			 
+			=
+			 
+			$Shipyard
+
+			end
+
+			end
+
+			end
+
+
+			* If not repairing pick a mission
+
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.None
+
+			if
+			 
+			[HOMEBASE]
+
+			gosub
+			 
+			Select.Mission.Homebased
+			:
+
+			else
+
+			gosub
+			 
+			Select.Mission.Free.Trader
+			:
+
+			end
+
+			end
+
+
+			break
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Select.Mission.Homebased:
+
+			*  Select a mission for a homebased trader
+
+			* ******************************************************************************
+
+			Select.Mission.Homebased
+			:
+
+			$Max.Jumps
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			max
+			 
+			trade
+			 
+			jumps
+
+			$Home.Sector
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			sector
+
+
+			$Prioritized.Tradeable.Ware.Entries
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Tradeable.Wares
+			 
+			Arg1
+			=
+			$Ware.Entries
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Default.Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Get.Excludes
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			append
+			 
+			[HOMEBASE]
+			 
+			to
+			 
+			array
+			 
+			$Default.Excludes
+
+
+			* Select a ware to trade
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Prioritized.Tradeable.Ware.Entries
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+
+			$Ware.Entry
+			 
+			=
+			 
+			$Prioritized.Tradeable.Ware.Entries
+			[
+			$idx
+			]
+
+			$Ware
+			 
+			=
+			 
+			$Ware.Entry
+			[
+			$Ware.Entry.Ware
+			]
+
+			$Mode
+			 
+			=
+			 
+			$Ware.Entry
+			[
+			$Ware.Entry.Mode
+			]
+
+
+			$Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Clone.Array
+			 
+			Arg1
+			=
+			$Default.Excludes
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Station
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Find.Station
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Mode
+			 
+			Arg3
+			=
+			$Excludes
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			0
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			$Station
+			->
+			 
+			exists
+
+			if
+			 
+			$Mode
+			 
+			==
+			 
+			$Mission.Type.Sell
+			 
+			AND
+			 
+			[ENVIRONMENT]
+			 
+			!=
+			 
+			[HOMEBASE]
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Amount.For.Sale
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Station
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Mission.Type
+			 
+			=
+			 
+			$Mission.Type.Move.Station
+
+			$Mission.Dest
+			 
+			=
+			 
+			[HOMEBASE]
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Select.Mission.Homebased: Must return to homebase to load ware %s for sale mission'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+
+			$Price
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$Mission.Type
+			 
+			=
+			 
+			$Mode
+
+			$Mission.Dest
+			 
+			=
+			 
+			$Station
+
+			$Mission.Dest2
+			 
+			=
+			 
+			[HOMEBASE]
+
+			$Mission.Ware
+			 
+			=
+			 
+			$Ware
+
+			$Mission.Price
+			 
+			=
+			 
+			$Price
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Select.Mission.Homebased: Trade opportunity: ware=%s, dest=%s, mode=%s, price=%s'
+			 
+			arg1
+			=
+			$Mission.Ware
+			 
+			arg2
+			=
+			$Mission.Dest
+			 
+			arg3
+			=
+			$Mission.Type
+			 
+			arg4
+			=
+			$Mission.Price
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.None
+			 
+			AND
+			 
+			[ENVIRONMENT]
+			 
+			!=
+			 
+			[HOMEBASE]
+
+			$Mission.Type
+			 
+			=
+			 
+			$Mission.Type.Move.Station
+
+			$Mission.Dest
+			 
+			=
+			 
+			[HOMEBASE]
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Select.Mission.Free.Trader
+
+			*  Pick a mission for a free trader
+
+			* ******************************************************************************
+
+			Select.Mission.Free.Trader
+			:
+
+			while
+			 
+			1
+
+
+			* Flog anything on board that isn't nailed down.
+
+			* Cannot have eco traders getting clogged up, so fall back to selling for profit
+
+			$rc
+			 
+			=
+			 
+			null
+
+			$Trade.Mode
+			 
+			=
+			 
+			$State
+			[
+			$State.Trade.Mode
+			]
+
+			if
+			 
+			$Trade.Mode
+			 
+			==
+			 
+			$Trade.Mode.Economy
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Best.Ware.To.Sell
+			 
+			Arg1
+			=
+			$Find.Eco
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			gosub
+			 
+			Sanity.Check
+			:
+
+			end
+
+			if
+			 
+			not
+			 
+			$rc
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Best.Ware.To.Sell
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			gosub
+			 
+			Sanity.Check
+			:
+
+			end
+
+
+			if
+			 
+			$rc
+
+			$Ware
+			 
+			=
+			 
+			$rc
+			[
+			0
+			]
+
+			$Sell.At
+			 
+			=
+			 
+			$rc
+			[
+			1
+			]
+
+			$Price
+			 
+			=
+			 
+			$rc
+			[
+			2
+			]
+
+
+			* Because waits are involved another ship may have won a race to this trade. Try again after a short wait
+
+			$Competition
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Check.Competition
+			 
+			Arg1
+			=
+			$Mission.Type.Sell
+			 
+			Arg2
+			=
+			$Sell.At
+			 
+			Arg3
+			=
+			$Ware
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			if
+			 
+			$Competition
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Select.Mission.Free.Trader: Lost a race to a sale. Ware=%s, Dest=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Sell.At
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$Action.Performed
+			 
+			=
+			 
+			1
+
+			break
+
+			end
+
+
+			$Mission.Type
+			 
+			=
+			 
+			$Mission.Type.Sell
+
+			$Mission.Dest
+			 
+			=
+			 
+			$Sell.At
+
+			$Mission.Ware
+			 
+			=
+			 
+			$Ware
+
+			$Mission.Price
+			 
+			=
+			 
+			$Price
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Select.Mission.Free.Trader: Sell %s at %s for %s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Sell.At
+			 
+			arg3
+			=
+			$Price
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			* Find the most profitable trade
+
+			$rc
+			 
+			=
+			 
+			null
+
+			$Trade.Mode
+			 
+			=
+			 
+			$State
+			[
+			$State.Trade.Mode
+			]
+
+			if
+			 
+			$Trade.Mode
+			 
+			==
+			 
+			$Trade.Mode.Economy
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Eco.Mission
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			* $rc = [THIS]-> call script 'glen.trade.ok.lib' : Func=$Lib.Get.Best.Ware.To.Buy Arg1=$Find.Eco Arg2=null Arg3=null Arg4=null Arg5=null Arg6=null
+
+			gosub
+			 
+			Sanity.Check
+			:
+
+			end
+
+			if
+			 
+			not
+			 
+			$rc
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Best.Ware.To.Buy
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			gosub
+			 
+			Sanity.Check
+			:
+
+			end
+
+
+			if
+			 
+			not
+			 
+			$rc
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Select.Mission.Free.Trader: Nothing to trade'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			$Ware
+			 
+			=
+			 
+			$rc
+			[
+			0
+			]
+
+			$Dest
+			 
+			=
+			 
+			$rc
+			[
+			1
+			]
+
+			$Dest2
+			 
+			=
+			 
+			$rc
+			[
+			2
+			]
+
+
+			* Because waits are involved another ship may have won a race to this trade. Try again after a short wait
+
+			$Competition
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Check.Competition
+			 
+			Arg1
+			=
+			$Mission.Type.Buy
+			 
+			Arg2
+			=
+			$Dest
+			 
+			Arg3
+			=
+			$Ware
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			if
+			 
+			$Competition
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Select.Mission.Free.Trader: Lost a race for a purchase. Ware=%s, Dest=%s, Dest2=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Dest
+			 
+			arg3
+			=
+			$Dest2
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$Action.Performed
+			 
+			=
+			 
+			1
+
+			break
+
+			end
+
+
+			$Mission.Type
+			 
+			=
+			 
+			$Mission.Type.Buy
+
+			$Mission.Ware
+			 
+			=
+			 
+			$Ware
+
+			$Mission.Dest
+			 
+			=
+			 
+			$Dest
+
+			$Mission.Dest2
+			 
+			=
+			 
+			$Dest2
+
+			$Mission.Price
+			 
+			=
+			 
+			$Mission.Dest
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Mission.Ware
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Select.Mission.Free.Trader: Buy %s at %s for %s'
+			 
+			arg1
+			=
+			$Mission.Ware
+			 
+			arg2
+			=
+			$Mission.Dest
+			 
+			arg3
+			=
+			$Mission.Price
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* State.Get:
+
+			*  Read state from local variable
+
+			* ******************************************************************************
+
+			State.Get
+			:
+
+			$State
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Fetch
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Last.Mission
+			 
+			=
+			 
+			$State
+			[
+			$State.Last.Mission
+			]
+
+			$Last.Dest
+			 
+			=
+			 
+			$State
+			[
+			$State.Last.Dest
+			]
+
+			$Last.Ware
+			 
+			=
+			 
+			$State
+			[
+			$State.Last.Ware
+			]
+
+			$Mission.Type
+			 
+			=
+			 
+			$State
+			[
+			$State.Mission
+			]
+
+			$Mission.Dest
+			 
+			=
+			 
+			$State
+			[
+			$State.Dest
+			]
+
+			$Mission.Dest2
+			 
+			=
+			 
+			$State
+			[
+			$State.Dest2
+			]
+
+			$Mission.Ware
+			 
+			=
+			 
+			$State
+			[
+			$State.Ware
+			]
+
+			$Mission.Price
+			 
+			=
+			 
+			$State
+			[
+			$State.Price
+			]
+
+			$Ware.Entries
+			 
+			=
+			 
+			$State
+			[
+			$State.Ware.Entries
+			]
+
+			endsub
+
+
+			* *****************
+
+			* Offload.Wares:
+
+			Offload.Wares
+			:
+
+			$Skip.Ware
+			 
+			=
+			 
+			null
+
+			if
+			 
+			(
+			$Last.Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+			 
+			AND
+			 
+			$Last.Dest
+			 
+			==
+			 
+			[DOCKEDAT]
+			)
+
+			$Skip.Ware
+			 
+			=
+			 
+			$Last.Ware
+
+			end
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Cmd.Offload.Wares
+			 
+			Arg1
+			=
+			$Skip.Ware
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			endsub
+
+
+			return
+			 
+			null

--- a/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.config.x3s
+++ b/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.config.x3s
@@ -1,0 +1,2261 @@
+#name: glen.trade.ok.config
+#lang: 44
+#origin_mod: OKTraders1_7_1
+#source: mods/OKTraders1_7_1/scripts/glen.trade.ok.config.xml
+
+
+			* ******************************************************************************
+
+			* OK Trade
+
+			*  Config related functions
+
+			* ******************************************************************************
+
+
+			$Comp
+			 
+			=
+			 
+			'Config'
+
+
+			$Config
+			 
+			=
+			 
+			get
+			 
+			global
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+
+			skip
+			 
+			if
+			 
+			$Config
+
+			return
+			 
+			null
+
+
+			$Config.Ver.Internal
+			 
+			=
+			 
+			3
+
+			$Config.Debug.Enabled
+			 
+			=
+			 
+			5
+
+
+			$Lib.Config.Get.Station.Config
+			 
+			=
+			 
+			0
+
+			$Lib.Config.Get.Stock.Limit.Min
+			 
+			=
+			 
+			1
+
+			$Lib.Config.Get.Stock.Limit.Max
+			 
+			=
+			 
+			2
+
+			$Lib.Config.Get.Stock.Limit.Free
+			 
+			=
+			 
+			3
+
+			$Lib.Config.Get.Stock.Limit.Tradeable
+			 
+			=
+			 
+			4
+
+			$Lib.Config.Get.Dockware.Limit
+			 
+			=
+			 
+			5
+
+
+			$Lib.Generic.Get.Minimum
+			 
+			=
+			 
+			1
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'>>> Func=%s, arg1=%s, arg2=%s, arg3=%s, arg4=%s'
+			 
+			arg1
+			=
+			$Func
+			 
+			arg2
+			=
+			$Arg1
+			 
+			arg3
+			=
+			$Arg2
+			 
+			arg4
+			=
+			$Arg3
+			 
+			arg5
+			=
+			$Arg4
+
+
+			$rc
+			 
+			=
+			 
+			null
+
+
+			* ******************************************************************************
+
+			* Options
+
+			* ******************************************************************************
+
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Config.Get.Station.Config
+
+			gosub
+			 
+			Lib.Config.Get.Station.Config
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Config.Get.Stock.Limit.Min
+
+			gosub
+			 
+			Lib.Config.Get.Stock.Limit.Min
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Config.Get.Stock.Limit.Max
+
+			gosub
+			 
+			Lib.Config.Get.Stock.Limit.Max
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Config.Get.Stock.Limit.Free
+
+			gosub
+			 
+			Lib.Config.Get.Stock.Limit.Free
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Config.Get.Stock.Limit.Tradeable
+
+			gosub
+			 
+			Lib.Config.Get.Stock.Limit.Tradeable
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Config.Get.Dockware.Limit
+
+			gosub
+			 
+			Lib.Config.Get.Dockware.Limit
+			:
+
+			else
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			0
+			 
+			fmt
+			=
+			'Unknown function %s'
+			 
+			arg1
+			=
+			$Func
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'<<< Func=%s, arg1=%s, arg2=%s, arg3=%s, rc=%s'
+			 
+			arg1
+			=
+			$Func
+			 
+			arg2
+			=
+			$Arg1
+			 
+			arg3
+			=
+			$Arg2
+			 
+			arg4
+			=
+			$Arg3
+			 
+			arg5
+			=
+			$rc
+
+
+			return
+			 
+			$rc
+
+
+			* ******************************************************************************
+
+			* Lib.Config.Get.Station.Config
+
+			*  Get the station config
+
+			* ******************************************************************************
+
+			Lib.Config.Get.Station.Config
+			:
+
+			$Station
+			 
+			=
+			 
+			$Arg1
+
+
+			if
+			 
+			not
+			 
+			$Station
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Station]
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			0
+			 
+			fmt
+			=
+			'Lib.Config.Get.Station.Config: Bad input Station=%s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+			end
+
+
+			$rc
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			local
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok.limits'
+
+			if
+			 
+			not
+			 
+			$rc
+
+			$rc
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			5
+
+			$rc
+			[
+			0
+			]
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			$Tmp
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$rc
+			[
+			1
+			]
+			 
+			=
+			 
+			$Tmp
+
+			$Tmp
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$rc
+			[
+			2
+			]
+			 
+			=
+			 
+			$Tmp
+
+			$Tmp
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$rc
+			[
+			3
+			]
+			 
+			=
+			 
+			$Tmp
+
+			$Station
+			->
+			 
+			set
+			 
+			local
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok.limits'
+			 
+			value
+			=
+			$rc
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Lib.Config.Get.Station.Config: Created config for station %s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+
+			$Ver
+			 
+			=
+			 
+			$rc
+			[
+			0
+			]
+
+			$Wares
+			 
+			=
+			 
+			$rc
+			[
+			1
+			]
+
+			$Mins
+			 
+			=
+			 
+			$rc
+			[
+			2
+			]
+
+			$Maxes
+			 
+			=
+			 
+			$rc
+			[
+			3
+			]
+
+
+			* Clear any 1.7.0 config that got out of step
+
+			if
+			 
+			$Ver
+			 
+			<
+			 
+			1007001
+
+			$Wares.Count
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares
+
+			$Mins.Count
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Mins
+
+			$Maxes.Count
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Maxes
+
+			if
+			 
+			$Wares.Count
+			 
+			!=
+			 
+			$Mins.Count
+			 
+			OR
+			 
+			$Mins.Count
+			 
+			!=
+			 
+			$Maxes.Count
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			1
+			 
+			fmt
+			=
+			'Lib.Config.Get.Station.Config: Clearing corrupt station ware config for %s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			resize
+			 
+			array
+			 
+			$Wares
+			 
+			to
+			 
+			0
+
+			resize
+			 
+			array
+			 
+			$Mins
+			 
+			to
+			 
+			0
+
+			resize
+			 
+			array
+			 
+			$Maxes
+			 
+			to
+			 
+			0
+
+			end
+
+			$rc
+			[
+			0
+			]
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			end
+
+
+			$Sort
+			 
+			=
+			 
+			0
+
+
+			* Add wares not already known
+
+			$Wares.Station
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			tradeable
+			 
+			ware
+			 
+			array
+			 
+			from
+			 
+			station
+
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares.Station
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ware
+			 
+			=
+			 
+			$Wares.Station
+			[
+			$idx
+			]
+
+
+			if
+			 
+			not
+			 
+			find
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			:
+			 
+			$Wares
+
+			append
+			 
+			$Ware
+			 
+			to
+			 
+			array
+			 
+			$Wares
+
+			append
+			 
+			0
+			 
+			to
+			 
+			array
+			 
+			$Mins
+
+			append
+			 
+			100
+			 
+			to
+			 
+			array
+			 
+			$Maxes
+
+			$Sort
+			 
+			=
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Lib.Config.Get.Station.Config: Added entry for ware %s station %s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			end
+
+
+			* Remove wares no longer present
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ware
+			 
+			=
+			 
+			$Wares
+			[
+			$idx
+			]
+
+
+			if
+			 
+			not
+			 
+			find
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			:
+			 
+			$Wares.Station
+
+			remove
+			 
+			element
+			 
+			from
+			 
+			array
+			 
+			$Wares
+			 
+			at
+			 
+			index
+			 
+			$idx
+
+			remove
+			 
+			element
+			 
+			from
+			 
+			array
+			 
+			$Mins
+			 
+			at
+			 
+			index
+			 
+			$idx
+
+			remove
+			 
+			element
+			 
+			from
+			 
+			array
+			 
+			$Maxes
+			 
+			at
+			 
+			index
+			 
+			$idx
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Lib.Config.Get.Station.Config: Removed entry for ware %s station %s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			end
+
+
+			* Sort alphabetically if wares were added
+
+			if
+			 
+			$Sort
+
+			$Wares
+			 
+			=
+			 
+			sort
+			 
+			array
+			:
+			 
+			data
+			=
+			$Wares
+			 
+			sort
+			 
+			values
+			=
+			$Wares
+
+			$Mins
+			 
+			=
+			 
+			sort
+			 
+			array
+			:
+			 
+			data
+			=
+			$Mins
+			 
+			sort
+			 
+			values
+			=
+			$Wares
+
+			$Maxes
+			 
+			=
+			 
+			sort
+			 
+			array
+			:
+			 
+			data
+			=
+			$Maxes
+			 
+			sort
+			 
+			values
+			=
+			$Wares
+
+			end
+
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Lib.Config.Get.Stock.Limit.Common
+
+			*  Common body for Lib.Config.Get.Stock.Limit.*
+
+			* ******************************************************************************
+
+			Lib.Config.Get.Stock.Limit.Common
+			:
+
+			$Station
+			 
+			=
+			 
+			$Arg1
+
+			$Ware
+			 
+			=
+			 
+			$Arg2
+
+
+			$Range
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			max
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			that
+			 
+			can
+			 
+			be
+			 
+			stored
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+
+			$Owner
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			owner
+			 
+			race
+
+			if
+			 
+			$Owner
+			 
+			!=
+			 
+			[Player]
+
+			$Min
+			 
+			=
+			 
+			0
+
+			$Max
+			 
+			=
+			 
+			$Range
+
+			endsub
+
+			end
+
+
+			$Station.Config
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Station.Config
+			 
+			Arg1
+			=
+			$Station
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+
+			$Wares
+			 
+			=
+			 
+			$Station.Config
+			[
+			1
+			]
+
+			$Mins
+			 
+			=
+			 
+			$Station.Config
+			[
+			2
+			]
+
+			$Maxes
+			 
+			=
+			 
+			$Station.Config
+			[
+			3
+			]
+
+
+			$idx
+			 
+			=
+			 
+			get
+			 
+			index
+			 
+			of
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			 
+			$Wares
+			 
+			offset
+			=
+			-1
+
+
+			if
+			 
+			$idx
+			 
+			<
+			 
+			0
+
+			$Min
+			 
+			=
+			 
+			0
+
+			$Max
+			 
+			=
+			 
+			$Range
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Lib.Config.Get.Stock.Limit.Common: Ware not found in station config: Ware=%s, Station=%s, Wares=%s, Mins=%s, Maxes=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Wares
+			 
+			arg4
+			=
+			$Mins
+			 
+			arg5
+			=
+			$Maxes
+
+			else
+
+			$Min
+			 
+			=
+			 
+			$Mins
+			[
+			$idx
+			]
+
+			$Max
+			 
+			=
+			 
+			$Maxes
+			[
+			$idx
+			]
+
+			end
+
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Lib.Config.Get.Stock.Limit.Min
+
+			*  Get the minimum stock limit for a station as absolute value
+
+			* ******************************************************************************
+
+			Lib.Config.Get.Stock.Limit.Min
+			:
+
+			gosub
+			 
+			Lib.Config.Get.Stock.Limit.Common
+			:
+
+			$rc
+			 
+			=
+			 
+			(
+			$Range
+			 
+			*
+			 
+			$Min
+			)
+			 
+			/
+			 
+			100
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Lib.Config.Get.Stock.Limit.Min: Ware=%s, Station=%s, Min.Perc=%s, Range=%s, rc=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Min
+			 
+			arg4
+			=
+			$Range
+			 
+			arg5
+			=
+			$rc
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Lib.Config.Get.Stock.Limit.Max
+
+			*  Get the maximum stock limit for a station as absolute value
+
+			* ******************************************************************************
+
+			Lib.Config.Get.Stock.Limit.Max
+			:
+
+			gosub
+			 
+			Lib.Config.Get.Stock.Limit.Common
+			:
+
+
+			if
+			 
+			$Owner
+			 
+			==
+			 
+			[Player]
+
+			$OK.Limit
+			 
+			=
+			 
+			(
+			$Range
+			 
+			*
+			 
+			$Max
+			)
+			 
+			/
+			 
+			100
+
+			$Dockware.Limit
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Dockware.Limit
+			 
+			Arg1
+			=
+			$Station
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$rc
+			 
+			=
+			 
+			$OK.Limit
+
+			skip
+			 
+			if
+			 
+			$Dockware.Limit
+			 
+			==
+			 
+			null
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Get.Minimum
+			 
+			Arg1
+			=
+			$OK.Limit
+			 
+			Arg2
+			=
+			$Dockware.Limit
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			else
+
+			$rc
+			 
+			=
+			 
+			$Max
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Lib.Config.Get.Stock.Limit.Max: Ware=%s, Station=%s, Max.OK=%s, Max.Dockware=%s, rc=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$OK.Limit
+			 
+			arg4
+			=
+			$Dockware.Limit
+			 
+			arg5
+			=
+			$rc
+
+			endsub
+
+
+
+			* ******************************************************************************
+
+			* Lib.Config.Get.Stock.Limit.Free
+
+			*  Get free amount of a ware for a station respecting limits
+
+			* ******************************************************************************
+
+			Lib.Config.Get.Stock.Limit.Free
+			:
+
+			gosub
+			 
+			Lib.Config.Get.Stock.Limit.Max
+			:
+
+			$Have
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$rc
+			 
+			=
+			 
+			$rc
+			 
+			-
+			 
+			$Have
+
+			skip
+			 
+			if
+			 
+			$rc
+			 
+			>=
+			 
+			0
+
+			$rc
+			 
+			=
+			 
+			0
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Lib.Config.Get.Stock.Limit.Free: Ware=%s, Station=%s, Have=%s, rc=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Have
+			 
+			arg4
+			=
+			$rc
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Lib.Config.Get.Stock.Limit.Tradeable
+
+			*  Get the amount of ware available at a station minus the reserved minumum
+
+			* ******************************************************************************
+
+			Lib.Config.Get.Stock.Limit.Tradeable
+			:
+
+			gosub
+			 
+			Lib.Config.Get.Stock.Limit.Min
+			:
+
+			$Have
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			true
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$rc
+			 
+			=
+			 
+			$Have
+			 
+			-
+			 
+			$rc
+
+			skip
+			 
+			if
+			 
+			$rc
+			 
+			>=
+			 
+			0
+
+			$rc
+			 
+			=
+			 
+			0
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Lib.Config.Get.Stock.Limit.Tradeable: Ware=%s, Station=%s, $Have=%s, rc=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Have
+			 
+			arg4
+			=
+			$rc
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Lib.Config.Get.Dockware.Limit
+
+			*  Get dockware manager limit on a ware. Returns null if no limit is set.
+
+			* ******************************************************************************
+
+			Lib.Config.Get.Dockware.Limit
+			:
+
+			$Station
+			 
+			=
+			 
+			$Arg1
+
+			$Ware
+			 
+			=
+			 
+			$Arg2
+
+
+			$Maintype
+			 
+			=
+			 
+			get
+			 
+			maintype
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$SubType
+			 
+			=
+			 
+			get
+			 
+			subtype
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$Variable
+			 
+			=
+			 
+			'dockware.manager.cargo.'
+			 
+			+
+			 
+			(
+			$Maintype
+			 
+			*
+			 
+			100
+			 
+			+
+			 
+			$SubType
+			)
+
+			$rc
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			local
+			 
+			variable
+			:
+			 
+			name
+			=
+			$Variable
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Lib.Config.Get.Dockware.Limit: Ware=%s, Station=%s, rc=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$rc
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			return
+			 
+			null

--- a/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.lib.generic.x3s
+++ b/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.lib.generic.x3s
@@ -1,0 +1,799 @@
+#name: glen.trade.ok.lib.generic
+#lang: 44
+#origin_mod: OKTraders1_7_1
+#source: mods/OKTraders1_7_1/scripts/glen.trade.ok.lib.generic.xml
+
+
+			* ******************************************************************************
+
+			* OK Trade
+
+			*  Generic optimized functions
+
+			* ******************************************************************************
+
+
+			* $Lib.Generic.Get.Minimum = 1
+
+			* $Lib.Generic.Join.Arrays = 2
+
+			* $Lib.Generic.Clone.Array = 3
+
+			* $Lib.Generic.Get.Jump.Energy.For.Trip = 4
+
+			* $Lib.Generic.Can.Jump.Trip = 5
+
+
+			$rc
+			 
+			=
+			 
+			null
+
+
+			if
+			 
+			$Func
+			 
+			==
+			 
+			1
+
+			gosub
+			 
+			Lib.Generic.Get.Minimum
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			2
+
+			gosub
+			 
+			Lib.Generic.Join.Arrays
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			3
+
+			gosub
+			 
+			Lib.Generic.Clone.Array
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			4
+
+			gosub
+			 
+			Lib.Generic.Get.Jump.Energy.For.Trip
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			5
+
+			gosub
+			 
+			Lib.Generic.Can.Jump.Trip
+			:
+
+			end
+
+
+			return
+			 
+			$rc
+
+
+			* ******************************************************************************
+
+			* Lib.Generic.Get.Minimum:
+
+			* ******************************************************************************
+
+			Lib.Generic.Get.Minimum
+			:
+
+			$Game.Version
+			 
+			=
+			 
+			script
+			 
+			engine
+			 
+			version
+
+			if
+			 
+			(
+			$Game.Version
+			 
+			>
+			 
+			49
+			)
+
+			$rc
+			 
+			=
+			 
+			get
+			 
+			minimum
+			,
+			 
+			$Arg1
+			,
+			 
+			$Arg2
+			,
+			 
+			$Arg3
+			,
+			 
+			$Arg4
+			,
+			 
+			$Arg5
+
+			else
+			 
+			if
+			 
+			not
+			 
+			is
+			 
+			datatype
+			[
+			$Arg1
+			]
+			 
+			==
+			 
+			[DATATYPE_NULL]
+
+			$rc
+			 
+			=
+			 
+			$Arg1
+
+			if
+			 
+			not
+			 
+			is
+			 
+			datatype
+			[
+			$Arg2
+			]
+			 
+			==
+			 
+			[DATATYPE_NULL]
+
+			skip
+			 
+			if
+			 
+			$rc
+			 
+			<
+			 
+			$Arg2
+
+			$rc
+			 
+			=
+			 
+			$Arg2
+
+			if
+			 
+			not
+			 
+			is
+			 
+			datatype
+			[
+			$Arg3
+			]
+			 
+			==
+			 
+			[DATATYPE_NULL]
+
+			skip
+			 
+			if
+			 
+			$rc
+			 
+			<
+			 
+			$Arg3
+
+			$rc
+			 
+			=
+			 
+			$Arg3
+
+			if
+			 
+			not
+			 
+			is
+			 
+			datatype
+			[
+			$Arg4
+			]
+			 
+			==
+			 
+			[DATATYPE_NULL]
+
+			skip
+			 
+			if
+			 
+			$rc
+			 
+			<
+			 
+			$Arg4
+
+			$rc
+			 
+			=
+			 
+			$Arg4
+
+			if
+			 
+			not
+			 
+			is
+			 
+			datatype
+			[
+			$Arg5
+			]
+			 
+			==
+			 
+			[DATATYPE_NULL]
+
+			skip
+			 
+			if
+			 
+			$rc
+			 
+			<
+			 
+			$Arg5
+
+			$rc
+			 
+			=
+			 
+			$Arg5
+
+			end
+
+			end
+
+			end
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Lib.Generic.Join.Arrays:
+
+			*  Return a new array containing elements of Arg1 + Arg2
+
+			* ******************************************************************************
+
+			Lib.Generic.Join.Arrays
+			:
+
+			$Arg1.Length
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Arg1
+
+			$Arg2.Length
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Arg2
+
+			$Joined.Length
+			 
+			=
+			 
+			$Arg1.Length
+			 
+			+
+			 
+			$Arg2.Length
+
+			$rc
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			$Joined.Length
+
+
+			if
+			 
+			$Arg2.Length
+
+			dec
+			 
+			$Arg2.Length
+
+			copy
+			 
+			array
+			 
+			$Arg2
+			 
+			index
+			 
+			0
+			 
+			...
+			 
+			$Arg2.Length
+			 
+			into
+			 
+			array
+			 
+			$rc
+			 
+			at
+			 
+			index
+			 
+			$Arg1.Length
+
+			end
+
+
+			if
+			 
+			$Arg1.Length
+
+			dec
+			 
+			$Arg1.Length
+
+			copy
+			 
+			array
+			 
+			$Arg1
+			 
+			index
+			 
+			0
+			 
+			...
+			 
+			$Arg1.Length
+			 
+			into
+			 
+			array
+			 
+			$rc
+			 
+			at
+			 
+			index
+			 
+			0
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Lib.Generic.Clone.Array:
+
+			* ******************************************************************************
+
+			Lib.Generic.Clone.Array
+			:
+
+			$size
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Arg1
+
+			if
+			 
+			$size
+
+			dec
+			 
+			$size
+
+			$rc
+			 
+			=
+			 
+			clone
+			 
+			array
+			 
+			$Arg1
+			 
+			:
+			 
+			index
+			 
+			0
+			 
+			...
+			 
+			$size
+
+			else
+
+			$rc
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Lib.Generic.Get.Jump.Energy.For.Trip:
+
+			*  Get energy required to jump the specified amount of sectors. Because
+
+			*  separate uses of the jumpdrive incur an additional unit cost, the number
+
+			*  of individual jumps should be specified in the segments parameter.
+
+			*   Range = Arg1
+
+			*   Segments = Arg2
+
+			* ******************************************************************************
+
+			Lib.Generic.Get.Jump.Energy.For.Trip
+			:
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			is
+			 
+			datatype
+			[
+			$Arg2
+			]
+			 
+			==
+			 
+			[DATATYPE_NULL]
+
+			$Arg2
+			 
+			=
+			 
+			1
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			needed
+			 
+			jump
+			 
+			drive
+			 
+			energy
+			 
+			for
+			 
+			jump
+			 
+			to
+			 
+			sector
+			 
+			[SECTOR]
+
+			$rc
+			 
+			=
+			 
+			$rc
+			 
+			*
+			 
+			(
+			$Arg1
+			 
+			+
+			 
+			$Arg2
+			)
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Lib.Generic.Can.Jump.Trip:
+
+			*  Whether the ship is capable of jumping a trip specified by amount of sectors
+
+			*  and segments, where each segment means a separate jumpdrive usage that incurs
+
+			*  one additional unit cost of energy.
+
+			*   Range = Arg1
+
+			*   Segments = Arg2
+
+			*   Optional topup energy = Arg3
+
+			* ******************************************************************************
+
+			Lib.Generic.Can.Jump.Trip
+			:
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Jumpdrive}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			$rc
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			is
+			 
+			datatype
+			[
+			$Arg2
+			]
+			 
+			==
+			 
+			[DATATYPE_NULL]
+
+			$Arg2
+			 
+			=
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			is
+			 
+			datatype
+			[
+			$Arg3
+			]
+			 
+			==
+			 
+			[DATATYPE_NULL]
+
+			$Arg3
+			 
+			=
+			 
+			0
+
+			$Energy.Required
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			needed
+			 
+			jump
+			 
+			drive
+			 
+			energy
+			 
+			for
+			 
+			jump
+			 
+			to
+			 
+			sector
+			 
+			[SECTOR]
+
+			$Energy.Required
+			 
+			=
+			 
+			$Energy.Required
+			 
+			*
+			 
+			(
+			$Arg1
+			 
+			+
+			 
+			$Arg2
+			)
+
+			$Energy.Have
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Energy Cells}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$Energy.Have
+			 
+			=
+			 
+			$Energy.Have
+			 
+			+
+			 
+			$Arg3
+
+			$rc
+			 
+			=
+			 
+			(
+			$Energy.Have
+			 
+			>=
+			 
+			$Energy.Required
+			)
+
+			end
+
+			endsub

--- a/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.lib.x3s
+++ b/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.lib.x3s
@@ -1,0 +1,23530 @@
+#name: glen.trade.ok.lib
+#lang: 44
+#origin_mod: OKTraders1_7_1
+#source: mods/OKTraders1_7_1/scripts/glen.trade.ok.lib.xml
+
+
+			* ******************************************************************************
+
+			* OK Trade
+
+			*  Library routines
+
+			* ******************************************************************************
+
+
+			$Comp
+			 
+			=
+			 
+			'Lib'
+
+
+			$Config
+			 
+			=
+			 
+			get
+			 
+			global
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+
+			skip
+			 
+			if
+			 
+			$Config
+
+			return
+			 
+			null
+
+
+			$Config.Ver.Internal
+			 
+			=
+			 
+			3
+
+			$Config.Debug.Enabled
+			 
+			=
+			 
+			5
+
+			$Config.PageId
+			 
+			=
+			 
+			4
+
+			$Config.Required.Ware
+			 
+			=
+			 
+			8
+
+			$Config.Blacklist
+			 
+			=
+			 
+			10
+
+			$Config.Monitor.Task
+			 
+			=
+			 
+			11
+
+			$Config.Trade.Threshold
+			 
+			=
+			 
+			12
+
+			$Config.All.Wares
+			 
+			=
+			 
+			13
+
+			$Config.Trade.Illegal.Wares
+			 
+			=
+			 
+			14
+
+			$Config.Races
+			 
+			=
+			 
+			15
+
+			$Config.Illegal.Wares
+			 
+			=
+			 
+			16
+
+			$Config.Refuel.Percent
+			 
+			=
+			 
+			17
+
+			$Config.Equip
+			 
+			=
+			 
+			20
+
+
+			$Deprecated.Get.Minimum
+			 
+			=
+			 
+			4
+
+			$Deprecated.Clone.Array
+			 
+			=
+			 
+			10
+
+			$Deprecated.Get.Jump.Energy.For.Trip
+			 
+			=
+			 
+			17
+
+			$Deprecated.Can.Jump.Trip
+			 
+			=
+			 
+			18
+
+			$Deprecated.Check.Competition
+			 
+			=
+			 
+			31
+
+
+			$Lib.Restart.Cmd
+			 
+			=
+			 
+			1
+
+			$Lib.Get.Reserve.Jump.Energy
+			 
+			=
+			 
+			2
+
+			$Lib.Get.Topup.Jump.Energy
+			 
+			=
+			 
+			3
+
+			$Lib.Uninstall
+			 
+			=
+			 
+			5
+
+			$Lib.Check.Cmd.Enabled
+			 
+			=
+			 
+			6
+
+			$Lib.Can.Trade.At
+			 
+			=
+			 
+			7
+
+			$Lib.Can.Trade.Ware
+			 
+			=
+			 
+			8
+
+			$Lib.Get.Non.Transportable.Wares
+			 
+			=
+			 
+			9
+
+			$Lib.Find.Shipyard
+			 
+			=
+			 
+			11
+
+			$Lib.Get.Amount.On.Order
+			 
+			=
+			 
+			12
+
+			$Lib.Can.Afford.Trade
+			 
+			=
+			 
+			13
+
+			$Lib.Test.Buys.Infinite.Wares
+			 
+			=
+			 
+			14
+
+			$Lib.Restart.Monitor
+			 
+			=
+			 
+			15
+
+			$Lib.Find.Station
+			 
+			=
+			 
+			16
+
+			$Lib.Get.Tradeable.Wares
+			 
+			=
+			 
+			19
+
+			$Lib.Get.Best.Ware.To.Buy
+			 
+			=
+			 
+			20
+
+			$Lib.Get.Max.Jumps
+			 
+			=
+			 
+			21
+
+			$Lib.Get.Profit
+			 
+			=
+			 
+			22
+
+			$Lib.Get.Best.Ware.To.Sell
+			 
+			=
+			 
+			23
+
+			$Lib.Get.Amount.For.Sale
+			 
+			=
+			 
+			24
+
+			$Lib.Get.Amount.To.Buy
+			 
+			=
+			 
+			25
+
+			$Lib.Get.Needs.Refuel
+			 
+			=
+			 
+			26
+
+			$Lib.Get.Refuel.Dest
+			 
+			=
+			 
+			27
+
+			$Lib.Get.Fleeing.Sector
+			 
+			=
+			 
+			28
+
+			$Lib.Get.Repair.Cost
+			 
+			=
+			 
+			29
+
+			$Lib.Get.Reserved.Amount
+			 
+			=
+			 
+			30
+
+			$Lib.Get.Threats
+			 
+			=
+			 
+			32
+
+			$Lib.BigInt.Add
+			 
+			=
+			 
+			33
+
+			$Lib.BigInt.Format
+			 
+			=
+			 
+			34
+
+			$Lib.Get.Eco.Mission
+			 
+			=
+			 
+			36
+
+			$Lib.Check.Dest2
+			 
+			=
+			 
+			37
+
+
+			$Lib.Generic.Get.Minimum
+			 
+			=
+			 
+			1
+
+			$Lib.Generic.Join.Arrays
+			 
+			=
+			 
+			2
+
+			$Lib.Generic.Clone.Array
+			 
+			=
+			 
+			3
+
+			$Lib.Generic.Get.Jump.Energy.For.Trip
+			 
+			=
+			 
+			4
+
+			$Lib.Generic.Can.Jump.Trip
+			 
+			=
+			 
+			5
+
+
+			$Lib.Config.Get.Station.Config
+			 
+			=
+			 
+			0
+
+			$Lib.Config.Get.Stock.Limit.Min
+			 
+			=
+			 
+			1
+
+			$Lib.Config.Get.Stock.Limit.Max
+			 
+			=
+			 
+			2
+
+			$Lib.Config.Get.Stock.Limit.Free
+			 
+			=
+			 
+			3
+
+			$Lib.Config.Get.Stock.Limit.Tradeable
+			 
+			=
+			 
+			4
+
+
+			* Mission types. Maps from Ware.Entry.Mode
+
+			$Mission.Type.None
+			 
+			=
+			 
+			0
+
+			$Mission.Type.Buy
+			 
+			=
+			 
+			1
+
+			$Mission.Type.Sell
+			 
+			=
+			 
+			2
+
+			$Mission.Type.Move.Station
+			 
+			=
+			 
+			3
+
+			$Mission.Type.Equip
+			 
+			=
+			 
+			4
+
+
+			* Published state entries
+
+			$State.Version
+			 
+			=
+			 
+			0
+
+			$State.Mission
+			 
+			=
+			 
+			1
+
+			$State.Dest
+			 
+			=
+			 
+			2
+
+			$State.Ware
+			 
+			=
+			 
+			3
+
+			$State.Price
+			 
+			=
+			 
+			4
+
+			$State.Fleeing
+			 
+			=
+			 
+			6
+
+			$State.Trade.Mode
+			 
+			=
+			 
+			8
+
+			$State.Tether.Sector
+			 
+			=
+			 
+			9
+
+			$State.Tether.Range
+			 
+			=
+			 
+			10
+
+			$State.Dest2
+			 
+			=
+			 
+			16
+
+			$State.Reserve.Fuel
+			 
+			=
+			 
+			17
+
+
+			$Trade.Mode.Normal
+			 
+			=
+			 
+			0
+
+			$Trade.Mode.Economy
+			 
+			=
+			 
+			1
+
+			$Trade.Mode.Player
+			 
+			=
+			 
+			2
+
+
+			* State functions
+
+			$Lib.State.Fetch
+			 
+			=
+			 
+			0
+
+			$Lib.State.Publish
+			 
+			=
+			 
+			1
+
+			$Lib.State.Get.Excludes
+			 
+			=
+			 
+			4
+
+			$Lib.State.Check.Competition
+			 
+			=
+			 
+			5
+
+
+			* Find flags
+
+			$Find.Ignore.Competition
+			 
+			=
+			 
+			1
+
+			$Find.Force.Best.Price
+			 
+			=
+			 
+			2
+
+			$Find.Equipping
+			 
+			=
+			 
+			4
+
+			$Find.Eco
+			 
+			=
+			 
+			8
+
+
+			* Find station options
+
+			$Find.Mode.Best.Price
+			 
+			=
+			 
+			2
+
+			$Find.Mode.Best.Chance
+			 
+			=
+			 
+			1
+
+			$Find.Mode.Nearest
+			 
+			=
+			 
+			0
+
+
+			* Equipping config
+
+			$Config.Equip.Ver
+			 
+			=
+			 
+			0
+
+			$Config.Equip.Lasers
+			 
+			=
+			 
+			1
+
+			$Config.Equip.Shields
+			 
+			=
+			 
+			2
+
+			$Config.Equip.Missiles
+			 
+			=
+			 
+			3
+
+			$Config.Equip.Drones
+			 
+			=
+			 
+			4
+
+			$Config.Equip.DockingComputer
+			 
+			=
+			 
+			5
+
+			$Config.Equip.Jumpdrive
+			 
+			=
+			 
+			6
+
+			$Config.Equip.Triplex
+			 
+			=
+			 
+			7
+
+			$Config.Equip.Rudder
+			 
+			=
+			 
+			8
+
+
+			$PageId
+			 
+			=
+			 
+			$Config
+			[
+			$Config.PageId
+			]
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Func=%s, arg1=%s, arg2=%s, arg3=%s, arg4=%s'
+			 
+			arg1
+			=
+			$Func
+			 
+			arg2
+			=
+			$Arg1
+			 
+			arg3
+			=
+			$Arg2
+			 
+			arg4
+			=
+			$Arg3
+			 
+			arg5
+			=
+			$Arg4
+
+
+			$rc
+			 
+			=
+			 
+			null
+
+
+			* ******************************************************************************
+
+			* Options
+
+			* ******************************************************************************
+
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Can.Trade.At
+
+			gosub
+			 
+			Can.Trade.At
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Can.Trade.Ware
+
+			gosub
+			 
+			Can.Trade.Ware
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Amount.On.Order
+
+			gosub
+			 
+			Get.Amount.On.Order
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Fleeing.Sector
+
+			gosub
+			 
+			Get.Fleeing.Sector
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Can.Afford.Trade
+
+			gosub
+			 
+			Can.Afford.Trade
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Test.Buys.Infinite.Wares
+
+			gosub
+			 
+			Test.Buys.Infinite.Wares
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Restart.Cmd
+
+			gosub
+			 
+			Restart.Cmd
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Restart.Monitor
+
+			gosub
+			 
+			Restart.Monitor
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Reserve.Jump.Energy
+
+			gosub
+			 
+			Get.Reserve.Jump.Energy
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Topup.Jump.Energy
+
+			gosub
+			 
+			Get.Topup.Jump.Energy
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Profit
+
+			gosub
+			 
+			Get.Profit
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Max.Jumps
+
+			gosub
+			 
+			Get.Max.Jumps
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Amount.For.Sale
+
+			gosub
+			 
+			Get.Amount.For.Sale
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Reserved.Amount
+
+			gosub
+			 
+			Get.Reserved.Amount
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Amount.To.Buy
+
+			gosub
+			 
+			Get.Amount.To.Buy
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Find.Station
+
+			gosub
+			 
+			Find.Station
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Check.Dest2
+
+			gosub
+			 
+			Check.Dest2
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Check.Cmd.Enabled
+
+			gosub
+			 
+			Check.Cmd.Enabled
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Tradeable.Wares
+
+			gosub
+			 
+			Get.Tradeable.Wares
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Non.Transportable.Wares
+
+			gosub
+			 
+			Get.Non.Transportable.Wares
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Best.Ware.To.Buy
+
+			gosub
+			 
+			Get.Best.Ware.To.Buy
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Best.Ware.To.Sell
+
+			gosub
+			 
+			Get.Best.Ware.To.Sell
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Eco.Mission
+
+			gosub
+			 
+			Get.Eco.Mission
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Needs.Refuel
+
+			gosub
+			 
+			Get.Needs.Refuel
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Refuel.Dest
+
+			gosub
+			 
+			Get.Refuel.Dest
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Repair.Cost
+
+			gosub
+			 
+			Get.Repair.Cost
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.BigInt.Add
+
+			gosub
+			 
+			BigInt.Add
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.BigInt.Format
+
+			gosub
+			 
+			BigInt.Format
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Find.Shipyard
+
+			gosub
+			 
+			Find.Shipyard
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Get.Threats
+
+			gosub
+			 
+			Get.Threats
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.Uninstall
+
+			gosub
+			 
+			Uninstall
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Deprecated.Get.Minimum
+
+			gosub
+			 
+			Deprecated.Get.Minimum
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Deprecated.Clone.Array
+
+			gosub
+			 
+			Deprecated.Clone.Array
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Deprecated.Get.Jump.Energy.For.Trip
+
+			gosub
+			 
+			Deprecated.Get.Jump.Energy.For.Trip
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Deprecated.Can.Jump.Trip
+
+			gosub
+			 
+			Deprecated.Can.Jump.Trip
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Deprecated.Check.Competition
+
+			gosub
+			 
+			Deprecated.Check.Competition
+			:
+
+
+			else
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			0
+			 
+			fmt
+			=
+			'Unknown function %s'
+			 
+			arg1
+			=
+			$Func
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+
+			return
+			 
+			$rc
+
+
+			Deprecated.Get.Minimum
+			:
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			3
+			 
+			fmt
+			=
+			'Deprecated call to Get.Minimum, arg1=%s, arg2=%s, arg3=%s, arg4=%s, arg5=%s'
+			 
+			arg1
+			=
+			$Arg1
+			 
+			arg2
+			=
+			$Arg2
+			 
+			arg3
+			=
+			$Arg3
+			 
+			arg4
+			=
+			$Arg4
+			 
+			arg5
+			=
+			$Arg5
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Get.Minimum
+			 
+			Arg1
+			=
+			$Arg1
+			 
+			Arg2
+			=
+			$Arg2
+			 
+			Arg3
+			=
+			$Arg3
+			 
+			Arg4
+			=
+			$Arg4
+			 
+			Arg5
+			=
+			$Arg5
+
+			endsub
+
+
+			Deprecated.Clone.Array
+			:
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			3
+			 
+			fmt
+			=
+			'Deprecated call to Clone.Array, arg1=%s'
+			 
+			arg1
+			=
+			$Arg1
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Clone.Array
+			 
+			Arg1
+			=
+			$Arg1
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			endsub
+
+
+			Deprecated.Get.Jump.Energy.For.Trip
+			:
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			3
+			 
+			fmt
+			=
+			'Deprecated call to Get.Jump.Energy.For.Trip, arg1=%s, arg2=%s'
+			 
+			arg1
+			=
+			$Arg1
+			 
+			arg2
+			=
+			$Arg2
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Get.Jump.Energy.For.Trip
+			 
+			Arg1
+			=
+			$Arg1
+			 
+			Arg2
+			=
+			$Arg2
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			endsub
+
+
+			Deprecated.Can.Jump.Trip
+			:
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			3
+			 
+			fmt
+			=
+			'Deprecated call to Can.Jump.Trip, arg1=%s, arg2=%s'
+			 
+			arg1
+			=
+			$Arg1
+			 
+			arg2
+			=
+			$Arg2
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Can.Jump.Trip
+			 
+			Arg1
+			=
+			$Arg1
+			 
+			Arg2
+			=
+			$Arg2
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			endsub
+
+
+			Deprecated.Check.Competition
+			:
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			3
+			 
+			fmt
+			=
+			'Deprecated call to Check.Competition, arg1=%s, arg2=%s, arg3=%s'
+			 
+			arg1
+			=
+			$Arg1
+			 
+			arg2
+			=
+			$Arg2
+			 
+			arg3
+			=
+			$Arg3
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Check.Competition
+			 
+			Arg1
+			=
+			$Arg1
+			 
+			Arg2
+			=
+			$Arg2
+			 
+			Arg3
+			=
+			$Arg3
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Restart
+
+			*  Wait for cmd script to exit and restart it.
+
+			* ******************************************************************************
+
+			Restart.Cmd
+			:
+
+			$Ship
+			 
+			=
+			 
+			$Arg1
+
+			$Unused
+			 
+			=
+			 
+			$Arg2
+
+			$Wait
+			 
+			=
+			 
+			$Arg3
+
+			$Directive.Type.Start
+			 
+			=
+			 
+			0
+
+			$Directive.Type.Resume
+			 
+			=
+			 
+			1
+
+
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$Wait
+			]
+			 
+			==
+			 
+			[DATATYPE_INT]
+
+			do
+			 
+			if
+			 
+			$Wait
+
+			=
+			 
+			wait
+			 
+			$Wait
+			 
+			ms
+
+			else
+
+			=
+			 
+			wait
+			 
+			randomly
+			 
+			from
+			 
+			200
+			 
+			to
+			 
+			400
+			 
+			ms
+
+			end
+
+
+			if
+			 
+			$Ship
+			->
+			 
+			exists
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Restart.Cmd: ship=%s'
+			 
+			arg1
+			=
+			$Ship
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$Ship
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			$Directive.Type.Resume
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			endsub
+
+
+			* ***************************************************
+
+			* Restart.Monitor
+
+			*  Optionally wait then start the task.
+
+			* ***************************************************
+
+			Restart.Monitor
+			:
+
+			$Ship
+			 
+			=
+			 
+			$Arg1
+
+			$Wait
+			 
+			=
+			 
+			$Arg2
+
+			$Task
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Monitor.Task
+			]
+
+			do
+			 
+			if
+			 
+			$Wait
+
+			=
+			 
+			wait
+			 
+			randomly
+			 
+			from
+			 
+			400
+			 
+			to
+			 
+			600
+			 
+			ms
+
+			if
+			 
+			$Ship
+			->
+			 
+			exists
+
+			if
+			 
+			not
+			 
+			$Ship
+			->
+			 
+			is
+			 
+			script
+			 
+			glen.trade.ok.monitor
+			 
+			on
+			 
+			stack
+			 
+			of
+			 
+			task
+			=
+			$Task
+
+			if
+			 
+			not
+			 
+			$Ship
+			->
+			 
+			is
+			 
+			task
+			 
+			$Task
+			 
+			in
+			 
+			use
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Restart.Monitor: starting monitor on ship=%s, waited=%s'
+			 
+			arg1
+			=
+			$Ship
+			 
+			arg2
+			=
+			$Wait
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$Ship
+			->
+			 
+			begin
+			 
+			task
+			 
+			$Task
+			 
+			with
+			 
+			script
+			 
+			glen.trade.ok.monitor
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			else
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			0
+			 
+			fmt
+			=
+			'Restart.Monitor: Task %s is occupied by a foreign script on ship %s'
+			 
+			arg1
+			=
+			$Task
+			 
+			arg2
+			=
+			$Ship
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			else
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Restart.Monitor: already running on ship=%s following wait=%s'
+			 
+			arg1
+			=
+			$Ship
+			 
+			arg2
+			=
+			$Wait
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Reserve.Jump.Energy
+
+			*  Capped at 40% of cargo space
+
+			* ******************************************************************************
+
+			Get.Reserve.Jump.Energy
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Dest
+			 
+			=
+			 
+			$Arg1
+
+
+			skip
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Jumpdrive}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			endsub
+
+
+			while
+			 
+			1
+
+
+			if
+			 
+			[HOMEBASE]
+
+			$State
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Fetch
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			* Destination of published mission
+
+			$Mission.Dest
+			 
+			=
+			 
+			$State
+			[
+			$State.Dest
+			]
+
+			* Destination of planned mission
+
+			do
+			 
+			if
+			 
+			$Dest
+
+			$Mission.Dest
+			 
+			=
+			 
+			$Dest
+
+
+			if
+			 
+			not
+			 
+			$Mission.Dest
+
+			$Jumps
+			 
+			=
+			 
+			0
+
+			$Segments
+			 
+			=
+			 
+			0
+
+			break
+
+			end
+
+
+			$Dest.Sector
+			 
+			=
+			 
+			$Mission.Dest
+			->
+			 
+			get
+			 
+			sector
+
+
+			if
+			 
+			$Mission.Dest
+			 
+			==
+			 
+			[HOMEBASE]
+
+			$Jumps
+			 
+			=
+			 
+			get
+			 
+			jumps
+			 
+			from
+			 
+			sector
+			 
+			[SECTOR]
+			 
+			to
+			 
+			sector
+			 
+			$Dest.Sector
+
+			$Segments
+			 
+			=
+			 
+			0
+
+			if
+			 
+			$Jumps
+
+			$Jumps.Contingency
+			 
+			=
+			 
+			$Jumps
+			 
+			/
+			 
+			2
+
+			$Jumps.Contingency
+			 
+			=
+			 
+			get
+			 
+			maximum
+			,
+			 
+			$Jumps.Contingency
+			,
+			 
+			2
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Jumps
+			 
+			=
+			 
+			$Jumps
+			 
+			+
+			 
+			$Jumps.Contingency
+
+			$Segments
+			 
+			=
+			 
+			2
+
+			end
+
+			else
+
+			$Home.Sector
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			sector
+
+			$Jumps.There
+			 
+			=
+			 
+			get
+			 
+			jumps
+			 
+			from
+			 
+			sector
+			 
+			[SECTOR]
+			 
+			to
+			 
+			sector
+			 
+			$Dest.Sector
+
+			$Jumps.Home
+			 
+			=
+			 
+			get
+			 
+			jumps
+			 
+			from
+			 
+			sector
+			 
+			$Dest.Sector
+			 
+			to
+			 
+			sector
+			 
+			$Home.Sector
+
+			$Jumps.Round.Trip
+			 
+			=
+			 
+			$Jumps.There
+			 
+			+
+			 
+			$Jumps.Home
+
+			$Jumps.Contingency
+			 
+			=
+			 
+			$Jumps.Round.Trip
+			 
+			/
+			 
+			2
+
+			$Jumps.Contingency
+			 
+			=
+			 
+			get
+			 
+			maximum
+			,
+			 
+			$Jumps.Contingency
+			,
+			 
+			2
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Jumps
+			 
+			=
+			 
+			$Jumps.Round.Trip
+			 
+			+
+			 
+			$Jumps.Contingency
+
+			$Segments
+			 
+			=
+			 
+			0
+
+			do
+			 
+			if
+			 
+			$Jumps.There
+
+			$Segments
+			 
+			=
+			 
+			$Segments
+			 
+			+
+			 
+			1
+
+			do
+			 
+			if
+			 
+			$Jumps.Home
+
+			$Segments
+			 
+			=
+			 
+			$Segments
+			 
+			+
+			 
+			1
+
+			do
+			 
+			if
+			 
+			$Segments
+
+			$Segments
+			 
+			=
+			 
+			$Segments
+			 
+			+
+			 
+			1
+
+			end
+
+
+			else
+
+			$Jumps
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Max.Jumps
+			 
+			Arg1
+			=
+			1
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Jumps
+			 
+			=
+			 
+			(
+			$Jumps
+			 
+			*
+			 
+			2
+			)
+
+			$Segments
+			 
+			=
+			 
+			3
+
+			end
+
+
+			break
+
+			end
+
+
+			$Desired
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Get.Jump.Energy.For.Trip
+			 
+			Arg1
+			=
+			$Jumps
+			 
+			Arg2
+			=
+			$Segments
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Max
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			cargo
+			 
+			bay
+			 
+			size
+
+
+			* $Min = ($Max * 5) / 100
+
+			* $Desired = get maximum, $Desired, $Min, null, null, null
+
+
+			$Max
+			 
+			=
+			 
+			(
+			$Max
+			 
+			*
+			 
+			40
+			)
+			 
+			/
+			 
+			100
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Get.Minimum
+			 
+			Arg1
+			=
+			$Desired
+			 
+			Arg2
+			=
+			$Max
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+
+			* Homebased trader jump energy is recorded when setting out from the homebase so the reserve
+
+			* amount never decreases for the duration of that outing. This avoids issues with trading energy
+
+			* cells caused by dynamic recalculation of jump energy reserve during the mission.
+
+			if
+			 
+			[HOMEBASE]
+
+			if
+			 
+			[ENVIRONMENT]
+			 
+			==
+			 
+			[HOMEBASE]
+
+			$State
+			[
+			$State.Reserve.Fuel
+			]
+			 
+			=
+			 
+			$rc
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Reserve.Jump.Energy: Dest=%s, Jumps=%s, Segments=%s, rc=%s. Reserve set.'
+			 
+			arg1
+			=
+			$Mission.Dest
+			 
+			arg2
+			=
+			$Jumps
+			 
+			arg3
+			=
+			$Segments
+			 
+			arg4
+			=
+			$rc
+			 
+			arg5
+			=
+			null
+
+			else
+
+			$Reserve
+			 
+			=
+			 
+			$State
+			[
+			$State.Reserve.Fuel
+			]
+
+			if
+			 
+			$rc
+			 
+			>
+			 
+			$Reserve
+
+			$State
+			[
+			$State.Reserve.Fuel
+			]
+			 
+			=
+			 
+			$rc
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Reserve.Jump.Energy: Dest=%s, Jumps=%s, Segments=%s, rc=%s (reserve updated from %s)'
+			 
+			arg1
+			=
+			$Mission.Dest
+			 
+			arg2
+			=
+			$Jumps
+			 
+			arg3
+			=
+			$Segments
+			 
+			arg4
+			=
+			$rc
+			 
+			arg5
+			=
+			$Reserve
+
+			else
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Reserve.Jump.Energy: Dest=%s, Jumps=%s, Segments=%s, rc=%s (%s not greater than reserve)'
+			 
+			arg1
+			=
+			$Mission.Dest
+			 
+			arg2
+			=
+			$Jumps
+			 
+			arg3
+			=
+			$Segments
+			 
+			arg4
+			=
+			$Reserve
+			 
+			arg5
+			=
+			$rc
+
+			$rc
+			 
+			=
+			 
+			$Reserve
+
+			end
+
+			end
+
+			else
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Reserve.Jump.Energy: Jumps=%s, Segments=%s, rc=%s'
+			 
+			arg1
+			=
+			$Jumps
+			 
+			arg2
+			=
+			$Segments
+			 
+			arg3
+			=
+			$rc
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Topup.Jump.Energy
+
+			*  Amount of energy ship needs to top up to the desired reserve
+
+			* ******************************************************************************
+
+			Get.Topup.Jump.Energy
+			:
+
+			$rc
+			 
+			=
+			 
+			$Arg1
+
+			skip
+			 
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$rc
+			]
+			 
+			==
+			 
+			[DATATYPE_INT]
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Reserve.Jump.Energy
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			$rc
+
+			$cur
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Energy Cells}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$rc
+			 
+			=
+			 
+			$rc
+			 
+			-
+			 
+			$cur
+
+			skip
+			 
+			if
+			 
+			$rc
+			 
+			>
+			 
+			0
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$free
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Energy Cells}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Get.Minimum
+			 
+			Arg1
+			=
+			$rc
+			 
+			Arg2
+			=
+			$free
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			end
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Get.Topup.Jump.Energy: rc=%s'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Non.Transportable.Wares
+
+			* ******************************************************************************
+
+			Get.Non.Transportable.Wares
+			:
+
+			$Ship
+			 
+			=
+			 
+			$Arg1
+
+			$homebase
+			 
+			=
+			 
+			$Arg2
+
+			$rc
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Wares
+			 
+			=
+			 
+			$homebase
+			->
+			 
+			get
+			 
+			tradeable
+			 
+			ware
+			 
+			array
+			 
+			from
+			 
+			station
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ware
+			 
+			=
+			 
+			$Wares
+			[
+			$idx
+			]
+
+			skip
+			 
+			if
+			 
+			$Ship
+			->
+			 
+			can
+			 
+			transport
+			 
+			ware
+			 
+			$Ware
+
+			append
+			 
+			$Ware
+			 
+			to
+			 
+			array
+			 
+			$rc
+
+			end
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Get.Non.Transportable.Wares: %s'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Uninstall
+
+			* ******************************************************************************
+
+			Uninstall
+			:
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			0
+			 
+			fmt
+			=
+			'Uninstalling...'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			* Text IDs
+
+			$Id.Uninstall.Progress
+			 
+			=
+			 
+			330
+
+			$Id.Uninstall.Complete
+			 
+			=
+			 
+			331
+
+
+			$Candidates
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Races
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Races
+			]
+
+			$idx.Race
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Races
+
+			while
+			 
+			$idx.Race
+
+			dec
+			 
+			$idx.Race
+
+			$Race
+			 
+			=
+			 
+			$Races
+			[
+			$idx.Race
+			]
+
+			$Ships
+			 
+			=
+			 
+			get
+			 
+			ship
+			 
+			array
+			:
+			 
+			of
+			 
+			race
+			 
+			$Race
+			 
+			class
+			/
+			type
+			=
+			[Ship]
+
+			$idx.Ships
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Ships
+
+			while
+			 
+			$idx.Ships
+
+			dec
+			 
+			$idx.Ships
+
+			$Ship
+			 
+			=
+			 
+			$Ships
+			[
+			$idx.Ships
+			]
+
+			do
+			 
+			if
+			 
+			$Ship
+			->
+			 
+			is
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			on
+			 
+			stack
+			 
+			of
+			 
+			task
+			=
+			0
+
+			append
+			 
+			$Ship
+			 
+			to
+			 
+			array
+			 
+			$Candidates
+
+			end
+
+			end
+
+
+			$Candidates.Count
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Candidates
+
+			$idx
+			 
+			=
+			 
+			0
+
+			$Perc.Next
+			 
+			=
+			 
+			0
+
+			while
+			 
+			$idx
+			 
+			<
+			 
+			$Candidates.Count
+
+			$Perc
+			 
+			=
+			 
+			(
+			$idx
+			 
+			*
+			 
+			100
+			)
+			 
+			/
+			 
+			$Candidates.Count
+
+
+			* Only print a message each 5%
+
+			if
+			 
+			$Perc
+			 
+			>=
+			 
+			$Perc.Next
+
+			$Perc.Floor
+			 
+			=
+			 
+			(
+			$Perc
+			 
+			/
+			 
+			20
+			)
+			 
+			*
+			 
+			20
+
+			$Msg
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Id.Uninstall.Progress
+			,
+			 
+			$Perc.Floor
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			display
+			 
+			subtitle
+			 
+			text
+			:
+			 
+			text
+			=
+			$Msg
+			 
+			duration
+			=
+			1500
+			 
+			ms
+
+			$Perc.Next
+			 
+			=
+			 
+			$Perc.Floor
+			 
+			+
+			 
+			(
+			$Perc
+			 
+			/
+			 
+			20
+			)
+
+			=
+			 
+			wait
+			 
+			1
+			 
+			ms
+
+			end
+
+
+			$Ship
+			 
+			=
+			 
+			$Candidates
+			[
+			$idx
+			]
+
+			do
+			 
+			if
+			 
+			$Ship
+			->
+			 
+			is
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			on
+			 
+			stack
+			 
+			of
+			 
+			task
+			=
+			0
+
+			gosub
+			 
+			Uninstall.Ship
+			:
+
+			inc
+			 
+			$idx
+
+			end
+
+			$Msg
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Id.Uninstall.Progress
+			,
+			 
+			100
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			display
+			 
+			subtitle
+			 
+			text
+			:
+			 
+			text
+			=
+			$Msg
+			 
+			duration
+			=
+			1500
+			 
+			ms
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			0
+			 
+			fmt
+			=
+			'Uninstall complete'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			set
+			 
+			global
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+			 
+			value
+			=
+			null
+
+
+			$Msg
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Uninstall.Complete
+
+			send
+			 
+			incoming
+			 
+			message
+			 
+			$Msg
+			 
+			to
+			 
+			player
+			:
+			 
+			display
+			 
+			it
+			=
+			0
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Uninstall.Ship
+
+			* ******************************************************************************
+
+			Uninstall.Ship
+			:
+
+			$State
+			 
+			=
+			 
+			$Ship
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Fetch
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Uninstalling ship=%s, state=%s'
+			 
+			arg1
+			=
+			$Ship
+			 
+			arg2
+			=
+			$State
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			$Mission
+			 
+			=
+			 
+			$State
+			[
+			$State.Mission
+			]
+
+			$Dest
+			 
+			=
+			 
+			$State
+			[
+			$State.Dest
+			]
+
+			$Ware
+			 
+			=
+			 
+			$State
+			[
+			$State.Ware
+			]
+
+			$Price
+			 
+			=
+			 
+			$State
+			[
+			$State.Price
+			]
+
+
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+			$Amount
+			 
+			=
+			 
+			$Ship
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			$Amount
+
+			$Ship
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			!ship.cmd.getware.std
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Dest
+			 
+			arg3
+			=
+			$Amount
+			 
+			arg4
+			=
+			$Price
+			 
+			arg5
+			=
+			0
+
+			else
+			 
+			if
+			 
+			[HOMEBASE]
+
+			$Ship
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			!ship.cmd.returnhome.std
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			else
+
+			$Ship
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			!ship.cmd.movestation.std
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			else
+			 
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Sell
+
+			$Amount
+			 
+			=
+			 
+			$Ship
+			->
+			 
+			get
+			 
+			true
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			$Amount
+
+			$Ship
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			!ship.cmd.sellware.std
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Dest
+			 
+			arg3
+			=
+			$Amount
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			else
+			 
+			if
+			 
+			[HOMEBASE]
+
+			$Ship
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			!ship.cmd.returnhome.std
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			else
+
+			$Ship
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			!ship.cmd.movestation.std
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			else
+			 
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Move.Station
+
+			$Ship
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			!ship.cmd.movestation.std
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			else
+			 
+			if
+			 
+			$Ship
+			->
+			 
+			get
+			 
+			homebase
+
+			$Ship
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			!ship.cmd.returnhome.std
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			else
+
+			$Ship
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			!lib.interrupt
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Check.Cmd.Enabled
+
+			*  Check if a ship can use OK traders.
+
+			* ******************************************************************************
+
+			Check.Cmd.Enabled
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Ship
+			 
+			=
+			 
+			$Arg1
+
+			while
+			 
+			1
+
+			if
+			 
+			not
+			 
+			$Ship
+			->
+			 
+			exists
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Check.Cmd.Enabled: Ship does not exist'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			$Required.Ware
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Required.Ware
+			]
+
+			if
+			 
+			not
+			 
+			$Ship
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Required.Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Check.Cmd.Enabled: Ship %s does not have required ware %s'
+			 
+			arg1
+			=
+			$Ship
+			 
+			arg2
+			=
+			$Required.Ware
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			$homebase
+			 
+			=
+			 
+			$Ship
+			->
+			 
+			get
+			 
+			homebase
+
+			if
+			 
+			$homebase
+			->
+			 
+			exists
+
+			if
+			 
+			not
+			 
+			is
+			 
+			datatype
+			[
+			$homebase
+			]
+			 
+			==
+			 
+			[DATATYPE_STATION]
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Check.Cmd.Enabled: Ship %s homebase %s is not a station'
+			 
+			arg1
+			=
+			$Ship
+			 
+			arg2
+			=
+			$homebase
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			if
+			 
+			not
+			 
+			$homebase
+			->
+			 
+			is
+			 
+			docking
+			 
+			possible
+			 
+			of
+			 
+			$Ship
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Check.Cmd.Enabled: Ship %s cannot dock at homebase %s'
+			 
+			arg1
+			=
+			$Ship
+			 
+			arg2
+			=
+			$homebase
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			$Arg2
+			 
+			=
+			 
+			$homebase
+
+			gosub
+			 
+			Get.Non.Transportable.Wares
+			:
+
+			$Non.Transportable.Count
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$rc
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Total.Count
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares
+
+			if
+			 
+			$Non.Transportable.Count
+			 
+			>=
+			 
+			$Total.Count
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Check.Cmd.Enabled: Ship %s cannot transport any of the wares at this station'
+			 
+			arg1
+			=
+			$Ship
+			 
+			arg2
+			=
+			$homebase
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Check.Cmd.Enabled: Ship %s - OK'
+			 
+			arg1
+			=
+			$Ship
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			$rc
+			 
+			=
+			 
+			1
+
+			break
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Can.Trade.Ware
+
+			*  Check if a ware can be traded
+
+			* ******************************************************************************
+
+			Can.Trade.Ware
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Ware
+			 
+			=
+			 
+			$Arg1
+
+			$Mission
+			 
+			=
+			 
+			$Arg2
+
+
+			while
+			 
+			1
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			can
+			 
+			transport
+			 
+			ware
+			 
+			$Ware
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.Ware: This ship cannot transport ware %s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			skip
+			 
+			if
+			 
+			$Ware
+			 
+			!=
+			 
+			{Marine}
+			 
+			AND
+			 
+			$Ware
+			 
+			!=
+			 
+			{Mercenary}
+
+			break
+
+
+			if
+			 
+			[HOMEBASE]
+
+			$Equipping
+			 
+			=
+			 
+			is
+			 
+			upgrade
+			:
+			 
+			ware
+			=
+			$Ware
+
+			skip
+			 
+			if
+			 
+			$Equipping
+
+			$Equipping
+			 
+			=
+			 
+			is
+			 
+			inventory
+			:
+			 
+			ware
+			=
+			$Ware
+
+			skip
+			 
+			if
+			 
+			$Equipping
+
+			$Equipping
+			 
+			=
+			 
+			is
+			 
+			equipment
+			:
+			 
+			ware
+			=
+			$Ware
+
+
+			if
+			 
+			not
+			 
+			$Equipping
+
+			if
+			 
+			not
+			 
+			[HOMEBASE]
+			->
+			 
+			trades
+			 
+			with
+			 
+			ware
+			 
+			$Ware
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.Ware: Homebase %s does not trade with ware %s'
+			 
+			arg1
+			=
+			[HOMEBASE]
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+
+			else
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Trade.Illegal.Wares
+			]
+
+			* The illegal ware trading setting is checked only on free traders.
+
+			$Illegal.Wares
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Illegal.Wares
+			]
+
+			if
+			 
+			find
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			:
+			 
+			$Illegal.Wares
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.Ware: Ware %s is illegal and config says no'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.Ware: No space in cargobay for ware %s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			$Price
+			 
+			=
+			 
+			get
+			 
+			max
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$Funds
+			 
+			=
+			 
+			get
+			 
+			player
+			 
+			money
+
+			do
+			 
+			if
+			 
+			[HOMEBASE]
+
+			$Funds
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			money
+
+			if
+			 
+			$Funds
+			 
+			<
+			 
+			$Price
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.Ware: Cannot afford to buy 1 unit of ware %s. Price=%s, funds=%s.'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Price
+			 
+			arg3
+			=
+			$Funds
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			else
+			 
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Sell
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			[HOMEBASE]
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Stock.Limit.Tradeable
+			 
+			Arg1
+			=
+			[HOMEBASE]
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.Ware: Homebase %s has no ware %s in stock'
+			 
+			arg1
+			=
+			[HOMEBASE]
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			else
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.Ware: No ware %s on board'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+			else
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			0
+			 
+			fmt
+			=
+			'Can.Trade.Ware: Unhandled mission type %s'
+			 
+			arg1
+			=
+			$Mission
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			$rc
+			 
+			=
+			 
+			1
+
+			break
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Can.Trade.At
+
+			*  Check if ship can trade at target
+
+			* ******************************************************************************
+
+			Can.Trade.At
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Station
+			 
+			=
+			 
+			$Arg1
+
+			$Mission
+			 
+			=
+			 
+			$Arg2
+
+			$Ware
+			 
+			=
+			 
+			$Arg3
+
+			$Excludes
+			 
+			=
+			 
+			$Arg4
+
+
+			* While loop used to work around an endsub bug in current X-Studio version
+
+			while
+			 
+			$Station
+			->
+			 
+			exists
+
+
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Stock.Limit.Tradeable
+			 
+			Arg1
+			=
+			$Station
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.At %s: no %s in stock'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			can
+			 
+			buy
+			 
+			ware
+			 
+			$Ware
+			 
+			at
+			 
+			station
+			 
+			$Station
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.At %s: not allowed to buy %s there'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			else
+			 
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Sell
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Stock.Limit.Free
+			 
+			Arg1
+			=
+			$Station
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.At %s: no space for %s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			$Owner
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			owner
+			 
+			race
+
+			if
+			 
+			$Owner
+			 
+			==
+			 
+			[Player]
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.At %s: cannot sell at player stations'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			else
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			0
+			 
+			fmt
+			=
+			'Can.Trade.At %s: Unhandled mission type %s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			$Mission
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			is
+			 
+			docking
+			 
+			allowed
+			 
+			at
+			 
+			$Station
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.At %s: docking not permitted'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			if
+			 
+			not
+			 
+			$Station
+			->
+			 
+			is
+			 
+			docking
+			 
+			possible
+			 
+			of
+			 
+			[THIS]
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.At %s: physically unable to dock there'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			if
+			 
+			[OWNER]
+			 
+			==
+			 
+			[Player]
+
+			$Sector
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			sector
+
+			if
+			 
+			not
+			 
+			$Sector
+			->
+			 
+			is
+			 
+			sector
+			 
+			known
+			 
+			by
+			 
+			the
+			 
+			player
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.At %s: sector not known to player'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			if
+			 
+			not
+			 
+			$Station
+			->
+			 
+			is
+			 
+			known
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.At %s: station not known to player'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			skip
+			 
+			if
+			 
+			$Excludes
+
+			$Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Get.Excludes
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			if
+			 
+			find
+			 
+			$Station
+			 
+			in
+			 
+			array
+			:
+			 
+			$Excludes
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.At %s: station is blacklisted'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			$Sector
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			sector
+
+			if
+			 
+			find
+			 
+			$Sector
+			 
+			in
+			 
+			array
+			:
+			 
+			$Excludes
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Trade.At %s: sector %s is blacklisted'
+			 
+			arg1
+			=
+			$Sector
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+			$rc
+			 
+			=
+			 
+			1
+
+			break
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Amount.On.Order
+
+			*  Estimate the amount of a ware due to be bought by in-progress missions, at
+
+			*  current prices and inventories.
+
+			* ******************************************************************************
+
+			Get.Amount.On.Order
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Ware
+			 
+			=
+			 
+			$Arg1
+
+
+			$Buddies
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			owned
+			 
+			ships
+			:
+			 
+			class
+			/
+			type
+			=
+			[Moveable Ship]
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Buddies
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Buddy
+			 
+			=
+			 
+			$Buddies
+			[
+			$idx
+			]
+
+
+			skip
+			 
+			if
+			 
+			$Buddy
+			->
+			 
+			is
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			on
+			 
+			stack
+			 
+			of
+			 
+			task
+			=
+			0
+
+			continue
+
+
+			$State.Buddy
+			 
+			=
+			 
+			$Buddy
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Fetch
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Buddy.Mission
+			 
+			=
+			 
+			$State.Buddy
+			[
+			$State.Mission
+			]
+
+			$Buddy.Dest
+			 
+			=
+			 
+			$State.Buddy
+			[
+			$State.Dest
+			]
+
+			$Buddy.Ware
+			 
+			=
+			 
+			$State.Buddy
+			[
+			$State.Ware
+			]
+
+
+			* Include amount other homebased ships are due to buy
+
+			if
+			 
+			$Buddy
+			 
+			!=
+			 
+			[THIS]
+			 
+			AND
+			 
+			$Buddy.Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+			 
+			AND
+			 
+			$Ware
+			 
+			==
+			 
+			$Buddy.Ware
+			 
+			AND
+			 
+			$Buddy.Dest
+			 
+			!=
+			 
+			[HOMEBASE]
+
+			$Amount
+			 
+			=
+			 
+			$Buddy
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Amount.To.Buy
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Buddy.Dest
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			1
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			if
+			 
+			$Amount
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Get.Amount.On.Order: + %s units of %s on order by %s from %s'
+			 
+			arg1
+			=
+			$Amount
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			$Buddy
+			 
+			arg4
+			=
+			$Buddy.Dest
+			 
+			arg5
+			=
+			null
+
+			$rc
+			 
+			=
+			 
+			$rc
+			 
+			+
+			 
+			$Amount
+
+			end
+
+			end
+
+			end
+
+
+			* Include amounts in cargobays of all homebased ships
+
+			$Amount
+			 
+			=
+			 
+			$Buddy
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Amount.For.Sale
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			$Amount
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Get.Amount.On.Order: + %s units of %s in cargo of %s'
+			 
+			arg1
+			=
+			$Amount
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			$Buddy
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$rc
+			 
+			=
+			 
+			$rc
+			 
+			+
+			 
+			$Amount
+
+			end
+
+			end
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Get.Amount.On.Order: Total %s units of %s'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Test.Buys.Infinite.Wares
+
+			*  Test whether a station buys infinite amounts of a ware
+
+			* ******************************************************************************
+
+			Test.Buys.Infinite.Wares
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Ship
+			 
+			=
+			 
+			$Arg1
+
+			$Ware
+			 
+			=
+			 
+			$Arg2
+
+			$Station
+			 
+			=
+			 
+			$Arg3
+
+
+			while
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			$Station
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Dock]
+
+			break
+
+			skip
+			 
+			if
+			 
+			$Station
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			break
+
+			$Maintype
+			 
+			=
+			 
+			get
+			 
+			maintype
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$Lasers.Shields.Missiles
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			8
+			,
+			 
+			9
+			,
+			 
+			10
+			,
+			 
+			null
+			,
+			 
+			null
+
+			skip
+			 
+			if
+			 
+			find
+			 
+			$Maintype
+			 
+			in
+			 
+			array
+			:
+			 
+			$Lasers.Shields.Missiles
+
+			break
+
+
+			$Cache
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			local
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok.infinite'
+
+			if
+			 
+			$Cache
+
+			$Infinite.Wares
+			 
+			=
+			 
+			$Cache
+			[
+			1
+			]
+
+			$rc
+			 
+			=
+			 
+			find
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			:
+			 
+			$Infinite.Wares
+
+			do
+			 
+			if
+			 
+			$rc
+
+			break
+
+			$Finite.Wares
+			 
+			=
+			 
+			$Cache
+			[
+			2
+			]
+
+			do
+			 
+			if
+			 
+			find
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			:
+			 
+			$Finite.Wares
+
+			break
+
+			else
+
+			$Ver
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			$Infinite.Wares
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Finite.Wares
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Cache
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Ver
+			,
+			 
+			$Infinite.Wares
+			,
+			 
+			$Finite.Wares
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Station
+			->
+			 
+			set
+			 
+			local
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok.infinite'
+			 
+			value
+			=
+			$Cache
+
+			end
+
+
+			$Race
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			owner
+			 
+			race
+
+			if
+			 
+			$Race
+			 
+			==
+			 
+			[Player]
+
+			append
+			 
+			$Ware
+			 
+			to
+			 
+			array
+			 
+			$Finite.Wares
+
+			break
+
+			end
+
+
+			$Ship.Ware
+			 
+			=
+			 
+			$Ship
+			->
+			 
+			get
+			 
+			ware
+			 
+			type
+			 
+			code
+			 
+			of
+			 
+			object
+
+			$Ship.Proxy
+			 
+			=
+			 
+			create
+			 
+			ship
+			:
+			 
+			type
+			=
+			$Ship.Ware
+			 
+			owner
+			=
+			$Race
+			 
+			addto
+			=
+			$Station
+			 
+			x
+			=
+			0
+			 
+			y
+			=
+			0
+			 
+			z
+			=
+			0
+
+			skip
+			 
+			if
+			 
+			$Ship.Proxy
+			->
+			 
+			exists
+
+			break
+
+
+			if
+			 
+			$Ship.Proxy
+			->
+			 
+			add
+			 
+			1
+			 
+			units
+			 
+			of
+			 
+			$Ware
+
+			$Before
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			$Ship.Proxy
+			->
+			 
+			sell
+			 
+			1
+			 
+			units
+			 
+			of
+			 
+			$Ware
+
+			$After
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			$Before
+			 
+			==
+			 
+			$After
+
+			$rc
+			 
+			=
+			 
+			1
+
+			append
+			 
+			$Ware
+			 
+			to
+			 
+			array
+			 
+			$Infinite.Wares
+
+			else
+
+			=
+			 
+			$Station
+			->
+			 
+			add
+			 
+			-1
+			 
+			units
+			 
+			of
+			 
+			$Ware
+
+			append
+			 
+			$Ware
+			 
+			to
+			 
+			array
+			 
+			$Finite.Wares
+
+			end
+
+			end
+
+			end
+
+			$Ship.Proxy
+			->
+			 
+			destruct
+			:
+			 
+			show
+			 
+			no
+			 
+			explosion
+			=
+			[TRUE]
+
+
+			break
+
+			end
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Test.Buys.Infinite.Wares: Station=%s, Ware=%s, Result=%s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			$rc
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Find.Station
+
+			*  Find a station to trade a ware
+
+			*  Excludes array gets modified
+
+			* ******************************************************************************
+
+			Find.Station
+			:
+
+			$Ware
+			 
+			=
+			 
+			$Arg1
+
+			$Mission
+			 
+			=
+			 
+			$Arg2
+
+			$Excludes
+			 
+			=
+			 
+			$Arg3
+
+			$Origin
+			 
+			=
+			 
+			$Arg4
+
+			$Find.Flags
+			 
+			=
+			 
+			$Arg5
+
+			$Price.Limit
+			 
+			=
+			 
+			$Arg6
+
+
+			skip
+			 
+			if
+			 
+			$Find.Flags
+
+			$Find.Flags
+			 
+			=
+			 
+			0
+
+
+			$Equipping
+			 
+			=
+			 
+			(
+			$Find.Flags
+			 
+			&
+			 
+			$Find.Equipping
+			)
+
+			$Eco
+			 
+			=
+			 
+			(
+			$Find.Flags
+			 
+			&
+			 
+			$Find.Eco
+			)
+
+
+			$Fleeing
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Fleeing.Sector
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Fleeing
+
+			append
+			 
+			$Fleeing
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+
+			gosub
+			 
+			Find.Station.Internal
+			:
+
+
+			if
+			 
+			$rc
+			 
+			==
+			 
+			null
+			 
+			OR
+			 
+			$Equipping
+			 
+			OR
+			 
+			(
+			$Mission
+			 
+			!=
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+			 
+			AND
+			 
+			$Mission
+			 
+			!=
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Sell
+			)
+
+			endsub
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			$rc
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Dock]
+
+			endsub
+
+
+			$Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Clone.Array
+			 
+			Arg1
+			=
+			$Excludes
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Best.Station
+			 
+			=
+			 
+			$rc
+
+			$Best.Amount
+			 
+			=
+			 
+			$rc
+			->
+			 
+			get
+			 
+			true
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$Best.Free
+			 
+			=
+			 
+			$rc
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$Start.Price
+			 
+			=
+			 
+			$rc
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$Capacity
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			max
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			that
+			 
+			can
+			 
+			be
+			 
+			stored
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			skip
+			 
+			if
+			 
+			$Start.Price
+
+			endsub
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Find.Station: %s is a dock, evaluating stock levels of alternate docks'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			while
+			 
+			$rc
+
+
+			$Price
+			 
+			=
+			 
+			$rc
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			if
+			 
+			$Price
+			 
+			!=
+			 
+			$Start.Price
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Find.Station: No more alternatives at this price'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			$Stock.Percent
+			 
+			=
+			 
+			$rc
+			->
+			 
+			get
+			 
+			ware
+			 
+			storage
+			 
+			percentage
+			:
+			 
+			ware
+			=
+			$Ware
+
+
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Sell
+
+
+			* If it has 80% free space then search no further
+
+			if
+			 
+			$Stock.Percent
+			 
+			<=
+			 
+			20
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Find.Station: Going with %s as it has low stock at %s percent, sufficient for sale mission'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			$Stock.Percent
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$Best.Station
+			 
+			=
+			 
+			$rc
+
+			break
+
+			end
+
+
+			$Amount
+			 
+			=
+			 
+			$rc
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			$Amount
+			 
+			>
+			 
+			$Best.Free
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Find.Station: %s has more capacity for ware than %s on sale mission. Free amount old=%s, new=%s'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			$Best.Station
+			 
+			arg3
+			=
+			$Best.Free
+			 
+			arg4
+			=
+			$Amount
+			 
+			arg5
+			=
+			null
+
+			$Best.Station
+			 
+			=
+			 
+			$rc
+
+			$Best.Free
+			 
+			=
+			 
+			$Amount
+
+			end
+
+
+			else
+
+
+			* If it has 80% stock then search no further
+
+			if
+			 
+			$Stock.Percent
+			 
+			>=
+			 
+			80
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Find.Station: Going with %s as it has high stock at %s percent, sufficient for buy mission'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			$Stock.Percent
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$Best.Station
+			 
+			=
+			 
+			$rc
+
+			break
+
+			end
+
+
+			$Amount
+			 
+			=
+			 
+			$rc
+			->
+			 
+			get
+			 
+			true
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			$Amount
+			 
+			>
+			 
+			$Best.Amount
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Find.Station: %s has more in stock than %s for buy mission. Amount old=%s, new=%s'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			$Best.Station
+			 
+			arg3
+			=
+			$Best.Amount
+			 
+			arg4
+			=
+			$Amount
+			 
+			arg5
+			=
+			null
+
+			$Best.Station
+			 
+			=
+			 
+			$rc
+
+			$Best.Amount
+			 
+			=
+			 
+			$Amount
+
+			end
+
+			end
+
+
+			append
+			 
+			$rc
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+			gosub
+			 
+			Find.Station.Internal
+			:
+
+
+			end
+
+
+			$rc
+			 
+			=
+			 
+			$Best.Station
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Find.Station: final rc=%s'
+			 
+			arg1
+			=
+			$Best.Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Find.Station.Internal
+
+			*  Find a station to trade a ware
+
+			*  Excludes array gets modified
+
+			* ******************************************************************************
+
+			Find.Station.Internal
+			:
+
+			$rc
+			 
+			=
+			 
+			null
+
+			$Find.Mode
+			 
+			=
+			 
+			$Find.Mode.Best.Chance
+
+			$Eco
+			 
+			=
+			 
+			(
+			$Find.Flags
+			 
+			&
+			 
+			$Find.Eco
+			)
+
+
+			skip
+			 
+			if
+			 
+			$Origin
+
+			$Origin
+			 
+			=
+			 
+			[SECTOR]
+
+
+			$Max.Jumps
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Max.Jumps
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			$Origin
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+
+			$Ignore.Competition
+			 
+			=
+			 
+			$Equipping
+			 
+			OR
+			 
+			(
+			$Find.Flags
+			 
+			&
+			 
+			$Find.Ignore.Competition
+			)
+
+
+			$Refuelling
+			 
+			=
+			 
+			0
+
+			if
+			 
+			$Equipping
+
+			$Find.Mode
+			 
+			=
+			 
+			$Find.Mode.Nearest
+
+
+			skip
+			 
+			if
+			 
+			$Ware
+			 
+			!=
+			 
+			{Energy Cells}
+
+			$Refuelling
+			 
+			=
+			 
+			1
+
+
+			$Price
+			 
+			=
+			 
+			get
+			 
+			average
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			skip
+			 
+			if
+			 
+			$Mission
+			 
+			!=
+			 
+			$Mission.Type.Buy
+
+			$Price
+			 
+			=
+			 
+			get
+			 
+			max
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+
+			else
+			 
+			if
+			 
+			[HOMEBASE]
+
+			$Price
+			 
+			=
+			 
+			get
+			 
+			average
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			do
+			 
+			if
+			 
+			[HOMEBASE]
+			->
+			 
+			trades
+			 
+			with
+			 
+			ware
+			 
+			$Ware
+
+			$Price
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+
+			if
+			 
+			(
+			$Find.Flags
+			 
+			&
+			 
+			$Find.Force.Best.Price
+			)
+
+			$Find.Mode
+			 
+			=
+			 
+			$Find.Mode.Best.Price
+
+			else
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Jumpdrive}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$Find.Mode
+			 
+			=
+			 
+			$Find.Mode.Best.Price
+
+			else
+
+			$Find.Mode
+			 
+			=
+			 
+			$Find.Mode.Best.Chance
+
+			end
+
+
+			else
+
+			$Price
+			 
+			=
+			 
+			get
+			 
+			average
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			skip
+			 
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$Price.Limit
+			]
+			 
+			==
+			 
+			[DATATYPE_NULL]
+
+			$Price
+			 
+			=
+			 
+			$Price.Limit
+
+
+			* Free traders with jumpdrives should seek out the best possible price.
+
+			if
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Jumpdrive}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$Find.Mode
+			 
+			=
+			 
+			$Find.Mode.Best.Price
+
+			else
+			 
+			if
+			 
+			(
+			$Find.Flags
+			 
+			&
+			 
+			$Find.Force.Best.Price
+			)
+
+			$Find.Mode
+			 
+			=
+			 
+			$Find.Mode.Best.Price
+
+			else
+
+			$Find.Mode
+			 
+			=
+			 
+			$Find.Mode.Best.Chance
+
+			end
+
+			end
+
+
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			$Type
+			 
+			=
+			 
+			datatype
+			[
+			$Price.Limit
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Find.Station: Ware=%s, Mission=%s, Origin=%s, Max.Jumps=%s, Find.Mode=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Mission
+			 
+			arg3
+			=
+			$Origin
+			 
+			arg4
+			=
+			$Max.Jumps
+			 
+			arg5
+			=
+			$Find.Mode
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'              Flags=%s, Limit=%s, Excludes=%s, Price=%s, Type=%s'
+			 
+			arg1
+			=
+			$Find.Flags
+			 
+			arg2
+			=
+			$Price.Limit
+			 
+			arg3
+			=
+			$Excludes
+			 
+			arg4
+			=
+			$Price
+			 
+			arg5
+			=
+			$Type
+
+			end
+
+
+			$Tries
+			 
+			=
+			 
+			150
+
+
+			$Station
+			 
+			=
+			 
+			null
+
+
+			while
+			 
+			$Tries
+
+			dec
+			 
+			$Tries
+
+
+			gosub
+			 
+			Find.Next.Station
+			:
+
+			skip
+			 
+			if
+			 
+			$Station
+			->
+			 
+			exists
+
+			break
+
+
+			if
+			 
+			(
+			$Eco
+			 
+			AND
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Sell
+			)
+
+			* Only report stations with stalled production
+
+			* Docks are not producers
+
+			if
+			 
+			$Station
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Dock]
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Find.Station: ECO: %s is a dock, so without production'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			append
+			 
+			$Station
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+			continue
+
+			else
+			 
+			if
+			 
+			$Station
+			->
+			 
+			get
+			 
+			production
+			 
+			status
+			:
+			 
+			as
+			 
+			percentage
+			=
+			0
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Find.Station: ECO: %s has positive production status'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			append
+			 
+			$Station
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+			continue
+
+			else
+			 
+			if
+			 
+			$Station
+			->
+			 
+			uses
+			 
+			ware
+			 
+			$Ware
+			 
+			as
+			 
+			secondary
+			 
+			resource
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Find.Station: ECO: %s uses %s only as a secondary resource'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			append
+			 
+			$Station
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+			continue
+
+			end
+
+			end
+
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Can.Trade.At
+			 
+			Arg1
+			=
+			$Station
+			 
+			Arg2
+			=
+			$Mission
+			 
+			Arg3
+			=
+			$Ware
+			 
+			Arg4
+			=
+			$Excludes
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			append
+			 
+			$Station
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+			continue
+
+			end
+
+
+			* If its a dock or station requiring resources then make sure it has some ecells.
+
+			if
+			 
+			$Refuelling
+
+			$Check.Stock
+			 
+			=
+			 
+			$Station
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Dock]
+
+			skip
+			 
+			if
+			 
+			$Check.Stock
+
+			$Check.Stock
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			number
+			 
+			of
+			 
+			primary
+			 
+			resources
+
+
+			if
+			 
+			$Check.Stock
+
+			$Fuel.Required
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Topup.Jump.Energy
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Fuel.Have
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Energy Cells}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			$Fuel.Have
+			 
+			<
+			 
+			$Fuel.Required
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Find.Station: %s has insufficient fuel for refuel. Have=%s, Required=%s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			$Fuel.Have
+			 
+			arg3
+			=
+			$Fuel.Required
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			append
+			 
+			$Station
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+			continue
+
+			else
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Find.Station: %s has sufficient fuel for refuel. Have=%s, Required=%s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			$Fuel.Have
+			 
+			arg3
+			=
+			$Fuel.Required
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			else
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Find.Station: %s does not require stock check for refuel'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			end
+
+
+			$Competition
+			 
+			=
+			 
+			0
+
+			skip
+			 
+			if
+			 
+			$Ignore.Competition
+
+			$Competition
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Check.Competition
+			 
+			Arg1
+			=
+			$Mission
+			 
+			Arg2
+			=
+			$Station
+			 
+			Arg3
+			=
+			$Ware
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			if
+			 
+			not
+			 
+			$Competition
+
+			$rc
+			 
+			=
+			 
+			$Station
+
+			break
+
+			end
+
+
+			append
+			 
+			$Station
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+			end
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Find.Station: exit rc=%s, tries.remain=%s'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			$Tries
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Find.Next.Station:
+
+			*  Find a factory or dock to trade the ware at, factoring in an exclusion array
+
+			*  of stations already checked.
+
+			* ******************************************************************************
+
+			Find.Next.Station
+			:
+
+			$Station
+			 
+			=
+			 
+			null
+
+
+			* Docks and stations are unfortunately searched using different APIs when buying so we need to search both and determine the best choice for next station ourselves
+
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+			if
+			 
+			$Find.Mode
+			 
+			==
+			 
+			$Find.Mode.Best.Price
+
+			$Factory
+			 
+			=
+			 
+			find
+			 
+			factory
+			:
+			 
+			sells
+			 
+			$Ware
+			 
+			with
+			 
+			best
+			 
+			price
+			:
+			 
+			max.price
+			=
+			$Price
+			,
+			 
+			amount
+			=
+			null
+			,
+			 
+			max.jumps
+			=
+			$Max.Jumps
+			,
+			 
+			startsector
+			=
+			$Origin
+			,
+			 
+			trader
+			=
+			[THIS]
+			,
+			 
+			exclude
+			 
+			array
+			=
+			$Excludes
+
+			$Dock
+			 
+			=
+			 
+			find
+			 
+			dock
+			:
+			 
+			sells
+			:
+			 
+			$Ware
+			 
+			with
+			 
+			best
+			 
+			price
+			:
+			 
+			max.price
+			=
+			$Price
+			,
+			 
+			amount
+			=
+			null
+			,
+			 
+			max.jumps
+			=
+			$Max.Jumps
+			,
+			 
+			startsector
+			=
+			$Origin
+			,
+			 
+			trader
+			=
+			[THIS]
+			,
+			 
+			exclude
+			 
+			array
+			=
+			$Excludes
+
+			else
+			 
+			if
+			 
+			$Find.Mode
+			 
+			==
+			 
+			$Find.Mode.Best.Chance
+
+			$Factory
+			 
+			=
+			 
+			find
+			 
+			factory
+			:
+			 
+			sells
+			 
+			$Ware
+			 
+			with
+			 
+			best
+			 
+			chance
+			:
+			 
+			max.price
+			=
+			$Price
+			,
+			 
+			amount
+			=
+			null
+			,
+			 
+			max.jumps
+			=
+			$Max.Jumps
+			,
+			 
+			startsector
+			=
+			$Origin
+			,
+			 
+			trader
+			=
+			[THIS]
+			,
+			 
+			exclude
+			 
+			array
+			=
+			$Excludes
+
+			$Dock
+			 
+			=
+			 
+			find
+			 
+			dock
+			:
+			 
+			sells
+			 
+			$Ware
+			 
+			with
+			 
+			best
+			 
+			chance
+			:
+			 
+			max.price
+			=
+			$Price
+			,
+			 
+			amount
+			=
+			null
+			,
+			 
+			max.jumps
+			=
+			$Max.Jumps
+			,
+			 
+			startsector
+			=
+			$Origin
+			,
+			 
+			trader
+			=
+			[THIS]
+			,
+			 
+			exclude
+			 
+			array
+			=
+			$Excludes
+
+			else
+
+			$Factory
+			 
+			=
+			 
+			find
+			 
+			factory
+			:
+			 
+			sells
+			 
+			$Ware
+			 
+			with
+			 
+			min
+			 
+			jumps
+			:
+			 
+			max.price
+			=
+			$Price
+			,
+			 
+			amount
+			=
+			null
+			,
+			 
+			max.jumps
+			=
+			$Max.Jumps
+			,
+			 
+			startsector
+			=
+			$Origin
+			,
+			 
+			trader
+			=
+			[THIS]
+			,
+			 
+			exclude
+			 
+			array
+			=
+			$Excludes
+
+			$Dock
+			 
+			=
+			 
+			find
+			 
+			dock
+			:
+			 
+			sells
+			 
+			$Ware
+			 
+			with
+			 
+			min.
+			 
+			jumps
+			:
+			 
+			max.price
+			=
+			$Price
+			,
+			 
+			amount
+			=
+			null
+			,
+			 
+			max.jumps
+			=
+			$Max.Jumps
+			,
+			 
+			startsector
+			=
+			$Origin
+			,
+			 
+			trader
+			=
+			[THIS]
+			,
+			 
+			exclude
+			 
+			array
+			=
+			$Excludes
+
+			end
+
+
+			if
+			 
+			not
+			 
+			$Factory
+
+			$Station
+			 
+			=
+			 
+			$Dock
+
+			else
+			 
+			if
+			 
+			not
+			 
+			$Dock
+
+			$Station
+			 
+			=
+			 
+			$Factory
+
+			else
+
+			$Factory.Price
+			 
+			=
+			 
+			$Factory
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$Factory.Sector
+			 
+			=
+			 
+			$Factory
+			->
+			 
+			get
+			 
+			sector
+
+			$Factory.Range
+			 
+			=
+			 
+			get
+			 
+			jumps
+			 
+			from
+			 
+			sector
+			 
+			[SECTOR]
+			 
+			to
+			 
+			sector
+			 
+			$Factory.Sector
+
+			$Dock.Price
+			 
+			=
+			 
+			$Dock
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$Dock.Sector
+			 
+			=
+			 
+			$Dock
+			->
+			 
+			get
+			 
+			sector
+
+			$Dock.Range
+			 
+			=
+			 
+			get
+			 
+			jumps
+			 
+			from
+			 
+			sector
+			 
+			[SECTOR]
+			 
+			to
+			 
+			sector
+			 
+			$Dock.Sector
+
+
+			if
+			 
+			(
+			$Dock.Price
+			 
+			<
+			 
+			$Factory.Price
+			)
+			 
+			OR
+			 
+			(
+			(
+			$Dock.Price
+			 
+			==
+			 
+			$Factory.Price
+			)
+			 
+			AND
+			 
+			(
+			$Dock.Range
+			 
+			<
+			 
+			$Factory.Range
+			)
+			)
+
+			$Station
+			 
+			=
+			 
+			$Dock
+
+			else
+
+			$Station
+			 
+			=
+			 
+			$Factory
+
+			end
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Find.Next.Station: Factory.Price=%s, Factory.Range=%s, Dock.Price=%s, Dock.Range=%s, rc=%s'
+			 
+			arg1
+			=
+			$Factory.Price
+			 
+			arg2
+			=
+			$Factory.Range
+			 
+			arg3
+			=
+			$Dock.Price
+			 
+			arg4
+			=
+			$Dock.Range
+			 
+			arg5
+			=
+			$Station
+
+			endsub
+
+			end
+
+			else
+			 
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Sell
+
+			if
+			 
+			$Find.Mode
+			 
+			==
+			 
+			$Find.Mode.Best.Price
+
+			$Station
+			 
+			=
+			 
+			find
+			 
+			factory
+			:
+			 
+			buys
+			 
+			$Ware
+			 
+			with
+			 
+			best
+			 
+			price
+			:
+			 
+			min.price
+			=
+			$Price
+			,
+			 
+			amount
+			=
+			null
+			,
+			 
+			max.jumps
+			=
+			$Max.Jumps
+			,
+			 
+			startsector
+			=
+			$Origin
+			,
+			 
+			trader
+			=
+			[THIS]
+			,
+			 
+			exclude
+			 
+			array
+			=
+			$Excludes
+
+			else
+			 
+			if
+			 
+			$Find.Mode
+			 
+			==
+			 
+			$Find.Mode.Best.Chance
+
+			$Station
+			 
+			=
+			 
+			find
+			 
+			factory
+			:
+			 
+			buys
+			 
+			$Ware
+			 
+			with
+			 
+			best
+			 
+			chance
+			:
+			 
+			min.price
+			=
+			$Price
+			,
+			 
+			amount
+			=
+			null
+			,
+			 
+			max.jumps
+			=
+			$Max.Jumps
+			,
+			 
+			startsector
+			=
+			$Origin
+			,
+			 
+			trader
+			=
+			[THIS]
+			,
+			 
+			exclude
+			 
+			array
+			=
+			$Excludes
+
+			else
+
+			$Station
+			 
+			=
+			 
+			find
+			 
+			factory
+			:
+			 
+			buys
+			 
+			$Ware
+			 
+			with
+			 
+			min
+			 
+			jumps
+			:
+			 
+			min.price
+			=
+			$Price
+			,
+			 
+			amount
+			=
+			null
+			,
+			 
+			max.jumps
+			=
+			$Max.Jumps
+			,
+			 
+			startsector
+			=
+			$Origin
+			,
+			 
+			trader
+			=
+			[THIS]
+			,
+			 
+			exclude
+			 
+			array
+			=
+			$Excludes
+
+			end
+
+			else
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			0
+			 
+			fmt
+			=
+			'Find.Next.Station: Unexpected Mission=%s'
+			 
+			arg1
+			=
+			$Mission
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			return
+			 
+			null
+
+			end
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Find.Next.Station: rc=%s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Tradeable.Wares
+
+			*  Get a priority ordered array of ware entries that can be traded
+
+			* ******************************************************************************
+
+			$Priority
+			 
+			=
+			 
+			0
+
+			Get.Tradeable.Wares
+			:
+
+			$Unsorted
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Priorities
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Ware.Entries
+			 
+			=
+			 
+			$Arg1
+
+			$Ware.Entry.Ware
+			 
+			=
+			 
+			0
+
+			$Ware.Entry.Mode
+			 
+			=
+			 
+			1
+
+			$Mission.Type.Buy
+			 
+			=
+			 
+			1
+
+			$Mission.Type.Sell
+			 
+			=
+			 
+			2
+
+			$Trade.Threshold
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Trade.Threshold
+			]
+
+			$Homebase.Is.Dock
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Dock]
+
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Ware.Entries
+
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ware.Entry
+			 
+			=
+			 
+			$Ware.Entries
+			[
+			$idx
+			]
+
+			$Ware
+			 
+			=
+			 
+			$Ware.Entry
+			[
+			$Ware.Entry.Ware
+			]
+
+			$Mode
+			 
+			=
+			 
+			$Ware.Entry
+			[
+			$Ware.Entry.Mode
+			]
+
+			if
+			 
+			$Mode
+			 
+			==
+			 
+			$Mission.Type.Buy
+			 
+			OR
+			 
+			$Mode
+			 
+			==
+			 
+			$Mission.Type.Sell
+
+			gosub
+			 
+			Get.Ware.Priority
+			:
+
+			if
+			 
+			(
+			$Priority
+			 
+			>
+			 
+			$Trade.Threshold
+			)
+			 
+			OR
+			 
+			(
+			$Homebase.Is.Dock
+			 
+			AND
+			 
+			$Mode
+			 
+			==
+			 
+			$Mission.Type.Sell
+			)
+
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Can.Trade.Ware
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Mode
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			append
+			 
+			$Ware.Entry
+			 
+			to
+			 
+			array
+			 
+			$Unsorted
+
+			append
+			 
+			$Priority
+			 
+			to
+			 
+			array
+			 
+			$Priorities
+
+			end
+
+			end
+
+			end
+
+			end
+
+
+			$rc
+			 
+			=
+			 
+			sort
+			 
+			array
+			:
+			 
+			data
+			=
+			$Unsorted
+			 
+			sort
+			 
+			values
+			=
+			$Priorities
+
+
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			$Priorities
+			 
+			=
+			 
+			sort
+			 
+			array
+			 
+			$Priorities
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$rc
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ware.Entry
+			 
+			=
+			 
+			$rc
+			[
+			$idx
+			]
+
+			$Ware
+			 
+			=
+			 
+			$Ware.Entry
+			[
+			$Ware.Entry.Ware
+			]
+
+			$Mode
+			 
+			=
+			 
+			$Ware.Entry
+			[
+			$Ware.Entry.Mode
+			]
+
+			$Priority
+			 
+			=
+			 
+			$Priorities
+			[
+			$idx
+			]
+
+			if
+			 
+			$Mode
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Get.Tradeable.Wares: Ware=%s, Priority=%s (Buy)'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Priority
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			else
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Get.Tradeable.Wares: Ware=%s, Priority=%s (Sell)'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Priority
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Ware.Priority
+
+			*  Obtain relative priority for a given ware. This is derived simply from
+
+			*  percentage stock level.
+
+			* ******************************************************************************
+
+			Get.Ware.Priority
+			:
+
+			$Priority
+			 
+			=
+			 
+			0
+
+
+			* Configured min (don't sell below this threshold) and max (don't buy above this threshold) limits
+
+			$Limit.Min
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Stock.Limit.Min
+			 
+			Arg1
+			=
+			[HOMEBASE]
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Limit.Max
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Stock.Limit.Max
+			 
+			Arg1
+			=
+			[HOMEBASE]
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+
+			if
+			 
+			not
+			 
+			$Limit.Max
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Get.Ware.Priority(%s): Limit.Max is zero'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+			end
+
+
+			* Current amount in station
+
+			$Amount.Current
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+
+			if
+			 
+			$Mode
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Can.Afford.Trade
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Get.Ware.Priority(Buy %s): Cannot afford'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+			end
+
+
+			$Amount.On.Order
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Amount.On.Order
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+
+			if
+			 
+			(
+			$Amount.Current
+			 
+			+
+			 
+			$Amount.On.Order
+			)
+			 
+			>=
+			 
+			$Limit.Max
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Get.Ware.Priority(Buy %s): Full stock. Stock=%s, OnOrder=%s, Limit.Max=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Amount.Current
+			 
+			arg3
+			=
+			$Amount.On.Order
+			 
+			arg4
+			=
+			$Limit.Max
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+			end
+
+
+			$Priority
+			 
+			=
+			 
+			100
+			 
+			-
+			 
+			(
+			(
+			(
+			$Amount.Current
+			 
+			+
+			 
+			$Amount.On.Order
+			)
+			 
+			*
+			 
+			100
+			)
+			 
+			/
+			 
+			$Limit.Max
+			)
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Get.Ware.Priority(Buy): Ware=%s, Stock=%s, OnOrder=%s, Limit.Max=%s, Priority=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Amount.Current
+			 
+			arg3
+			=
+			$Amount.On.Order
+			 
+			arg4
+			=
+			$Limit.Max
+			 
+			arg5
+			=
+			$Priority
+
+			else
+
+			if
+			 
+			$Amount.Current
+			 
+			<=
+			 
+			$Limit.Min
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Get.Ware.Priority(Sell %s): None for sale. Stock=%s, Limit.Min=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Amount.Current
+			 
+			arg3
+			=
+			$Limit.Min
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+			end
+
+
+			$Max.Actual
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			max
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			that
+			 
+			can
+			 
+			be
+			 
+			stored
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+
+			$Priority
+			 
+			=
+			 
+			(
+			(
+			$Amount.Current
+			 
+			-
+			 
+			$Limit.Min
+			)
+			 
+			*
+			 
+			100
+			)
+			 
+			/
+			 
+			(
+			$Max.Actual
+			 
+			-
+			 
+			$Limit.Min
+			)
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Get.Ware.Priority(Sell %s): Stock=%s, Limit.Min=%s, Max.Actual=%s, Priority=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Amount.Current
+			 
+			arg3
+			=
+			$Limit.Min
+			 
+			arg4
+			=
+			$Max.Actual
+			 
+			arg5
+			=
+			$Priority
+
+			end
+
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Can.Afford.Trade
+
+			*  Whether homebase can afford to trade a ware
+
+			* ******************************************************************************
+
+			Can.Afford.Trade
+			:
+
+			$Ware
+			 
+			=
+			 
+			$Arg1
+
+			$Price
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$Funds
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			money
+
+			$rc
+			 
+			=
+			 
+			(
+			$Funds
+			 
+			>=
+			 
+			$Price
+			)
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Can.Afford.Trade: Ware=%s, Price=%s, Funds=%s, rc=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Price
+			 
+			arg3
+			=
+			$Funds
+			 
+			arg4
+			=
+			$rc
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Max.Jumps
+
+			*  For homebased traders return homebase max jumps. For free traders, estimate
+
+			*  the amount of jumps between most distant points in the gate network.
+
+			* ******************************************************************************
+
+			Get.Max.Jumps
+			:
+
+			$Ignore.Offset
+			 
+			=
+			 
+			$Arg1
+
+			$Origin
+			 
+			=
+			 
+			$Arg2
+
+			skip
+			 
+			if
+			 
+			$Origin
+
+			$Origin
+			 
+			=
+			 
+			[SECTOR]
+
+			if
+			 
+			[HOMEBASE]
+
+			$rc
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			max
+			 
+			trade
+			 
+			jumps
+
+			else
+
+			$State
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Fetch
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Tether.Sector
+			 
+			=
+			 
+			$State
+			[
+			$State.Tether.Sector
+			]
+
+			if
+			 
+			$Tether.Sector
+
+			$rc
+			 
+			=
+			 
+			$State
+			[
+			$State.Tether.Range
+			]
+
+			$Offset
+			 
+			=
+			 
+			0
+
+			skip
+			 
+			if
+			 
+			$Ignore.Offset
+
+			$Offset
+			 
+			=
+			 
+			get
+			 
+			jumps
+			 
+			from
+			 
+			sector
+			 
+			$Origin
+			 
+			to
+			 
+			sector
+			 
+			$Tether.Sector
+
+			$rc
+			 
+			=
+			 
+			$rc
+			 
+			+
+			 
+			$Offset
+
+			else
+
+			$x
+			 
+			=
+			 
+			get
+			 
+			max
+			 
+			sectors
+			 
+			in
+			 
+			x
+			 
+			direction
+
+			$y
+			 
+			=
+			 
+			get
+			 
+			max
+			 
+			sectors
+			 
+			in
+			 
+			y
+			 
+			direction
+
+			$rc
+			 
+			=
+			 
+			$x
+			 
+			+
+			 
+			$y
+
+			end
+
+			end
+
+
+			* === CLAMP BLOCK: apply optional global cap ===
+
+			$Global.MaxJumps
+			 
+			=
+			 
+			get
+			 
+			global
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok.max.jumps'
+
+			if
+			 
+			$Global.MaxJumps
+			 
+			AND
+			 
+			$Global.MaxJumps
+			 
+			>
+			 
+			0
+
+			  
+			if
+			 
+			(
+			 
+			$rc
+			 
+			==
+			 
+			null
+			 
+			)
+			 
+			OR
+			 
+			(
+			 
+			$rc
+			 
+			>
+			 
+			$Global.MaxJumps
+			 
+			)
+
+			    
+			$rc
+			 
+			=
+			 
+			$Global.MaxJumps
+
+			  
+			end
+
+			end
+
+			* === end clamp ===
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Get.Max.Jumps: origin=%s, rc=%s'
+			 
+			arg1
+			=
+			$Origin
+			 
+			arg2
+			=
+			$rc
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Profit
+
+			*  Get the potential profit from trading a given ware between two stations
+
+			* ******************************************************************************
+
+			Get.Profit
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Ware
+			 
+			=
+			 
+			$Arg1
+
+			$Buying.At
+			 
+			=
+			 
+			$Arg2
+
+			$Selling.At
+			 
+			=
+			 
+			$Arg3
+
+
+			while
+			 
+			1
+
+
+			* Assume there is no sellable amount of this ware on board because free traders sell before buying
+
+
+			$p1
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$p2
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Stock.Limit.Tradeable
+			 
+			Arg1
+			=
+			$Buying.At
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$p3
+			 
+			=
+			 
+			0
+
+			skip
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Test.Buys.Infinite.Wares
+			 
+			Arg1
+			=
+			[THIS]
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			$Selling.At
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$p3
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Stock.Limit.Free
+			 
+			Arg1
+			=
+			$Selling.At
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+
+			$Tradeable.Amount
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Get.Minimum
+			 
+			Arg1
+			=
+			$p1
+			 
+			Arg2
+			=
+			$p2
+			 
+			Arg3
+			=
+			$p3
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			$Tradeable.Amount
+			 
+			>
+			 
+			0
+
+			break
+
+
+			$Buying.At.Price
+			 
+			=
+			 
+			$Buying.At
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$Selling.At.Price
+			 
+			=
+			 
+			$Selling.At
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$rc
+			 
+			=
+			 
+			$Tradeable.Amount
+			 
+			*
+			 
+			(
+			$Selling.At.Price
+			 
+			-
+			 
+			$Buying.At.Price
+			)
+
+			break
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			$rc
+			 
+			>
+			 
+			0
+
+			$rc
+			 
+			=
+			 
+			0
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Get.Profit: Ware=%s, Buying.At=%s, Selling.At=%s, rc=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Buying.At
+			 
+			arg3
+			=
+			$Selling.At
+			 
+			arg4
+			=
+			$rc
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Best.Ware.To.Buy
+
+			*  Get the most profitable ware a free trader could buy
+
+			* ******************************************************************************
+
+			Get.Best.Ware.To.Buy
+			:
+
+			$Ver.Start
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			$Find.Flags
+			 
+			=
+			 
+			$Arg1
+
+			$All.Wares
+			 
+			=
+			 
+			$Config
+			[
+			$Config.All.Wares
+			]
+
+			$Default.Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Get.Excludes
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Wares
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Profits
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Stations.Buy.At
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Stations.Sell.At
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+
+			$Fleeing
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Fleeing.Sector
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+
+			$Eco
+			 
+			=
+			 
+			(
+			$Find.Flags
+			 
+			&
+			 
+			$Find.Eco
+			)
+
+
+			$Max.Results
+			 
+			=
+			 
+			999
+
+			if
+			 
+			$Eco
+
+			$Eco.Exclude.Maintypes
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			8
+			,
+			 
+			9
+			,
+			 
+			10
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Max.Results
+			 
+			=
+			 
+			3
+
+			end
+
+
+			$Wait.Count
+			 
+			=
+			 
+			0
+
+			$idx.Ware
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$All.Wares
+
+			while
+			 
+			$idx.Ware
+
+			dec
+			 
+			$idx.Ware
+
+			$Ware
+			 
+			=
+			 
+			$All.Wares
+			[
+			$idx.Ware
+			]
+
+
+			if
+			 
+			$Eco
+
+			$Maintype
+			 
+			=
+			 
+			get
+			 
+			maintype
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			do
+			 
+			if
+			 
+			find
+			 
+			$Maintype
+			 
+			in
+			 
+			array
+			:
+			 
+			$Eco.Exclude.Maintypes
+
+			continue
+
+			end
+
+
+			inc
+			 
+			$Wait.Count
+
+			if
+			 
+			$Wait.Count
+			 
+			>
+			 
+			2
+
+			=
+			 
+			wait
+			 
+			randomly
+			 
+			from
+			 
+			50
+			 
+			to
+			 
+			100
+			 
+			ms
+
+			$Ver.Now
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			skip
+			 
+			if
+			 
+			$Ver.Now
+			 
+			==
+			 
+			$Ver.Start
+
+			return
+			 
+			null
+
+			$Wait.Count
+			 
+			=
+			 
+			0
+
+			end
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Get.Best.Ware.To.Buy: Evaluating ware %s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			while
+			 
+			1
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Can.Trade.Ware
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Mission.Type.Buy
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Get.Best.Ware.To.Buy: Cannot trade in ware %s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			$Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Clone.Array
+			 
+			Arg1
+			=
+			$Default.Excludes
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Fleeing
+
+			append
+			 
+			$Fleeing
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+			$Station.Buy.At
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Find.Station
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Mission.Type.Buy
+			 
+			Arg3
+			=
+			$Excludes
+			 
+			Arg4
+			=
+			[SECTOR]
+			 
+			Arg5
+			=
+			0
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			not
+			 
+			$Station.Buy.At
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Get.Best.Ware.To.Buy: Nowhere to buy ware %s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			$Price.Buy
+			 
+			=
+			 
+			$Station.Buy.At
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$Funds
+			 
+			=
+			 
+			get
+			 
+			player
+			 
+			money
+
+			if
+			 
+			$Funds
+			 
+			<
+			 
+			$Price.Buy
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Get.Best.Ware.To.Buy: Cannot afford ware %s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			$Station.Buy.At.Sector
+			 
+			=
+			 
+			$Station.Buy.At
+			->
+			 
+			get
+			 
+			sector
+
+			$Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Clone.Array
+			 
+			Arg1
+			=
+			$Default.Excludes
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Fleeing
+
+			append
+			 
+			$Fleeing
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+			append
+			 
+			$Station.Buy.At
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+			$Price.Sell
+			 
+			=
+			 
+			$Price.Buy
+			 
+			+
+			 
+			1
+
+			$Station.Sell.At
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Find.Station
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Mission.Type.Sell
+			 
+			Arg3
+			=
+			$Excludes
+			 
+			Arg4
+			=
+			$Station.Buy.At.Sector
+			 
+			Arg5
+			=
+			$Find.Flags
+			 
+			Arg6
+			=
+			$Price.Sell
+
+			if
+			 
+			not
+			 
+			$Station.Sell.At
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Get.Best.Ware.To.Buy: Nowhere to sell ware %s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			$Price.Sell
+			 
+			=
+			 
+			$Station.Sell.At
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			if
+			 
+			$Price.Sell
+			 
+			<=
+			 
+			$Price.Buy
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Get.Best.Ware.To.Buy: No profit on ware %s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			$Profit
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Profit
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Station.Buy.At
+			 
+			Arg3
+			=
+			$Station.Sell.At
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			append
+			 
+			$Ware
+			 
+			to
+			 
+			array
+			 
+			$Wares
+
+			append
+			 
+			$Profit
+			 
+			to
+			 
+			array
+			 
+			$Profits
+
+			append
+			 
+			$Station.Buy.At
+			 
+			to
+			 
+			array
+			 
+			$Stations.Buy.At
+
+			append
+			 
+			$Station.Sell.At
+			 
+			to
+			 
+			array
+			 
+			$Stations.Sell.At
+
+			if
+			 
+			$Eco
+
+			$Wares.Count
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares
+
+			if
+			 
+			$Wares.Count
+			 
+			>=
+			 
+			$Max.Results
+
+			$idx.Ware
+			 
+			=
+			 
+			0
+
+			end
+
+			end
+
+			break
+
+			end
+
+
+			end
+
+
+			$Wares
+			 
+			=
+			 
+			sort
+			 
+			array
+			:
+			 
+			data
+			=
+			$Wares
+			 
+			sort
+			 
+			values
+			=
+			$Profits
+
+			$Stations.Buy.At
+			 
+			=
+			 
+			sort
+			 
+			array
+			:
+			 
+			data
+			=
+			$Stations.Buy.At
+			 
+			sort
+			 
+			values
+			=
+			$Profits
+
+			$Stations.Sell.At
+			 
+			=
+			 
+			sort
+			 
+			array
+			:
+			 
+			data
+			=
+			$Stations.Sell.At
+			 
+			sort
+			 
+			values
+			=
+			$Profits
+
+
+			$rc
+			 
+			=
+			 
+			null
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares
+
+			if
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ware
+			 
+			=
+			 
+			$Wares
+			[
+			$idx
+			]
+
+			$Station.Buy.At
+			 
+			=
+			 
+			$Stations.Buy.At
+			[
+			$idx
+			]
+
+			$Station.Sell.At
+			 
+			=
+			 
+			$Stations.Sell.At
+			[
+			$idx
+			]
+
+			$rc
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Ware
+			,
+			 
+			$Station.Buy.At
+			,
+			 
+			$Station.Sell.At
+			,
+			 
+			null
+			,
+			 
+			null
+
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			$Profits
+			 
+			=
+			 
+			sort
+			 
+			array
+			:
+			 
+			data
+			=
+			$Profits
+			 
+			sort
+			 
+			values
+			=
+			$Profits
+
+			$Profit
+			 
+			=
+			 
+			$Profits
+			[
+			$idx
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Best.Ware.To.Buy: Ware=%s, From=%s, To=%s, Profit=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Station.Buy.At
+			 
+			arg3
+			=
+			$Station.Sell.At
+			 
+			arg4
+			=
+			$Profit
+			 
+			arg5
+			=
+			null
+
+			$Wares
+			 
+			=
+			 
+			reverse
+			 
+			array
+			 
+			$Wares
+
+			$Profits
+			 
+			=
+			 
+			reverse
+			 
+			array
+			 
+			$Profits
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Best.Ware.To.Buy: Top.Wares=%s, Top.Profits=%s'
+			 
+			arg1
+			=
+			$Wares
+			 
+			arg2
+			=
+			$Profits
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			else
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Best.Ware.To.Buy: Nothing available'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Reserved.Amount:
+
+			*  Get amount of a ware that should be reserved
+
+			* ******************************************************************************
+
+			Get.Reserved.Amount
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Ware
+			 
+			=
+			 
+			$Arg1
+
+			$Dest
+			 
+			=
+			 
+			$Arg2
+
+
+			$Equip.Config
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Equip
+			]
+
+
+			while
+			 
+			1
+
+
+			if
+			 
+			is
+			 
+			upgrade
+			:
+			 
+			ware
+			=
+			$Ware
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			max
+			 
+			upgrades
+			 
+			for
+			 
+			upgrade
+			 
+			$Ware
+
+			break
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			can
+			 
+			transport
+			 
+			ware
+			 
+			$Ware
+
+			break
+
+
+			if
+			 
+			is
+			 
+			equipment
+			:
+			 
+			ware
+			=
+			$Ware
+
+			$rc
+			 
+			=
+			 
+			1
+
+			if
+			 
+			$Ware
+			 
+			==
+			 
+			{Duplex Scanner}
+
+			do
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Triplex Scanner}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$rc
+			 
+			=
+			 
+			0
+
+			end
+
+			break
+
+			end
+
+
+			$Wares
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			{Argon Jump Beacon}
+			,
+			 
+			{Fighter Drone}
+			,
+			 
+			{Fighter Drone MKII}
+			,
+			 
+			{Keris}
+			,
+			 
+			null
+
+			if
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Drones
+			]
+
+			$Amounts
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			1
+			,
+			 
+			10
+			,
+			 
+			5
+			,
+			 
+			5
+			,
+			 
+			null
+
+			else
+
+			$Amounts
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			1
+			,
+			 
+			0
+			,
+			 
+			0
+			,
+			 
+			0
+			,
+			 
+			null
+
+			end
+
+
+			* General wares and equipment
+
+			$idx
+			 
+			=
+			 
+			get
+			 
+			index
+			 
+			of
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			 
+			$Wares
+			 
+			offset
+			=
+			-1
+
+			if
+			 
+			$idx
+			 
+			>=
+			 
+			0
+
+			$rc
+			 
+			=
+			 
+			$Amounts
+			[
+			$idx
+			]
+
+			break
+
+			end
+
+
+			* Fuel
+
+			if
+			 
+			$Ware
+			 
+			==
+			 
+			{Energy Cells}
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Reserve.Jump.Energy
+			 
+			Arg1
+			=
+			$Dest
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			break
+
+			end
+
+
+			$Maintype
+			 
+			=
+			 
+			get
+			 
+			maintype
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+
+			* Lasers
+
+			if
+			 
+			$Maintype
+			 
+			==
+			 
+			8
+
+
+			if
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Lasers
+			]
+
+			* Sell tractor beams and MDS
+
+			if
+			 
+			$Ware
+			 
+			==
+			 
+			{Tractor Beam}
+			 
+			OR
+			 
+			$Ware
+			 
+			==
+			 
+			{Mobile Drilling System}
+
+			$rc
+			 
+			=
+			 
+			0
+
+			break
+
+			end
+
+
+			$TurretId
+			 
+			=
+			 
+			0
+
+			skip
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			max.
+			 
+			number
+			 
+			of
+			 
+			lasers
+			 
+			in
+			 
+			turret
+			 
+			0
+
+			$TurretId
+			 
+			=
+			 
+			1
+
+			$NumTurretsPlusOne
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			number
+			 
+			of
+			 
+			turrets
+
+			while
+			 
+			$TurretId
+			 
+			<
+			 
+			$NumTurretsPlusOne
+
+			$Wares
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			compatible
+			 
+			laser
+			 
+			array
+			:
+			 
+			turret
+			=
+			$TurretId
+
+			if
+			 
+			find
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			:
+			 
+			$Wares
+
+			$Amount
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			max.
+			 
+			number
+			 
+			of
+			 
+			lasers
+			 
+			in
+			 
+			turret
+			 
+			$TurretId
+
+			$rc
+			 
+			=
+			 
+			$rc
+			 
+			+
+			 
+			$Amount
+
+			end
+
+			inc
+			 
+			$TurretId
+
+			end
+
+
+			else
+
+			* Preserve installed lasers
+
+			$TurretId
+			 
+			=
+			 
+			0
+
+			skip
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			max.
+			 
+			number
+			 
+			of
+			 
+			lasers
+			 
+			in
+			 
+			turret
+			 
+			0
+
+			$TurretId
+			 
+			=
+			 
+			1
+
+			$NumTurretsPlusOne
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			number
+			 
+			of
+			 
+			turrets
+
+			while
+			 
+			$TurretId
+			 
+			<
+			 
+			$NumTurretsPlusOne
+
+			$Slot
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			max.
+			 
+			number
+			 
+			of
+			 
+			lasers
+			 
+			in
+			 
+			turret
+			 
+			$TurretId
+
+			while
+			 
+			$Slot
+
+			dec
+			 
+			$Slot
+
+			$Laser
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			laser
+			 
+			type
+			 
+			in
+			 
+			turret
+			 
+			$TurretId
+			 
+			at
+			 
+			slot
+			 
+			$Slot
+
+			skip
+			 
+			if
+			 
+			$Laser
+			 
+			!=
+			 
+			$Ware
+
+			inc
+			 
+			$rc
+
+			end
+
+			inc
+			 
+			$TurretId
+
+			end
+
+			end
+
+
+			break
+
+			end
+
+
+			* Missiles
+
+			if
+			 
+			$Maintype
+			 
+			==
+			 
+			10
+
+			if
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Missiles
+			]
+
+			$Wares
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			compatible
+			 
+			missile
+			 
+			array
+
+			do
+			 
+			if
+			 
+			find
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			:
+			 
+			$Wares
+
+			$rc
+			 
+			=
+			 
+			3
+
+			end
+
+			break
+
+			end
+
+
+			* Shields
+
+			if
+			 
+			$Maintype
+			 
+			==
+			 
+			9
+
+			if
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Missiles
+			]
+
+			$Amount
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$True.Amount
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			true
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			$True.Amount
+			 
+			!=
+			 
+			$Amount
+
+			* This suggests some shields of this type are installed. If so then reserve
+
+			* the amount that could be installed
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			number
+			 
+			of
+			 
+			shield
+			 
+			bays
+
+			end
+
+			else
+
+			* Preserve installed shields
+
+			$Bay
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			number
+			 
+			of
+			 
+			shield
+			 
+			bays
+
+			while
+			 
+			$Bay
+
+			dec
+			 
+			$Bay
+
+			$Shield
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			shield
+			 
+			type
+			 
+			in
+			 
+			bay
+			 
+			$Bay
+
+			skip
+			 
+			if
+			 
+			$Shield
+			 
+			!=
+			 
+			$Ware
+
+			inc
+			 
+			$rc
+
+			end
+
+			end
+
+			break
+
+			end
+
+
+			* Replicators
+
+			$Rep
+			 
+			=
+			 
+			get
+			 
+			global
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.replication'
+
+			if
+			 
+			$Rep
+
+			$Rep
+			 
+			=
+			 
+			$Rep
+			[
+			5
+			]
+
+			skip
+			 
+			if
+			 
+			$Ware
+			 
+			!=
+			 
+			$Rep
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			end
+
+
+			break
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			$rc
+			 
+			>
+			 
+			0
+
+			$rc
+			 
+			=
+			 
+			0
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Get.Reserved.Amount: Ware=%s, rc=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$rc
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Amount.For.Sale:
+
+			*  Determine how much of a ware a ship is allowed to sell
+
+			* ******************************************************************************
+
+			Get.Amount.For.Sale
+			:
+
+			$Ware
+			 
+			=
+			 
+			$Arg1
+
+			$Dest
+			 
+			=
+			 
+			$Arg2
+
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			$rc
+
+			$Reserved
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Reserved.Amount
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Dest
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$rc
+			 
+			=
+			 
+			$rc
+			 
+			-
+			 
+			$Reserved
+
+			end
+
+			skip
+			 
+			if
+			 
+			$rc
+			 
+			>
+			 
+			0
+
+			$rc
+			 
+			=
+			 
+			0
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Get.Amount.For.Sale: Ware=%s, rc=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$rc
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Best.Ware.To.Sell
+
+			*  Get a ware to sell from cargo
+
+			* ******************************************************************************
+
+			Get.Best.Ware.To.Sell
+			:
+
+			$Find.Flags
+			 
+			=
+			 
+			$Arg1
+
+			$Ver.Start
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			$rc
+			 
+			=
+			 
+			null
+
+			$Default.Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Get.Excludes
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			do
+			 
+			if
+			 
+			[DOCKEDAT]
+
+			append
+			 
+			[DOCKEDAT]
+			 
+			to
+			 
+			array
+			 
+			$Default.Excludes
+
+			$Wares
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			tradeable
+			 
+			ware
+			 
+			array
+			 
+			from
+			 
+			ship
+
+
+			$Fleeing
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Fleeing.Sector
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+
+			$Wait.Count
+			 
+			=
+			 
+			0
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ware
+			 
+			=
+			 
+			$Wares
+			[
+			$idx
+			]
+
+
+			inc
+			 
+			$Wait.Count
+
+			if
+			 
+			$Wait.Count
+			 
+			>
+			 
+			2
+
+			=
+			 
+			wait
+			 
+			randomly
+			 
+			from
+			 
+			50
+			 
+			to
+			 
+			100
+			 
+			ms
+
+			$Ver.Now
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			skip
+			 
+			if
+			 
+			$Ver.Now
+			 
+			==
+			 
+			$Ver.Start
+
+			return
+			 
+			null
+
+			$Wait.Count
+			 
+			=
+			 
+			0
+
+			end
+
+
+			$Amount
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Amount.For.Sale
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			$Amount
+
+			continue
+
+
+			$Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Clone.Array
+			 
+			Arg1
+			=
+			$Default.Excludes
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Fleeing
+
+			append
+			 
+			$Fleeing
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+			$Station
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Find.Station
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Mission.Type.Sell
+			 
+			Arg3
+			=
+			$Excludes
+			 
+			Arg4
+			=
+			[SECTOR]
+			 
+			Arg5
+			=
+			$Find.Flags
+			 
+			Arg6
+			=
+			1
+
+			if
+			 
+			not
+			 
+			$Station
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Get.Best.Ware.To.Sell: Nowhere to sell ware %s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			continue
+
+			end
+
+
+			$Price.Station
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+
+			$rc
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Ware
+			,
+			 
+			$Station
+			,
+			 
+			$Price.Station
+			,
+			 
+			null
+			,
+			 
+			null
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Best.Ware.To.Sell: Ware=%s, Dest=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Amount.To.Buy
+
+			*  Calculate amount to buy
+
+			* ******************************************************************************
+
+			Get.Amount.To.Buy
+			:
+
+			$Ware
+			 
+			=
+			 
+			$Arg1
+
+			$Dest
+			 
+			=
+			 
+			$Arg2
+
+			$Dest2
+			 
+			=
+			 
+			$Arg3
+
+			$Ignore.Amount.On.Order
+			 
+			=
+			 
+			$Arg4
+
+
+			$Equipping
+			 
+			=
+			 
+			is
+			 
+			upgrade
+			:
+			 
+			ware
+			=
+			$Ware
+
+			skip
+			 
+			if
+			 
+			$Equipping
+
+			$Equipping
+			 
+			=
+			 
+			is
+			 
+			inventory
+			:
+			 
+			ware
+			=
+			$Ware
+
+			skip
+			 
+			if
+			 
+			$Equipping
+
+			$Equipping
+			 
+			=
+			 
+			is
+			 
+			equipment
+			:
+			 
+			ware
+			=
+			$Ware
+
+
+			* How much the ship can hold
+
+			$p1
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			* Minus space for jump energy
+
+			$Volume
+			 
+			=
+			 
+			get
+			 
+			volume
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			if
+			 
+			$Volume
+
+			$Fuel.Topup
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Topup.Jump.Energy
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$p1
+			 
+			=
+			 
+			$p1
+			 
+			-
+			 
+			(
+			$Fuel.Topup
+			 
+			/
+			 
+			$Volume
+			)
+
+			end
+
+			skip
+			 
+			if
+			 
+			$p1
+			 
+			>
+			 
+			0
+
+			$p1
+			 
+			=
+			 
+			0
+
+
+			$p2
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Stock.Limit.Tradeable
+			 
+			Arg1
+			=
+			$Dest
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$p3
+			 
+			=
+			 
+			null
+
+			if
+			 
+			[HOMEBASE]
+
+			if
+			 
+			not
+			 
+			$Equipping
+
+			$Max
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Stock.Limit.Max
+			 
+			Arg1
+			=
+			[HOMEBASE]
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Have
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$Amount.On.Order
+			 
+			=
+			 
+			0
+
+			skip
+			 
+			if
+			 
+			$Ignore.Amount.On.Order
+
+			$Amount.On.Order
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Amount.On.Order
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$p3
+			 
+			=
+			 
+			$Max
+			 
+			-
+			 
+			$Have
+			 
+			-
+			 
+			$Amount.On.Order
+
+			skip
+			 
+			if
+			 
+			$p3
+			 
+			>
+			 
+			0
+
+			$p3
+			 
+			=
+			 
+			0
+
+			end
+
+			else
+
+			if
+			 
+			$Dest2
+
+			* Adjust for how much a designated consumer station can consume
+
+			skip
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Test.Buys.Infinite.Wares
+			 
+			Arg1
+			=
+			[THIS]
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			$Dest2
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$p3
+			 
+			=
+			 
+			$Dest2
+			->
+			 
+			get
+			 
+			free
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			end
+
+			end
+
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Get.Minimum
+			 
+			Arg1
+			=
+			$p1
+			 
+			Arg2
+			=
+			$p2
+			 
+			Arg3
+			=
+			$p3
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			$rc
+			 
+			>
+			 
+			0
+
+			$rc
+			 
+			=
+			 
+			0
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Get.Amount.To.Buy: Ware=%s, Dest=%s, Dest2=%s, rc=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Dest
+			 
+			arg3
+			=
+			$Dest2
+			 
+			arg4
+			=
+			$rc
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Needs.Refuel
+
+			*  Check if the ship should refuel
+
+			* ******************************************************************************
+
+			Get.Needs.Refuel
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Dest
+			 
+			=
+			 
+			$Arg1
+
+
+			$Fleeing
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Fleeing.Sector
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+
+			while
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Jumpdrive}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			break
+
+			skip
+			 
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$Dest
+			]
+			 
+			==
+			 
+			[DATATYPE_STATION]
+
+			break
+
+			$Dest.Sector
+			 
+			=
+			 
+			$Dest
+			->
+			 
+			get
+			 
+			sector
+
+			skip
+			 
+			if
+			 
+			$Dest.Sector
+			 
+			!=
+			 
+			[SECTOR]
+
+			break
+
+
+			$Energy.Topup
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Topup.Jump.Energy
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			$Energy.Topup
+
+			break
+
+
+			$Energy.Have
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Energy Cells}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$Energy.Possible
+			 
+			=
+			 
+			$Energy.Topup
+			 
+			+
+			 
+			$Energy.Have
+
+			$Energy.Required
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			needed
+			 
+			jump
+			 
+			drive
+			 
+			energy
+			 
+			for
+			 
+			jump
+			 
+			to
+			 
+			sector
+			 
+			[SECTOR]
+
+
+			if
+			 
+			$Energy.Possible
+			 
+			<
+			 
+			$Energy.Required
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Needs.Refuel: N - Cannot hold enough fuel to jump there. Topup=%s, Have=%s, Possible=%s, Required=%s'
+			 
+			arg1
+			=
+			$Energy.Topup
+			 
+			arg2
+			=
+			$Energy.Have
+			 
+			arg3
+			=
+			$Energy.Possible
+			 
+			arg4
+			=
+			$Energy.Required
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			* Can we jump there
+
+			$Jumps.Dest
+			 
+			=
+			 
+			get
+			 
+			jumps
+			 
+			from
+			 
+			sector
+			 
+			[SECTOR]
+			 
+			to
+			 
+			sector
+			 
+			$Dest.Sector
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Can.Jump.Trip
+			 
+			Arg1
+			=
+			$Jumps.Dest
+			 
+			Arg2
+			=
+			1
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Needs.Refuel: Y - Cannot jump to dest'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$rc
+			 
+			=
+			 
+			1
+
+			break
+
+			end
+
+
+			* If home has energy supply then check we can jump home
+
+			if
+			 
+			[HOMEBASE]
+
+			$Home.Sector
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			sector
+
+			if
+			 
+			$Fleeing
+			 
+			!=
+			 
+			$Home.Sector
+
+			if
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Energy Cells}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			$Home.Sector
+			 
+			==
+			 
+			$Dest.Sector
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Get.Needs.Refuel: N - dest is homebase and has fuel'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			$Jumps.Dest.Home
+			 
+			=
+			 
+			get
+			 
+			jumps
+			 
+			from
+			 
+			sector
+			 
+			$Dest.Sector
+			 
+			to
+			 
+			sector
+			 
+			$Home.Sector
+
+			$Jumps.Trip
+			 
+			=
+			 
+			$Jumps.Dest
+			 
+			+
+			 
+			$Jumps.Dest.Home
+
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Can.Jump.Trip
+			 
+			Arg1
+			=
+			$Jumps.Trip
+			 
+			Arg2
+			=
+			2
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Get.Needs.Refuel: N - Can jump to dest then homebase'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+			end
+
+			end
+
+
+			* Can we jump from dest to an energy supplier
+
+			$Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Get.Excludes
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Fleeing
+
+			append
+			 
+			$Fleeing
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+			$Flags
+			 
+			=
+			 
+			(
+			$Find.Ignore.Competition
+			 
+			|
+			 
+			$Find.Equipping
+			)
+
+			$Alt
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Find.Station
+			 
+			Arg1
+			=
+			{Energy Cells}
+			 
+			Arg2
+			=
+			$Mission.Type.Buy
+			 
+			Arg3
+			=
+			$Excludes
+			 
+			Arg4
+			=
+			$Dest.Sector
+			 
+			Arg5
+			=
+			$Flags
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			$Alt
+
+			$Alt.Sector
+			 
+			=
+			 
+			$Alt
+			->
+			 
+			get
+			 
+			sector
+
+			if
+			 
+			$Alt.Sector
+			 
+			==
+			 
+			$Dest.Sector
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Get.Needs.Refuel: N - Can jump to dest. Energy supply available in sector'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			$Jumps.Dest.Alt
+			 
+			=
+			 
+			get
+			 
+			jumps
+			 
+			from
+			 
+			sector
+			 
+			$Dest.Sector
+			 
+			to
+			 
+			sector
+			 
+			$Alt.Sector
+
+			$Jumps.Trip
+			 
+			=
+			 
+			$Jumps.Dest
+			 
+			+
+			 
+			$Jumps.Dest.Alt
+
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Can.Jump.Trip
+			 
+			Arg1
+			=
+			$Jumps.Trip
+			 
+			Arg2
+			=
+			2
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Get.Needs.Refuel: N - Can jump to dest then to energy source'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			* If we had a full tank could we jump from dest to an energy source
+
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Can.Jump.Trip
+			 
+			Arg1
+			=
+			$Jumps.Trip
+			 
+			Arg2
+			=
+			2
+			 
+			Arg3
+			=
+			$Energy.Topup
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Get.Needs.Refuel: Y - Can jump to dest then to energy source if we get a topup'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$rc
+			 
+			=
+			 
+			1
+
+			break
+
+			end
+
+
+			end
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Needs.Refuel: N - Cannot jump from dest to fuel source even if we had a full tank'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			break
+
+			end
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Get.Needs.Refuel: rc=%s'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Refuel.Dest:
+
+			*  Get a place to refuel at
+
+			* ******************************************************************************
+
+			Get.Refuel.Dest
+			:
+
+			$rc
+			 
+			=
+			 
+			null
+
+			$Fleeing
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Fleeing.Sector
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+
+			while
+			 
+			1
+
+
+			* Can we jump home
+
+			$Home.Energy
+			 
+			=
+			 
+			0
+
+			if
+			 
+			[HOMEBASE]
+
+			$Home.Sector
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			sector
+
+			if
+			 
+			$Fleeing
+			 
+			!=
+			 
+			$Home.Sector
+
+			$Home.Energy
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Energy Cells}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			$Home.Energy
+
+			$Jumps.Home
+			 
+			=
+			 
+			get
+			 
+			jumps
+			 
+			from
+			 
+			sector
+			 
+			[SECTOR]
+			 
+			to
+			 
+			sector
+			 
+			$Home.Sector
+
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Can.Jump.Trip
+			 
+			Arg1
+			=
+			$Jumps.Home
+			 
+			Arg2
+			=
+			1
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Refuel.Dest: Can jump home'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$rc
+			 
+			=
+			 
+			[HOMEBASE]
+
+			break
+
+			end
+
+			end
+
+			end
+
+			end
+
+
+			* Can we jump to an energy source
+
+			$Alt.Energy
+			 
+			=
+			 
+			0
+
+			$Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Get.Excludes
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Fleeing
+
+			append
+			 
+			$Fleeing
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+			$Flags
+			 
+			=
+			 
+			(
+			$Find.Ignore.Competition
+			 
+			|
+			 
+			$Find.Equipping
+			)
+
+			$Alt
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Find.Station
+			 
+			Arg1
+			=
+			{Energy Cells}
+			 
+			Arg2
+			=
+			$Mission.Type.Buy
+			 
+			Arg3
+			=
+			$Excludes
+			 
+			Arg4
+			=
+			$Dest.Sector
+			 
+			Arg5
+			=
+			$Flags
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			$Alt
+
+			$Alt.Sector
+			 
+			=
+			 
+			$Alt
+			->
+			 
+			get
+			 
+			sector
+
+			$Alt.Energy
+			 
+			=
+			 
+			$Alt
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Energy Cells}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			$Alt.Energy
+
+			$Jumps.Alt
+			 
+			=
+			 
+			get
+			 
+			jumps
+			 
+			from
+			 
+			sector
+			 
+			[SECTOR]
+			 
+			to
+			 
+			sector
+			 
+			$Alt.Sector
+
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Can.Jump.Trip
+			 
+			Arg1
+			=
+			$Jumps.Alt
+			 
+			Arg2
+			=
+			1
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Refuel.Dest: Can jump to %s'
+			 
+			arg1
+			=
+			$Alt
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$rc
+			 
+			=
+			 
+			$Alt
+
+			break
+
+			end
+
+			end
+
+			end
+
+
+			* Prefer home over exiting sector when fleeing
+
+			if
+			 
+			$Fleeing
+			 
+			==
+			 
+			[SECTOR]
+			 
+			AND
+			 
+			[HOMEBASE]
+			 
+			AND
+			 
+			[SECTOR]
+			 
+			==
+			 
+			$Home.Sector
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Refuel.Dest: Cant jump to fuel, heading home'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$rc
+			 
+			=
+			 
+			[HOMEBASE]
+
+			break
+
+			end
+
+
+			* Which is closer
+
+			if
+			 
+			$Home.Energy
+
+			if
+			 
+			$Alt.Energy
+
+			if
+			 
+			$Jumps.Alt
+			 
+			<
+			 
+			$Jumps.Home
+
+			$rc
+			 
+			=
+			 
+			$Alt
+
+			else
+
+			$rc
+			 
+			=
+			 
+			[HOMEBASE]
+
+			end
+
+			else
+
+			$rc
+			 
+			=
+			 
+			[HOMEBASE]
+
+			end
+
+			else
+			 
+			if
+			 
+			$Alt.Energy
+
+			$rc
+			 
+			=
+			 
+			$Alt
+
+			end
+
+
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			do
+			 
+			if
+			 
+			$rc
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Refuel.Dest: Must crawl to %s. Alt.Energy=%s, Home.Energy=%s'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			$Alt.Energy
+			 
+			arg3
+			=
+			$Home.Energy
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+
+			break
+
+			end
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Get.Refuel.Dest: rc=%s'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Find.Shipyard
+
+			* ******************************************************************************
+
+			Find.Shipyard
+			:
+
+			$rc
+			 
+			=
+			 
+			null
+
+			$Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Get.Excludes
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Fleeing
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Fleeing.Sector
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Fleeing
+
+			append
+			 
+			$Fleeing
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+
+			$Max.Jumps
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Max.Jumps
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+
+			* Check out the closest
+
+			$Flags
+			 
+			=
+			 
+			[Find.DockingAllowed]
+			 
+			|
+			 
+			[Find.Known]
+			 
+			|
+			 
+			[Find.Nearest]
+
+			$Nearest
+			 
+			=
+			 
+			find
+			 
+			station
+			 
+			in
+			 
+			galaxy
+			:
+			 
+			startsector
+			=
+			[SECTOR]
+			 
+			class
+			 
+			or
+			 
+			type
+			=
+			[Shipyard]
+			 
+			race
+			=
+			null
+			 
+			flags
+			=
+			$Flags
+			 
+			refobj
+			=
+			[THIS]
+			 
+			serial
+			=
+			null
+			 
+			max.jumps
+			=
+			$Max.Jumps
+
+
+			while
+			 
+			1
+
+			if
+			 
+			$Nearest
+
+			$Sector
+			 
+			=
+			 
+			$Nearest
+			->
+			 
+			get
+			 
+			sector
+
+			if
+			 
+			not
+			 
+			find
+			 
+			$Sector
+			 
+			in
+			 
+			array
+			:
+			 
+			$Excludes
+
+			if
+			 
+			$Nearest
+			->
+			 
+			is
+			 
+			docking
+			 
+			possible
+			 
+			of
+			 
+			[THIS]
+
+			if
+			 
+			[THIS]
+			->
+			 
+			is
+			 
+			docking
+			 
+			allowed
+			 
+			at
+			 
+			$Nearest
+
+			$rc
+			 
+			=
+			 
+			$Nearest
+
+			break
+
+			end
+
+			end
+
+			end
+
+			end
+
+
+			$Flags
+			 
+			=
+			 
+			[Find.DockingAllowed]
+			 
+			|
+			 
+			[Find.Known]
+			 
+			|
+			 
+			[Find.Multiple]
+
+			$Shipyards
+			 
+			=
+			 
+			find
+			 
+			station
+			 
+			in
+			 
+			galaxy
+			:
+			 
+			startsector
+			=
+			[SECTOR]
+			 
+			class
+			 
+			or
+			 
+			type
+			=
+			[Shipyard]
+			 
+			race
+			=
+			null
+			 
+			flags
+			=
+			$Flags
+			 
+			refobj
+			=
+			[THIS]
+			 
+			serial
+			=
+			null
+			 
+			max.jumps
+			=
+			$Max.Jumps
+			 
+			num
+			=
+			42
+
+			$count
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Shipyards
+
+			$idx
+			 
+			=
+			 
+			0
+
+			while
+			 
+			$idx
+			 
+			<
+			 
+			$count
+
+			$Shipyard
+			 
+			=
+			 
+			$Shipyards
+			[
+			$idx
+			]
+
+			$Sector
+			 
+			=
+			 
+			$Shipyard
+			->
+			 
+			get
+			 
+			sector
+
+			if
+			 
+			not
+			 
+			find
+			 
+			$Sector
+			 
+			in
+			 
+			array
+			:
+			 
+			$Excludes
+
+			if
+			 
+			$Shipyard
+			->
+			 
+			is
+			 
+			docking
+			 
+			possible
+			 
+			of
+			 
+			[THIS]
+
+			if
+			 
+			[THIS]
+			->
+			 
+			is
+			 
+			docking
+			 
+			allowed
+			 
+			at
+			 
+			$Shipyard
+
+			$rc
+			 
+			=
+			 
+			$Shipyard
+
+			break
+
+			end
+
+			end
+
+			end
+
+			inc
+			 
+			$idx
+
+			end
+
+			break
+
+			end
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Find.Shipyard: rc=%s'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get cost to repair ship
+
+			* ******************************************************************************
+
+			Get.Repair.Cost
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Hull
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			hull
+			 
+			percent
+
+			$Hull
+			 
+			=
+			 
+			100
+			 
+			-
+			 
+			$Hull
+
+			$Ware
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			ware
+			 
+			type
+			 
+			code
+			 
+			of
+			 
+			object
+
+			$rc
+			 
+			=
+			 
+			get
+			 
+			average
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$rc
+			 
+			=
+			 
+			(
+			$rc
+			 
+			*
+			 
+			$Hull
+			)
+			 
+			/
+			 
+			100
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Get.Repair.Cost: Percentage=%s, rc=%s'
+			 
+			arg1
+			=
+			$Hull
+			 
+			arg2
+			=
+			$rc
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+
+			* ******************************************************************************
+
+			* Get.Fleeing.Sector
+
+			*  Get sector ship is fleeing from
+
+			* ******************************************************************************
+
+			Get.Fleeing.Sector
+			:
+
+			$rc
+			 
+			=
+			 
+			null
+
+
+			while
+			 
+			1
+
+			$State
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Fetch
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			$State
+
+			break
+
+
+			$Fleeing
+			 
+			=
+			 
+			$State
+			[
+			$State.Fleeing
+			]
+
+			skip
+			 
+			if
+			 
+			$Fleeing
+
+			break
+
+
+			do
+			 
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$Fleeing
+			]
+			 
+			==
+			 
+			[DATATYPE_SECTOR]
+
+			$rc
+			 
+			=
+			 
+			$Fleeing
+
+			break
+
+			end
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Get.Fleeing.Sector: rc=%s'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Threats:
+
+			*  Get threats to the ship
+
+			* ******************************************************************************
+
+			Get.Threats
+			:
+
+			$rc
+			 
+			=
+			 
+			null
+
+			$Missiles
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			array
+			 
+			of
+			 
+			missiles
+			 
+			aiming
+			 
+			to
+			 
+			me
+
+			$Enemies
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+
+			$Flags
+			 
+			=
+			 
+			[Find.Enemy]
+			 
+			|
+			 
+			[Find.Multiple]
+
+			$Range
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			scanner
+			 
+			range
+
+			$Ships
+			 
+			=
+			 
+			find
+			 
+			ship
+			:
+			 
+			sector
+			=
+			[SECTOR]
+			 
+			class
+			 
+			or
+			 
+			type
+			=
+			null
+			 
+			race
+			=
+			null
+			 
+			flags
+			=
+			$Flags
+			 
+			refobj
+			=
+			[THIS]
+			 
+			maxdist
+			=
+			$Range
+			 
+			maxnum
+			=
+			42
+			 
+			refpos
+			=
+			null
+
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$Ships
+			]
+			 
+			==
+			 
+			[DATATYPE_ARRAY]
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Ships
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ship
+			 
+			=
+			 
+			$Ships
+			[
+			$idx
+			]
+
+			skip
+			 
+			if
+			 
+			$Ship
+			->
+			 
+			exists
+
+			continue
+
+
+			$Target
+			 
+			=
+			 
+			$Ship
+			->
+			 
+			get
+			 
+			attack
+			 
+			target
+
+			if
+			 
+			$Target
+			 
+			==
+			 
+			[THIS]
+
+			append
+			 
+			$Ship
+			 
+			to
+			 
+			array
+			 
+			$Enemies
+
+			else
+
+			$Target
+			 
+			=
+			 
+			$Ship
+			->
+			 
+			get
+			 
+			command
+			 
+			target
+
+			do
+			 
+			if
+			 
+			$Target
+			 
+			==
+			 
+			[THIS]
+
+			append
+			 
+			$Ship
+			 
+			to
+			 
+			array
+			 
+			$Enemies
+
+			end
+
+			end
+
+			end
+
+
+			$Attacker
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			attacker
+
+			if
+			 
+			$Attacker
+			->
+			 
+			exists
+
+			if
+			 
+			[THIS]
+			->
+			 
+			is
+			 
+			$Attacker
+			 
+			a
+			 
+			enemy
+
+			if
+			 
+			[THIS]
+			->
+			 
+			has
+			 
+			same
+			 
+			environment
+			 
+			as
+			 
+			$Attacker
+
+			skip
+			 
+			if
+			 
+			find
+			 
+			$Attacker
+			 
+			in
+			 
+			array
+			:
+			 
+			$Enemies
+
+			append
+			 
+			$Attacker
+			 
+			to
+			 
+			array
+			 
+			$Enemies
+
+			end
+
+			end
+
+			end
+
+
+			$rc
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Missiles
+
+			skip
+			 
+			if
+			 
+			$rc
+
+			$rc
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Enemies
+
+			if
+			 
+			$rc
+
+			$Ver
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			$rc
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Ver
+			,
+			 
+			$Missiles
+			,
+			 
+			$Enemies
+			,
+			 
+			null
+			,
+			 
+			null
+
+			end
+
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			if
+			 
+			$rc
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			6
+			 
+			fmt
+			=
+			'Get.Threats: Missiles=%s, Ships=%s'
+			 
+			arg1
+			=
+			$Missiles
+			 
+			arg2
+			=
+			$Ships
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			else
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Get.Threats: rc=%s'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* BigInt.Add:
+
+			*  Add 2 quantities and return result as a big int
+
+			* ******************************************************************************
+
+			BigInt.Add
+			:
+
+			$Billion
+			 
+			=
+			 
+			1000000000
+
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$Arg1
+			]
+			 
+			==
+			 
+			[DATATYPE_ARRAY]
+
+			$Arg1.HI
+			 
+			=
+			 
+			$Arg1
+			[
+			0
+			]
+
+			$Arg1.LO
+			 
+			=
+			 
+			$Arg1
+			[
+			1
+			]
+
+			else
+			 
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$Arg1
+			]
+			 
+			==
+			 
+			[DATATYPE_INT]
+
+			$Arg1.HI
+			 
+			=
+			 
+			$Arg1
+			 
+			/
+			 
+			$Billion
+
+			$Arg1.LO
+			 
+			=
+			 
+			$Arg1
+			 
+			mod
+			 
+			$Billion
+
+			else
+
+			$Arg1.HI
+			 
+			=
+			 
+			0
+
+			$Arg1.LO
+			 
+			=
+			 
+			0
+
+			end
+
+
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$Arg2
+			]
+			 
+			==
+			 
+			[DATATYPE_ARRAY]
+
+			$Arg2.HI
+			 
+			=
+			 
+			$Arg2
+			[
+			0
+			]
+
+			$Arg2.LO
+			 
+			=
+			 
+			$Arg2
+			[
+			1
+			]
+
+			else
+			 
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$Arg2
+			]
+			 
+			==
+			 
+			[DATATYPE_INT]
+
+			$Arg2.HI
+			 
+			=
+			 
+			$Arg2
+			 
+			/
+			 
+			$Billion
+
+			$Arg2.LO
+			 
+			=
+			 
+			$Arg2
+			 
+			mod
+			 
+			$Billion
+
+			else
+
+			$Arg2.HI
+			 
+			=
+			 
+			0
+
+			$Arg2.LO
+			 
+			=
+			 
+			0
+
+			end
+
+
+			$Arg1.HI
+			 
+			=
+			 
+			$Arg1.HI
+			 
+			+
+			 
+			$Arg2.HI
+
+			$Arg1.LO
+			 
+			=
+			 
+			$Arg1.LO
+			 
+			+
+			 
+			$Arg2.LO
+
+
+			$Arg1.HI
+			 
+			=
+			 
+			$Arg1.HI
+			 
+			+
+			 
+			(
+			$Arg1.LO
+			 
+			/
+			 
+			$Billion
+			)
+
+			$Arg1.LO
+			 
+			=
+			 
+			$Arg1.LO
+			 
+			mod
+			 
+			$Billion
+
+
+
+			$rc
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Arg1.HI
+			,
+			 
+			$Arg1.LO
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'BigInt.Add: Arg1=%s, Arg2=%s, rc=%s'
+			 
+			arg1
+			=
+			$Arg1
+			 
+			arg2
+			=
+			$Arg2
+			 
+			arg3
+			=
+			$rc
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* BigInt.Format:
+
+			*  Format a bigint as a string
+
+			* ******************************************************************************
+
+			BigInt.Format
+			:
+
+			$Billion
+			 
+			=
+			 
+			1000000000
+
+			$rc
+			 
+			=
+			 
+			''
+
+
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$Arg1
+			]
+			 
+			==
+			 
+			[DATATYPE_ARRAY]
+
+			$HI
+			 
+			=
+			 
+			$Arg1
+			[
+			0
+			]
+
+			$LO
+			 
+			=
+			 
+			$Arg1
+			[
+			1
+			]
+
+			else
+			 
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$Arg1
+			]
+			 
+			==
+			 
+			[DATATYPE_INT]
+
+			$HI
+			 
+			=
+			 
+			$Arg1
+			 
+			/
+			 
+			$Billion
+
+			$LO
+			 
+			=
+			 
+			$Arg1
+			 
+			mod
+			 
+			$Billion
+
+			else
+
+			$HI
+			 
+			=
+			 
+			0
+
+			$LO
+			 
+			=
+			 
+			0
+
+			end
+
+
+			if
+			 
+			$HI
+			 
+			<
+			 
+			0
+
+			$rc
+			 
+			=
+			 
+			'-'
+
+			$HI
+			 
+			=
+			 
+			$HI
+			 
+			*
+			 
+			-1
+
+			end
+
+
+			if
+			 
+			$LO
+			 
+			<
+			 
+			0
+
+			$rc
+			 
+			=
+			 
+			'-'
+
+			$LO
+			 
+			=
+			 
+			$LO
+			 
+			*
+			 
+			-1
+
+			end
+
+
+			$Zero.Is.Significant
+			 
+			=
+			 
+			0
+
+			$Significant
+			 
+			=
+			 
+			0
+
+			$Value
+			 
+			=
+			 
+			$HI
+
+			gosub
+			 
+			BigInt.Format.Dword
+			:
+
+			do
+			 
+			if
+			 
+			$Significant
+
+			$rc
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			fmt
+			=
+			'%s,'
+			,
+			 
+			$rc
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Zero.Is.Significant
+			 
+			=
+			 
+			1
+
+			$Value
+			 
+			=
+			 
+			$LO
+
+			gosub
+			 
+			BigInt.Format.Dword
+			:
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'BigInt.Format: Input=%s, rc=%s'
+			 
+			arg1
+			=
+			$Arg1
+			 
+			arg2
+			=
+			$rc
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* BigInt.Format.Dword
+
+			*  Format one dword as a string with comma separator.
+
+			* ******************************************************************************
+
+			BigInt.Format.Dword
+			:
+
+			$Separator.Idx
+			 
+			=
+			 
+			-1
+
+			$idx
+			 
+			=
+			 
+			100000000
+
+			while
+			 
+			$idx
+			 
+			>
+			 
+			0
+
+			if
+			 
+			$Separator.Idx
+			 
+			==
+			 
+			2
+
+			do
+			 
+			if
+			 
+			$Significant
+
+			$rc
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			fmt
+			=
+			'%s,'
+			,
+			 
+			$rc
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Separator.Idx
+			 
+			=
+			 
+			0
+
+			else
+
+			inc
+			 
+			$Separator.Idx
+
+			end
+
+
+			$Digit
+			 
+			=
+			 
+			$Value
+			 
+			/
+			 
+			$idx
+
+			if
+			 
+			$Digit
+
+			$Significant
+			 
+			=
+			 
+			1
+
+			$rc
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			fmt
+			=
+			'%s%s'
+			,
+			 
+			$rc
+			,
+			 
+			$Digit
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Value
+			 
+			=
+			 
+			$Value
+			 
+			-
+			 
+			(
+			$Digit
+			 
+			*
+			 
+			$idx
+			)
+
+			else
+			 
+			if
+			 
+			$Significant
+			 
+			OR
+			 
+			(
+			$Zero.Is.Significant
+			 
+			AND
+			 
+			$idx
+			 
+			==
+			 
+			1
+			)
+
+			$rc
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			fmt
+			=
+			'%s%s'
+			,
+			 
+			$rc
+			,
+			 
+			0
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			end
+
+
+			$idx
+			 
+			=
+			 
+			$idx
+			 
+			/
+			 
+			10
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.All.Wares.From.Ship
+
+			*  Get all wares including installed shields, lasers
+
+			* ******************************************************************************
+
+			Get.All.Wares.From.Ship
+			:
+
+			$All.Wares
+			 
+			=
+			 
+			$Config
+			[
+			$Config.All.Wares
+			]
+
+			$rc
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$All.Wares
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ware
+			 
+			=
+			 
+			$All.Wares
+			[
+			$idx
+			]
+
+
+			do
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			append
+			 
+			$Ware
+			 
+			to
+			 
+			array
+			 
+			$rc
+
+			end
+
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			9
+			 
+			fmt
+			=
+			'Get.All.Wares.From.Ship: rc=%s'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Eco.Mission:
+
+			*  Select a mission for an eco trader
+
+			* ******************************************************************************
+
+			Get.Eco.Mission
+			:
+
+			$rc
+			 
+			=
+			 
+			null
+
+
+			$State
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Fetch
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Default.Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Get.Excludes
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Fleeing
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Fleeing.Sector
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			do
+			 
+			if
+			 
+			$Fleeing
+
+			append
+			 
+			$Fleeing
+			 
+			to
+			 
+			array
+			 
+			$Default.Excludes
+
+
+			$Illegal.Wares
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Illegal.Wares
+			]
+
+			$Tether.Sector
+			 
+			=
+			 
+			$State
+			[
+			$State.Tether.Sector
+			]
+
+			$Tether.Range
+			 
+			=
+			 
+			$State
+			[
+			$State.Tether.Range
+			]
+
+			$Funds
+			 
+			=
+			 
+			get
+			 
+			player
+			 
+			money
+
+
+			$Stations
+			 
+			=
+			 
+			get
+			 
+			station
+			 
+			array
+			:
+			 
+			resource
+			=
+			{Energy Cells}
+			 
+			include
+			 
+			empty
+			=
+			[TRUE]
+
+			$idx.Station
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Stations
+
+			while
+			 
+			$idx.Station
+
+			dec
+			 
+			$idx.Station
+
+			$Station
+			 
+			=
+			 
+			$Stations
+			[
+			$idx.Station
+			]
+
+
+			* Test station qualifies for eco
+
+			do
+			 
+			if
+			 
+			$Station
+			->
+			 
+			get
+			 
+			production
+			 
+			status
+			:
+			 
+			as
+			 
+			percentage
+			=
+			0
+
+			continue
+
+			do
+			 
+			if
+			 
+			$Station
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Dock]
+
+			continue
+
+
+			* Ship can trade there
+
+			$Sector
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			sector
+
+			skip
+			 
+			if
+			 
+			$Sector
+			->
+			 
+			is
+			 
+			sector
+			 
+			known
+			 
+			by
+			 
+			the
+			 
+			player
+
+			continue
+
+			skip
+			 
+			if
+			 
+			$Station
+			->
+			 
+			is
+			 
+			known
+
+			continue
+
+			skip
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			is
+			 
+			docking
+			 
+			allowed
+			 
+			at
+			 
+			$Station
+
+			continue
+
+			skip
+			 
+			if
+			 
+			$Station
+			->
+			 
+			is
+			 
+			docking
+			 
+			possible
+			 
+			of
+			 
+			[THIS]
+
+			continue
+
+			$Owner
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			owner
+			 
+			race
+
+			skip
+			 
+			if
+			 
+			$Owner
+			 
+			!=
+			 
+			[Player]
+
+			continue
+
+
+			* Within tether range
+
+			if
+			 
+			$Tether.Sector
+
+			$Jumps
+			 
+			=
+			 
+			get
+			 
+			jumps
+			 
+			from
+			 
+			sector
+			 
+			$Tether.Sector
+			 
+			to
+			 
+			sector
+			 
+			$Sector
+
+			skip
+			 
+			if
+			 
+			$Jumps
+			 
+			<=
+			 
+			$Tether.Range
+
+			continue
+
+			end
+
+
+			* Not excluded
+
+			do
+			 
+			if
+			 
+			find
+			 
+			$Sector
+			 
+			in
+			 
+			array
+			:
+			 
+			$Excludes
+
+			continue
+
+			do
+			 
+			if
+			 
+			find
+			 
+			$Station
+			 
+			in
+			 
+			array
+			:
+			 
+			$Excludes
+
+			continue
+
+
+			* Filter to primary resources and sort by stock level
+
+			$Primaries
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Primaries.Sort
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Wares
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			tradeable
+			 
+			ware
+			 
+			array
+			 
+			from
+			 
+			station
+
+			$idx.Ware
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares
+
+			while
+			 
+			$idx.Ware
+
+			dec
+			 
+			$idx.Ware
+
+			$Ware
+			 
+			=
+			 
+			$Wares
+			[
+			$idx.Ware
+			]
+
+
+			if
+			 
+			$Station
+			->
+			 
+			uses
+			 
+			ware
+			 
+			$Ware
+			 
+			as
+			 
+			primary
+			 
+			resource
+
+			$Stock
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			ware
+			 
+			storage
+			 
+			percentage
+			:
+			 
+			ware
+			=
+			$Ware
+
+			if
+			 
+			$Stock
+			 
+			<
+			 
+			90
+
+			append
+			 
+			$Ware
+			 
+			to
+			 
+			array
+			 
+			$Primaries
+
+			append
+			 
+			$Stock
+			 
+			to
+			 
+			array
+			 
+			$Primaries.Sort
+
+			end
+
+			end
+
+			end
+
+
+			* Test qualifying wares in order of increasing stock level
+
+			$Wares
+			 
+			=
+			 
+			sort
+			 
+			array
+			:
+			 
+			data
+			=
+			$Primaries
+			 
+			sort
+			 
+			values
+			=
+			$Primaries.Sort
+
+			$Wares
+			 
+			=
+			 
+			reverse
+			 
+			array
+			 
+			$Wares
+
+			$idx.Ware
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares
+
+			while
+			 
+			$idx.Ware
+
+			dec
+			 
+			$idx.Ware
+
+			$Ware
+			 
+			=
+			 
+			$Wares
+			[
+			$idx.Ware
+			]
+
+
+			$Price
+			 
+			=
+			 
+			get
+			 
+			max
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			skip
+			 
+			if
+			 
+			$Funds
+			 
+			>=
+			 
+			$Price
+
+			continue
+
+
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Trade.Illegal.Wares
+			]
+
+			do
+			 
+			if
+			 
+			find
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			:
+			 
+			$Illegal.Wares
+
+			continue
+
+			end
+
+
+			do
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Check.Competition
+			 
+			Arg1
+			=
+			$Mission.Type.Sell
+			 
+			Arg2
+			=
+			$Station
+			 
+			Arg3
+			=
+			$Ware
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			continue
+
+
+			$Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Clone.Array
+			 
+			Arg1
+			=
+			$Default.Excludes
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Price
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$Station.Buy.At
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Find.Station
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Mission.Type.Buy
+			 
+			Arg3
+			=
+			$Excludes
+			 
+			Arg4
+			=
+			[SECTOR]
+			 
+			Arg5
+			=
+			0
+			 
+			Arg6
+			=
+			$Price
+
+			skip
+			 
+			if
+			 
+			$Station.Buy.At
+
+			continue
+
+
+			$rc
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Ware
+			,
+			 
+			$Station.Buy.At
+			,
+			 
+			$Station
+			,
+			 
+			null
+			,
+			 
+			null
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Get.Eco.Mission: Ware=%s, Dest=%s, Dest2=%s, rc=%s'
+			 
+			arg1
+			=
+			$Ware
+			 
+			arg2
+			=
+			$Station.Buy.At
+			 
+			arg3
+			=
+			$Station
+			 
+			arg4
+			=
+			$rc
+			 
+			arg5
+			=
+			null
+
+			return
+			 
+			$rc
+
+			end
+
+
+			end
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Get.Eco.Mission: No trades available'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Check.Dest2:
+
+			*  Check that dest2 remains valid. If not, set a new dest2.
+
+			* ******************************************************************************
+
+			Check.Dest2
+			:
+
+			$rc
+			 
+			=
+			 
+			null
+
+			$State
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Fetch
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Mission
+			 
+			=
+			 
+			$State
+			[
+			$State.Mission
+			]
+
+			$Dest
+			 
+			=
+			 
+			$State
+			[
+			$State.Dest
+			]
+
+			$Dest2
+			 
+			=
+			 
+			$State
+			[
+			$State.Dest2
+			]
+
+			$Ware
+			 
+			=
+			 
+			$State
+			[
+			$State.Ware
+			]
+
+			$Price
+			 
+			=
+			 
+			$State
+			[
+			$State.Price
+			]
+
+
+			skip
+			 
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+			return
+			 
+			null
+
+
+			* Check if dest2 is still valid
+
+			if
+			 
+			$Dest2
+			->
+			 
+			exists
+
+			$Price.Dest2
+			 
+			=
+			 
+			$Dest2
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			if
+			 
+			$Price.Dest2
+			 
+			<=
+			 
+			$Price
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Check.Dest2: Dest2 is no longer viable. Dest1=%s, Dest2=%s, Ware=%s, Price.Dest1=%s, Price.Dest2=%s'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			$Dest2
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Price
+			 
+			arg5
+			=
+			$Price.Dest2
+
+			$Dest2
+			 
+			=
+			 
+			null
+
+			end
+
+			end
+
+
+			* Find a dest2 if we don't have one
+
+			if
+			 
+			not
+			 
+			$Dest2
+			->
+			 
+			exists
+
+			$Origin
+			 
+			=
+			 
+			$Dest
+			->
+			 
+			get
+			 
+			sector
+
+			$Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Get.Excludes
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Price.Sell
+			 
+			=
+			 
+			$Price
+			 
+			+
+			 
+			1
+
+			$Trade.Mode
+			 
+			=
+			 
+			$State
+			[
+			$State.Trade.Mode
+			]
+
+			skip
+			 
+			if
+			 
+			$Trade.Mode
+			 
+			!=
+			 
+			$Trade.Mode.Economy
+
+			$Dest2
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Find.Station
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Mission.Type.Sell
+			 
+			Arg3
+			=
+			$Excludes
+			 
+			Arg4
+			=
+			$Origin
+			 
+			Arg5
+			=
+			$Find.Eco
+			 
+			Arg6
+			=
+			$Price.Sell
+
+			skip
+			 
+			if
+			 
+			$Dest2
+			->
+			 
+			exists
+
+			$Dest2
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Find.Station
+			 
+			Arg1
+			=
+			$Ware
+			 
+			Arg2
+			=
+			$Mission.Type.Sell
+			 
+			Arg3
+			=
+			$Excludes
+			 
+			Arg4
+			=
+			$Origin
+			 
+			Arg5
+			=
+			0
+			 
+			Arg6
+			=
+			$Price.Sell
+
+
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			if
+			 
+			$Dest2
+			->
+			 
+			exists
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Check.Dest2: Found a new dest2. Dest1=%s, Dest2=%s, Ware=%s. Price.Dest1=%s, Price.Dest2=%s'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			$Dest2
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Price
+			 
+			arg5
+			=
+			$Price.Dest2
+
+			else
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Check.Dest2: Failed to find a new dest2. Dest1=%s, Ware=%s. Price.Dest1=%s'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			$Price
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			end
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.Buy
+			 
+			Arg2
+			=
+			$Dest
+			 
+			Arg3
+			=
+			$Ware
+			 
+			Arg4
+			=
+			$Price
+			 
+			Arg5
+			=
+			$Dest2
+
+			end
+
+
+			$rc
+			 
+			=
+			 
+			$Dest2
+
+			do
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Check.Dest2: Dest=%s, Ware=%s, Price=%s, rc=%s'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			$Price
+			 
+			arg4
+			=
+			$rc
+			 
+			arg5
+			=
+			null
+
+			endsub

--- a/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.menu.x3s
+++ b/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.menu.x3s
@@ -1,0 +1,10691 @@
+#name: glen.trade.ok.menu
+#lang: 44
+#origin_mod: OKTraders1_7_1
+#source: mods/OKTraders1_7_1/scripts/glen.trade.ok.menu.xml
+
+
+			* ******************************************************************************
+
+			* OK Trade
+
+			*  Trade menu
+
+			* ******************************************************************************
+
+
+			$Comp
+			 
+			=
+			 
+			'Menu'
+
+
+			$Config
+			 
+			=
+			 
+			get
+			 
+			global
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+
+			skip
+			 
+			if
+			 
+			$Config
+
+			return
+			 
+			null
+
+			skip
+			 
+			if
+			 
+			$Trader
+			->
+			 
+			exists
+
+			return
+			 
+			null
+
+
+			$Game.Version
+			 
+			=
+			 
+			script
+			 
+			engine
+			 
+			version
+
+			$Is.AP
+			 
+			=
+			 
+			(
+			$Game.Version
+			 
+			>
+			 
+			49
+			)
+
+
+			* Config array members
+
+			$Config.Ver.Major
+			 
+			=
+			 
+			0
+
+			$Config.Ver.Minor
+			 
+			=
+			 
+			1
+
+			$Config.Ver.Patch
+			 
+			=
+			 
+			2
+
+			$Config.Ver.Internal
+			 
+			=
+			 
+			3
+
+			$Config.PageId
+			 
+			=
+			 
+			4
+
+			$Config.Debug.Enabled
+			 
+			=
+			 
+			5
+
+			$Config.Debug.Verbosity
+			 
+			=
+			 
+			6
+
+			$Config.Debug.Target
+			 
+			=
+			 
+			7
+
+			$Config.Required.Ware
+			 
+			=
+			 
+			8
+
+			$Config.Auto.Rename
+			 
+			=
+			 
+			9
+
+			$Config.Blacklist
+			 
+			=
+			 
+			10
+
+			$Config.Monitor.Task
+			 
+			=
+			 
+			11
+
+			$Config.Trade.Threshold
+			 
+			=
+			 
+			12
+
+			$Config.Trade.Illegal.Wares
+			 
+			=
+			 
+			14
+
+			$Config.Refuel.Percent
+			 
+			=
+			 
+			17
+
+			$Config.Global.Balance
+			 
+			=
+			 
+			18
+
+			$Config.Equip
+			 
+			=
+			 
+			20
+
+			$Config.Alert.Sound
+			 
+			=
+			 
+			21
+
+
+			$Lib.Config.Get.Station.Config
+			 
+			=
+			 
+			0
+
+			$Lib.Config.Get.Stock.Limit.Min
+			 
+			=
+			 
+			1
+
+			$Lib.Config.Get.Stock.Limit.Max
+			 
+			=
+			 
+			2
+
+			$Lib.Config.Get.Stock.Limit.Free
+			 
+			=
+			 
+			3
+
+			$Lib.Config.Get.Stock.Limit.Tradeable
+			 
+			=
+			 
+			4
+
+			$Lib.Config.Get.Dockware.Limit
+			 
+			=
+			 
+			5
+
+
+			* Config settings referenced in this script
+
+			$Ver.Major
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Major
+			]
+
+			$Ver.Minor
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Minor
+			]
+
+			$Ver.Patch
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Patch
+			]
+
+			$Ver.Internal
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			$PageId
+			 
+			=
+			 
+			$Config
+			[
+			$Config.PageId
+			]
+
+			$Debug
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			$Required.Ware
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Required.Ware
+			]
+
+			$Blacklist
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Blacklist
+			]
+
+
+			* Selected mode for trading a given ware
+
+			$Mission.Type.None
+			 
+			=
+			 
+			0
+
+			$Mission.Type.Buy
+			 
+			=
+			 
+			1
+
+			$Mission.Type.Sell
+			 
+			=
+			 
+			2
+
+
+			* Whether the command script should start anew or
+
+			* continue an existing mission
+
+			$Directive.Type.Start
+			 
+			=
+			 
+			0
+
+			$Directive.Type.Resume
+			 
+			=
+			 
+			1
+
+
+			* Trader local state
+
+			$State.Ware.Entries
+			 
+			=
+			 
+			5
+
+
+			* Ware entry members
+
+			$Ware.Entry.Ware
+			 
+			=
+			 
+			0
+
+			$Ware.Entry.Mode
+			 
+			=
+			 
+			1
+
+
+			* State contents
+
+			$State.Version
+			 
+			=
+			 
+			0
+
+			$State.Mission
+			 
+			=
+			 
+			1
+
+			$State.Dest
+			 
+			=
+			 
+			2
+
+			$State.Ware
+			 
+			=
+			 
+			3
+
+			$State.Price
+			 
+			=
+			 
+			4
+
+			$State.Ware.Entries
+			 
+			=
+			 
+			5
+
+			$State.Fleeing
+			 
+			=
+			 
+			6
+
+			$State.Balance
+			 
+			=
+			 
+			7
+
+			$State.Trade.Mode
+			 
+			=
+			 
+			8
+
+			$State.Tether.Sector
+			 
+			=
+			 
+			9
+
+			$State.Tether.Range
+			 
+			=
+			 
+			10
+
+			$State.Ver.Cmd
+			 
+			=
+			 
+			11
+
+			$State.Ver.Monitor
+			 
+			=
+			 
+			12
+
+
+			* Equipping config
+
+			$Config.Equip.Ver
+			 
+			=
+			 
+			0
+
+			$Config.Equip.Lasers
+			 
+			=
+			 
+			1
+
+			$Config.Equip.Shields
+			 
+			=
+			 
+			2
+
+			$Config.Equip.Missiles
+			 
+			=
+			 
+			3
+
+			$Config.Equip.Drones
+			 
+			=
+			 
+			4
+
+			$Config.Equip.DockingComputer
+			 
+			=
+			 
+			5
+
+			$Config.Equip.Jumpdrive
+			 
+			=
+			 
+			6
+
+			$Config.Equip.Triplex
+			 
+			=
+			 
+			7
+
+			$Config.Equip.Rudder
+			 
+			=
+			 
+			8
+
+			$Config.Equip.CargoLifeSupport
+			 
+			=
+			 
+			9
+
+			$Config.Equip.Duplex
+			 
+			=
+			 
+			10
+
+
+			* Text IDs
+
+			$Id.Menu.Root.Title
+			 
+			=
+			 
+			0
+
+			$Id.Menu.Root.Title.Homebased
+			 
+			=
+			 
+			1
+
+			$Id.Menu.Root.Title.Free
+			 
+			=
+			 
+			2
+
+			$Id.Menu.Root.Economy.Boost
+			 
+			=
+			 
+			5
+
+			$Id.Menu.Root.Tether.Sector
+			 
+			=
+			 
+			6
+
+			$Id.Menu.Root.Tether.Range
+			 
+			=
+			 
+			7
+
+			$Id.Menu.Root.Begin
+			 
+			=
+			 
+			10
+
+			$Id.Menu.Root.Balance.Red
+			 
+			=
+			 
+			15
+
+			$Id.Menu.Root.Balance.Green
+			 
+			=
+			 
+			16
+
+			$Id.Menu.Root.Balance.Collective.Red
+			 
+			=
+			 
+			17
+
+			$Id.Menu.Root.Balance.Collective.Green
+			 
+			=
+			 
+			18
+
+			$Id.Menu.Root.Settings
+			 
+			=
+			 
+			20
+
+			$Id.Menu.Root.Section.Broadcast
+			 
+			=
+			 
+			21
+
+			$Id.Menu.Root.Broadcast.Ship.Type
+			 
+			=
+			 
+			22
+
+			$Id.Menu.Root.Broadcast.Docked.Title
+			 
+			=
+			 
+			25
+
+			$Id.Menu.Root.Broadcast.Homebased
+			 
+			=
+			 
+			28
+
+			$Id.Menu.Root.Broadcast.Docked
+			 
+			=
+			 
+			29
+
+			$Id.Menu.Root.Uninstall
+			 
+			=
+			 
+			30
+
+			$Id.Menu.Root.Broadcast.Fleet
+			 
+			=
+			 
+			31
+
+			$Id.Menu.Root.Info.Enable.Free
+			 
+			=
+			 
+			49
+
+			$Id.Menu.Root.Info.Enable.Homebased
+			 
+			=
+			 
+			50
+
+			$Id.Menu.Root.Info.Update
+			 
+			=
+			 
+			51
+
+			$Id.Menu.Root.Info.Already
+			 
+			=
+			 
+			52
+
+			$Id.Menu.Root.Info.Homebased
+			 
+			=
+			 
+			53
+
+			$Id.Menu.Root.Info.Free
+			 
+			=
+			 
+			54
+
+			$Id.Menu.Root.Info.Broadcast
+			 
+			=
+			 
+			55
+
+			$Id.Menu.Root.Info.NoFit
+			 
+			=
+			 
+			56
+
+			$Id.Menu.Root.Mode
+			 
+			=
+			 
+			70
+
+			$Id.Menu.Root.Mode.Normal
+			 
+			=
+			 
+			71
+
+			$Id.Menu.Root.Mode.Economy
+			 
+			=
+			 
+			72
+
+			$Id.Menu.Root.Mode.Player
+			 
+			=
+			 
+			73
+
+			$Id.Menu.Root.Limits
+			 
+			=
+			 
+			80
+
+			$Id.Menu.Limits.Title
+			 
+			=
+			 
+			81
+
+			$Id.Menu.Limits.Desc1
+			 
+			=
+			 
+			82
+
+			$Id.Menu.Limits.Desc2
+			 
+			=
+			 
+			83
+
+			$Id.Menu.Limits.Desc3
+			 
+			=
+			 
+			84
+
+			$Id.Menu.Limits.Min.Perc
+			 
+			=
+			 
+			85
+
+			$Id.Menu.Limits.Max.Perc
+			 
+			=
+			 
+			86
+
+			$Id.Menu.Limits.Dockware.Limit
+			 
+			=
+			 
+			87
+
+			$Id.Menu.Limits.Ware
+			 
+			=
+			 
+			88
+
+			$Id.Menu.Root.Buy
+			 
+			=
+			 
+			120
+
+			$Id.Menu.Root.Sell
+			 
+			=
+			 
+			121
+
+			$Id.Menu.Root.NoTrade
+			 
+			=
+			 
+			122
+
+			$Id.Menu.Settings.Title
+			 
+			=
+			 
+			200
+
+			$Id.Menu.Settings.Auto.Rename
+			 
+			=
+			 
+			210
+
+			$Id.Menu.Settings.Blacklist
+			 
+			=
+			 
+			211
+
+			$Id.Menu.Settings.Trade.Threshold
+			 
+			=
+			 
+			212
+
+			$Id.Menu.Settings.Illegal.Wares
+			 
+			=
+			 
+			213
+
+			$Id.Menu.Settings.Alert.Sound
+			 
+			=
+			 
+			214
+
+			$Id.Menu.Settings.Section.Homebased
+			 
+			=
+			 
+			238
+
+			$Id.Menu.Settings.Section.Free
+			 
+			=
+			 
+			239
+
+			$Id.Menu.Settings.Section.Debugging
+			 
+			=
+			 
+			240
+
+			$Id.Menu.Settings.Logging.Enabled
+			 
+			=
+			 
+			241
+
+			$Id.Menu.Settings.Logging.Target
+			 
+			=
+			 
+			242
+
+			$Id.Menu.Settings.Logging.Verbosity
+			 
+			=
+			 
+			243
+
+			$Id.Menu.Settings.Logging.Target.All
+			 
+			=
+			 
+			250
+
+			$Id.Menu.Settings.Select.Logging.Target
+			 
+			=
+			 
+			260
+
+			$Id.Menu.Settings.Section.Equipment
+			 
+			=
+			 
+			270
+
+			$Id.Menu.Settings.Equipment.Lasers
+			 
+			=
+			 
+			271
+
+			$Id.Menu.Settings.Equipment.Shields
+			 
+			=
+			 
+			272
+
+			$Id.Menu.Settings.Equipment.Missiles
+			 
+			=
+			 
+			273
+
+			$Id.Menu.Settings.Equipment.Drones
+			 
+			=
+			 
+			274
+
+			$Id.Menu.Settings.Equipment.DockingComputer
+			 
+			=
+			 
+			275
+
+			$Id.Menu.Settings.Equipment.Jumpdrive
+			 
+			=
+			 
+			276
+
+			$Id.Menu.Settings.Equipment.Triplex
+			 
+			=
+			 
+			277
+
+			$Id.Menu.Settings.Equipment.Rudder
+			 
+			=
+			 
+			278
+
+			$Id.Menu.Settings.Equipment.CargoLifeSupport
+			 
+			=
+			 
+			279
+
+			$Id.Menu.Settings.Equipment.Duplex
+			 
+			=
+			 
+			280
+
+			$Id.Menu.Uninstall.Title
+			 
+			=
+			 
+			300
+
+			$Id.Menu.Uninstall.Abort
+			 
+			=
+			 
+			310
+
+			$Id.Menu.Uninstall.Uninstall
+			 
+			=
+			 
+			311
+
+			$Id.Menu.Uninstall.Info
+			 
+			=
+			 
+			320
+
+			$Id.Menu.Blacklist.Title
+			 
+			=
+			 
+			400
+
+			$Id.Menu.Blacklist.Add.Sector
+			 
+			=
+			 
+			410
+
+			$Id.Menu.Blacklist.Add.Pirate
+			 
+			=
+			 
+			411
+
+			$Id.Menu.Blacklist.Add.Non.Jumpable
+			 
+			=
+			 
+			412
+
+			$Id.Menu.Blacklist.Add.War
+			 
+			=
+			 
+			413
+
+			$Id.Menu.Blacklist.Clear
+			 
+			=
+			 
+			414
+
+			$Id.Menu.Blacklist.Add.Station
+			 
+			=
+			 
+			415
+
+			$Id.Menu.Blacklist.Add.Race
+			 
+			=
+			 
+			416
+
+			$Id.Menu.Blacklist.Sector
+			 
+			=
+			 
+			420
+
+			$Id.Menu.Blacklist.Race
+			 
+			=
+			 
+			421
+
+			$Id.Menu.Blacklist.Add.Message
+			 
+			=
+			 
+			430
+
+			$Id.Reset.Trader.Balance
+			 
+			=
+			 
+			500
+
+			$Id.Reset.Global.Balance
+			 
+			=
+			 
+			501
+
+			$Id.Off
+			 
+			=
+			 
+			1050
+
+			$Id.On
+			 
+			=
+			 
+			1051
+
+			$Id.Yes
+			 
+			=
+			 
+			1052
+
+			$Id.No
+			 
+			=
+			 
+			1053
+
+			$Id.None
+			 
+			=
+			 
+			1054
+
+			$Id.Any
+			 
+			=
+			 
+			1056
+
+			$Id.BluePrefix
+			 
+			=
+			 
+			1059
+
+			$Id.Freighters
+			 
+			=
+			 
+			1060
+
+			$Id.Version
+			 
+			=
+			 
+			2000
+
+
+			* Text
+
+			$Text.Menu.Root.Title
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Title
+
+			$Text.Menu.Root.Title.Homebased
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Title.Homebased
+
+			$Text.Menu.Root.Title.Free
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Title.Free
+
+			* $Text.Menu.Root.Tether.Sector = read text: page=$PageId id=$Id.Menu.Root.Tether.Sector
+
+			* $Text.Menu.Root.Tether.Range = read text: page=$PageId id=$Id.Menu.Root.Tether.Range
+
+			$Text.Menu.Root.Begin
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Begin
+
+			$Text.Menu.Root.Settings
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Settings
+
+			$Text.Menu.Root.Section.Broadcast
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Section.Broadcast
+
+			$Text.Menu.Root.Broadcast.Ship.Type
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Broadcast.Ship.Type
+
+			$Text.Menu.Root.Broadcast.Docked.Title
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Broadcast.Docked.Title
+
+			$Text.Menu.Root.Broadcast.Docked
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Broadcast.Docked
+
+			$Text.Menu.Root.Uninstall
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Uninstall
+
+			$Text.Menu.Root.Broadcast.Fleet
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Broadcast.Fleet
+
+			$Text.Menu.Root.Info.Enable.Free
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Id.Menu.Root.Info.Enable.Free
+			,
+			 
+			$Required.Ware
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Text.Menu.Root.Info.Enable.Homebased
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Id.Menu.Root.Info.Enable.Homebased
+			,
+			 
+			$Required.Ware
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Text.Menu.Root.Info.Update
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Info.Update
+
+			$Text.Menu.Root.Info.Already
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Info.Already
+
+			$Text.Menu.Root.Info.Homebased
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Info.Homebased
+
+			$Text.Menu.Root.Info.Free
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Info.Free
+
+			$Text.Menu.Root.Info.Broadcast
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Info.Broadcast
+
+			$Text.Menu.Root.Info.NoFit
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Info.NoFit
+
+			$Text.Menu.Root.Mode
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Mode
+
+			$Text.Menu.Root.Mode.Normal
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Mode.Normal
+
+			$Text.Menu.Root.Mode.Economy
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Mode.Economy
+
+			$Text.Menu.Root.Mode.Player
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Mode.Player
+
+			$Text.Menu.Root.Limits
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Limits
+
+			$Text.Menu.Limits.Title
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Limits.Title
+
+			$Text.Menu.Limits.Desc1
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Limits.Desc1
+
+			$Text.Menu.Limits.Desc2
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Limits.Desc2
+
+			$Text.Menu.Limits.Desc3
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Limits.Desc3
+
+			$Text.Menu.Limits.Min.Perc
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Limits.Min.Perc
+
+			$Text.Menu.Limits.Max.Perc
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Limits.Max.Perc
+
+			$Text.Menu.Limits.Dockware.Limit
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Limits.Dockware.Limit
+
+			$Text.Menu.Limits.Ware
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Limits.Ware
+
+			$Text.Menu.Root.Buy
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Buy
+
+			$Text.Menu.Root.Sell
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.Sell
+
+			$Text.Menu.Root.NoTrade
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Root.NoTrade
+
+			$Text.Menu.Settings.Title
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Title
+
+			$Text.Menu.Settings.Auto.Rename
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Auto.Rename
+
+			$Text.Menu.Settings.Blacklist
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Blacklist
+
+			$Text.Menu.Settings.Trade.Threshold
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Trade.Threshold
+
+			$Text.Menu.Settings.Illegal.Wares
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Illegal.Wares
+
+			$Text.Menu.Settings.Alert.Sound
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Alert.Sound
+
+			$Text.Menu.Settings.Section.Homebased
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Section.Homebased
+
+			$Text.Menu.Settings.Section.Free
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Section.Free
+
+			$Text.Menu.Settings.Section.Debugging
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Section.Debugging
+
+			$Text.Menu.Settings.Logging.Enabled
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Logging.Enabled
+
+			$Text.Menu.Settings.Logging.Verbosity
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Logging.Verbosity
+
+			$Text.Menu.Settings.Logging.Target.All
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Logging.Target.All
+
+			$Text.Menu.Settings.Select.Logging.Target
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Select.Logging.Target
+
+			$Text.Menu.Settings.Section.Equipment
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Section.Equipment
+
+			$Text.Menu.Settings.Equipment.Lasers
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Equipment.Lasers
+
+			$Text.Menu.Settings.Equipment.Shields
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Equipment.Shields
+
+			$Text.Menu.Settings.Equipment.Missiles
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Equipment.Missiles
+
+			$Text.Menu.Settings.Equipment.Drones
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Equipment.Drones
+
+			$Text.Menu.Settings.Equipment.DockingComputer
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Equipment.DockingComputer
+
+			$Text.Menu.Settings.Equipment.Jumpdrive
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Equipment.Jumpdrive
+
+			$Text.Menu.Settings.Equipment.Triplex
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Equipment.Triplex
+
+			$Text.Menu.Settings.Equipment.Rudder
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Equipment.Rudder
+
+			$Text.Menu.Settings.Equipment.CargoLifeSupport
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Equipment.CargoLifeSupport
+
+			$Text.Menu.Settings.Equipment.Duplex
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Settings.Equipment.Duplex
+
+			$Text.Menu.Uninstall.Title
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Uninstall.Title
+
+			$Text.Menu.Uninstall.Abort
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Uninstall.Abort
+
+			$Text.Menu.Uninstall.Uninstall
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Uninstall.Uninstall
+
+			$Text.Menu.Uninstall.Info
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Uninstall.Info
+
+			$Text.Menu.Blacklist.Title
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Blacklist.Title
+
+			$Text.Menu.Blacklist.Add.Sector
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Blacklist.Add.Sector
+
+			$Text.Menu.Blacklist.Add.Pirate
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Blacklist.Add.Pirate
+
+			$Text.Menu.Blacklist.Add.War
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Blacklist.Add.War
+
+			$Text.Menu.Blacklist.Add.Non.Jumpable
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Blacklist.Add.Non.Jumpable
+
+			$Text.Menu.Blacklist.Clear
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Blacklist.Clear
+
+			$Text.Menu.Blacklist.Add.Station
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Blacklist.Add.Station
+
+			$Text.Menu.Blacklist.Add.Race
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Blacklist.Add.Race
+
+			$Text.Menu.Blacklist.Sector
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Blacklist.Sector
+
+			$Text.Menu.Blacklist.Race
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Blacklist.Race
+
+			$Text.Menu.Blacklist.Add.Message
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Menu.Blacklist.Add.Message
+
+			$Text.Reset.Trader.Balance
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Reset.Trader.Balance
+
+			$Text.Reset.Global.Balance
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Reset.Global.Balance
+
+			$Text.Off
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Off
+
+			$Text.On
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.On
+
+			$Text.Yes
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Yes
+
+			$Text.No
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.No
+
+			$Text.None
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.None
+
+			$Text.Any
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Any
+
+			$Text.Freighters
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			$Id.Freighters
+
+			$Text.Version
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Id.Version
+			,
+			 
+			$Ver.Major
+			,
+			 
+			$Ver.Minor
+			,
+			 
+			$Ver.Patch
+			,
+			 
+			null
+			,
+			 
+			null
+
+
+			* Value selections
+
+			$Values.Menu.Root.Mode
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Text.Menu.Root.NoTrade
+			,
+			 
+			$Text.Menu.Root.Buy
+			,
+			 
+			$Text.Menu.Root.Sell
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Values.Trade.Mode
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Text.Menu.Root.Mode.Normal
+			,
+			 
+			$Text.Menu.Root.Mode.Economy
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Values.Off.On
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Text.Off
+			,
+			 
+			$Text.On
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Values.No.Yes
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Text.No
+			,
+			 
+			$Text.Yes
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Values.Logging.Verbosity
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Values.Trade.Thresholds
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+
+			$Values.Trade.Min
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$idx
+			 
+			=
+			 
+			0
+
+			while
+			 
+			$idx
+			 
+			<
+			 
+			17
+
+			$tmp
+			 
+			=
+			 
+			$idx
+			 
+			*
+			 
+			5
+
+			append
+			 
+			$tmp
+			 
+			to
+			 
+			array
+			 
+			$Values.Trade.Min
+
+			inc
+			 
+			$idx
+
+			end
+
+
+			$Values.Trade.Max
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$idx
+			 
+			=
+			 
+			4
+
+			while
+			 
+			$idx
+			 
+			<
+			 
+			21
+
+			$tmp
+			 
+			=
+			 
+			$idx
+			 
+			*
+			 
+			5
+
+			append
+			 
+			$tmp
+			 
+			to
+			 
+			array
+			 
+			$Values.Trade.Max
+
+			inc
+			 
+			$idx
+
+			end
+
+
+			* Library functions
+
+			$Lib.Uninstall
+			 
+			=
+			 
+			5
+
+			$Lib.Check.Cmd.Enabled
+			 
+			=
+			 
+			6
+
+			$Lib.Get.Non.Transportable.Wares
+			 
+			=
+			 
+			9
+
+			$Lib.BigInt.Format
+			 
+			=
+			 
+			34
+
+
+			* Generic library functions
+
+			$Lib.Generic.List.Fleets
+			 
+			=
+			 
+			6
+
+
+			* State functions
+
+			$Lib.State.Fetch
+			 
+			=
+			 
+			0
+
+			$Lib.State.Publish
+			 
+			=
+			 
+			1
+
+			$Lib.State.Reset.Config
+			 
+			=
+			 
+			2
+
+			$Lib.State.Update.Config
+			 
+			=
+			 
+			3
+
+
+			$Ware.Entries
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+
+			$idx
+			 
+			=
+			 
+			0
+
+			while
+			 
+			$idx
+			 
+			<
+			 
+			11
+
+			append
+			 
+			$idx
+			 
+			to
+			 
+			array
+			 
+			$Values.Logging.Verbosity
+
+			inc
+			 
+			$idx
+
+			end
+
+
+			$idx
+			 
+			=
+			 
+			0
+
+			while
+			 
+			$idx
+			 
+			<
+			 
+			100
+
+			append
+			 
+			$idx
+			 
+			to
+			 
+			array
+			 
+			$Values.Trade.Thresholds
+
+			$idx
+			 
+			=
+			 
+			$idx
+			 
+			+
+			 
+			5
+
+			end
+
+
+			$Null
+			 
+			=
+			 
+			null
+
+			$Cmd.Enabled
+			 
+			=
+			 
+			$Null
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Check.Cmd.Enabled
+			 
+			Arg1
+			=
+			$Trader
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+
+			* ****************************************
+
+			* Ship does not qualify to run OK Traders
+
+			* ****************************************
+
+			if
+			 
+			not
+			 
+			$Cmd.Enabled
+
+			gosub
+			 
+			Menu.Root.Basic
+			:
+
+			return
+			 
+			null
+
+			end
+
+
+			$Cmd.Already.Running
+			 
+			=
+			 
+			$Trader
+			->
+			 
+			is
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			on
+			 
+			stack
+			 
+			of
+			 
+			task
+			=
+			0
+
+			$State
+			 
+			=
+			 
+			$Trader
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Fetch
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			if
+			 
+			$Cmd.Already.Running
+
+			=
+			 
+			$Trader
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Update.Config
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			else
+
+			=
+			 
+			$Trader
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Reset.Config
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			end
+
+
+			$Homebase
+			 
+			=
+			 
+			$Trader
+			->
+			 
+			get
+			 
+			homebase
+
+
+			* ************
+
+			* Free trader
+
+			* ************
+
+			if
+			 
+			not
+			 
+			$Homebase
+			->
+			 
+			exists
+
+			gosub
+			 
+			Menu.Root.Free
+			:
+
+			return
+			 
+			null
+
+			end
+
+
+			* *****************
+
+			* Homebased trader
+
+			* *****************
+
+			$Non.Transportable.Wares
+			 
+			=
+			 
+			$Null
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Non.Transportable.Wares
+			 
+			Arg1
+			=
+			$Trader
+			 
+			Arg2
+			=
+			$Homebase
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Ware.Entries
+			 
+			=
+			 
+			$State
+			[
+			$State.Ware.Entries
+			]
+
+			gosub
+			 
+			Menu.Root.Homebased
+			:
+
+			return
+			 
+			null
+
+
+			* ******************************************************************************
+
+			* Menu.Root
+
+			*  Root level menu for homebase trading
+
+			* ******************************************************************************
+
+			Menu.Root.Homebased
+			:
+
+			$Text.Menu.Root.Broadcast.Homebased
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Id.Menu.Root.Broadcast.Homebased
+			,
+			 
+			$Homebase
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+
+			while
+			 
+			1
+
+			$Menu.Root
+			 
+			=
+			 
+			create
+			 
+			custom
+			 
+			menu
+			 
+			array
+
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Info.Homebased
+
+
+			if
+			 
+			$Cmd.Already.Running
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			' '
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Info.Update
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			' '
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Info.Broadcast
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			' '
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Info.NoFit
+
+			add
+			 
+			section
+			 
+			to
+			 
+			custom
+			 
+			menu
+			:
+			 
+			$Menu.Root
+
+			else
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			' '
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Info.Broadcast
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			' '
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Info.NoFit
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Begin
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Begin
+
+			add
+			 
+			section
+			 
+			to
+			 
+			custom
+			 
+			menu
+			:
+			 
+			$Menu.Root
+
+			end
+
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Ware.Entries
+
+			$Options
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			$idx
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+
+			$Ware.Entry
+			 
+			=
+			 
+			$Ware.Entries
+			[
+			$idx
+			]
+
+			$Ware
+			 
+			=
+			 
+			$Ware.Entry
+			[
+			$Ware.Entry.Ware
+			]
+
+			$Mode
+			 
+			=
+			 
+			$Ware.Entry
+			[
+			$Ware.Entry.Mode
+			]
+
+			$ReturnValue
+			 
+			=
+			 
+			$idx
+			 
+			+
+			 
+			10000
+
+
+			$Text.Ware
+			 
+			=
+			 
+			$Ware
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			find
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			:
+			 
+			$Non.Transportable.Wares
+
+			$Text.Ware
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Id.BluePrefix
+			,
+			 
+			$Ware
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+
+			$Opt
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Ware
+			,
+			 
+			$Values.Menu.Root.Mode
+			,
+			 
+			$Mode
+			,
+			 
+			$ReturnValue
+
+			append
+			 
+			$Opt
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+
+			$Options
+			[
+			$idx
+			]
+			 
+			=
+			 
+			$Opt
+
+			end
+
+
+			add
+			 
+			section
+			 
+			to
+			 
+			custom
+			 
+			menu
+			:
+			 
+			$Menu.Root
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Settings
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Settings
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Limits
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Limits
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Uninstall
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Uninstall
+
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			heading
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			title
+			=
+			$Text.Menu.Root.Section.Broadcast
+
+			$Options.Broadcast.Ship.Type
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Text.Any
+			,
+			 
+			$Text.Freighters
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Values.Broadcast.Ship.Type
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Root.Broadcast.Ship.Type
+			,
+			 
+			$Options.Broadcast.Ship.Type
+			,
+			 
+			0
+			,
+			 
+			$Id.Menu.Root.Broadcast.Ship.Type
+
+			append
+			 
+			$Values.Broadcast.Ship.Type
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Broadcast.Homebased
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Broadcast.Homebased
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Broadcast.Docked
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Broadcast.Docked
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Is.AP
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Broadcast.Fleet
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Broadcast.Fleet
+
+
+			$Menu.Result
+			 
+			=
+			 
+			open
+			 
+			custom
+			 
+			menu
+			:
+			 
+			title
+			=
+			$Text.Menu.Root.Title.Homebased
+			 
+			description
+			=
+			$Text.Version
+			 
+			option
+			 
+			array
+			=
+			$Menu.Root
+
+
+			* Save value selections
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Options
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Opt
+			 
+			=
+			 
+			$Options
+			[
+			$idx
+			]
+
+			if
+			 
+			$Opt
+
+			$Ware.Entry
+			 
+			=
+			 
+			$Ware.Entries
+			[
+			$idx
+			]
+
+			$Ware.Entry
+			[
+			$Ware.Entry.Mode
+			]
+			 
+			=
+			 
+			$Opt
+			[
+			3
+			]
+
+			end
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$Menu.Result
+			]
+			 
+			==
+			 
+			[DATATYPE_ARRAY]
+
+			break
+
+			$Menu.Selection
+			 
+			=
+			 
+			$Menu.Result
+			[
+			0
+			]
+
+			skip
+			 
+			if
+			 
+			$Menu.Selection
+			 
+			>
+			 
+			0
+
+			break
+
+
+			if
+			 
+			$Menu.Selection
+			 
+			==
+			 
+			$Id.Menu.Root.Begin
+
+			* The preload script return array must match args of the cmd script.
+
+			$Output
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			2
+
+			$Output
+			[
+			0
+			]
+			 
+			=
+			 
+			null
+
+			$Output
+			[
+			1
+			]
+			 
+			=
+			 
+			$Directive.Type.Start
+
+			return
+			 
+			$Output
+
+			else
+			 
+			if
+			 
+			$Menu.Selection
+			 
+			==
+			 
+			$Id.Menu.Root.Broadcast.Homebased
+
+			$Broadcast.Fleet
+			 
+			=
+			 
+			null
+
+			$Broadcast.Station
+			 
+			=
+			 
+			null
+
+			$Broadcast.Ship.Type
+			 
+			=
+			 
+			$Values.Broadcast.Ship.Type
+			[
+			3
+			]
+
+			gosub
+			 
+			Broadcast
+			:
+
+			else
+			 
+			if
+			 
+			$Menu.Selection
+			 
+			==
+			 
+			$Id.Menu.Root.Broadcast.Docked
+
+			$Broadcast.Fleet
+			 
+			=
+			 
+			null
+
+			$Broadcast.Station
+			 
+			=
+			 
+			$Trader
+			->
+			 
+			get
+			 
+			user
+			 
+			input
+			:
+			 
+			type
+			=
+			[Var/Station]
+			,
+			 
+			title
+			=
+			$Text.Menu.Root.Broadcast.Docked.Title
+
+			$Broadcast.Ship.Type
+			 
+			=
+			 
+			$Values.Broadcast.Ship.Type
+			[
+			3
+			]
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Broadcast.Station
+
+			gosub
+			 
+			Broadcast
+			:
+
+			else
+			 
+			if
+			 
+			$Menu.Selection
+			 
+			==
+			 
+			$Id.Menu.Root.Broadcast.Fleet
+
+			$Broadcast.Fleet
+			 
+			=
+			 
+			$Trader
+			->
+			 
+			get
+			 
+			user
+			 
+			input
+			:
+			 
+			type
+			=
+			[Var/Fleet Commander]
+			,
+			 
+			title
+			=
+			$Text.Menu.Root.Title
+
+			$Broadcast.Station
+			 
+			=
+			 
+			null
+
+			$Broadcast.Ship.Type
+			 
+			=
+			 
+			$Values.Broadcast.Ship.Type
+			[
+			3
+			]
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Broadcast.Fleet
+
+			gosub
+			 
+			Broadcast
+			:
+
+			else
+			 
+			if
+			 
+			$Menu.Selection
+			 
+			==
+			 
+			$Id.Menu.Root.Settings
+
+			gosub
+			 
+			Menu.Settings
+			:
+
+			else
+			 
+			if
+			 
+			$Menu.Selection
+			 
+			==
+			 
+			$Id.Menu.Root.Limits
+
+			gosub
+			 
+			Menu.Limits
+			:
+
+			else
+			 
+			if
+			 
+			$Menu.Selection
+			 
+			==
+			 
+			$Id.Menu.Root.Uninstall
+
+			gosub
+			 
+			Menu.Uninstall
+			:
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Menu.Root.Free
+
+			*  Root level menu for free trading
+
+			* ******************************************************************************
+
+			$Text.Balance
+			 
+			=
+			 
+			null
+
+			Menu.Root.Free
+			:
+
+
+			while
+			 
+			1
+
+			$Tether.Sector
+			 
+			=
+			 
+			$State
+			[
+			$State.Tether.Sector
+			]
+
+			$Tether.Range
+			 
+			=
+			 
+			$State
+			[
+			$State.Tether.Range
+			]
+
+
+			$Menu.Root
+			 
+			=
+			 
+			create
+			 
+			custom
+			 
+			menu
+			 
+			array
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Info.Free
+
+			if
+			 
+			$Cmd.Already.Running
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			' '
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Info.Already
+
+			gosub
+			 
+			Format.Trader.Balance
+			:
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Balance
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Balance.Green
+
+			gosub
+			 
+			Format.Global.Balance
+			:
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Balance
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Balance.Collective.Green
+
+
+			add
+			 
+			section
+			 
+			to
+			 
+			custom
+			 
+			menu
+			:
+			 
+			$Menu.Root
+
+			else
+
+			* Begin Trading
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Begin
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Begin
+
+			add
+			 
+			section
+			 
+			to
+			 
+			custom
+			 
+			menu
+			:
+			 
+			$Menu.Root
+
+			end
+
+
+			* Trade Mode
+
+			$Trade.Mode
+			 
+			=
+			 
+			$State
+			[
+			$State.Trade.Mode
+			]
+
+			$Select.Trade.Mode
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Root.Mode
+			,
+			 
+			$Values.Trade.Mode
+			,
+			 
+			$Trade.Mode
+			,
+			 
+			$Id.Menu.Root.Mode
+
+			append
+			 
+			$Select.Trade.Mode
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+
+
+			* Tether Sector
+
+			$Text.Tether.Sector
+			 
+			=
+			 
+			$Tether.Sector
+
+			skip
+			 
+			if
+			 
+			$Text.Tether.Sector
+
+			$Text.Tether.Sector
+			 
+			=
+			 
+			$Text.None
+
+			$Text.Tether.Sector
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Id.Menu.Root.Tether.Sector
+			,
+			 
+			$Text.Tether.Sector
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Tether.Sector
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Tether.Sector
+
+
+			* Tether Range
+
+			$Text.Tether.Range
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Id.Menu.Root.Tether.Range
+			,
+			 
+			$Tether.Range
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Tether.Range
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Tether.Range
+
+
+			add
+			 
+			section
+			 
+			to
+			 
+			custom
+			 
+			menu
+			:
+			 
+			$Menu.Root
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Settings
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Settings
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Uninstall
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Uninstall
+
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			heading
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			title
+			=
+			$Text.Menu.Root.Section.Broadcast
+
+			$Options.Broadcast.Ship.Type
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Text.Any
+			,
+			 
+			$Text.Freighters
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Values.Broadcast.Ship.Type
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Root.Broadcast.Ship.Type
+			,
+			 
+			$Options.Broadcast.Ship.Type
+			,
+			 
+			0
+			,
+			 
+			$Id.Menu.Root.Broadcast.Ship.Type
+
+			append
+			 
+			$Values.Broadcast.Ship.Type
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Broadcast.Docked
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Broadcast.Docked
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Is.AP
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Broadcast.Fleet
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Broadcast.Fleet
+
+
+			$Menu.Result
+			 
+			=
+			 
+			open
+			 
+			custom
+			 
+			menu
+			:
+			 
+			title
+			=
+			$Text.Menu.Root.Title.Free
+			 
+			description
+			=
+			$Text.Version
+			 
+			option
+			 
+			array
+			=
+			$Menu.Root
+
+
+			* Save off selection values
+
+			$State
+			[
+			$State.Trade.Mode
+			]
+			 
+			=
+			 
+			$Select.Trade.Mode
+			[
+			3
+			]
+
+
+			skip
+			 
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$Menu.Result
+			]
+			 
+			==
+			 
+			[DATATYPE_ARRAY]
+
+			break
+
+			$Menu.Result
+			 
+			=
+			 
+			$Menu.Result
+			[
+			0
+			]
+
+			skip
+			 
+			if
+			 
+			$Menu.Result
+			 
+			>
+			 
+			0
+
+			break
+
+
+			* if not is datatype[$Menu.Result] == [DATATYPE_ARRAY]
+
+			* $State[$State.Tether.Sector] = $Tether.Sector
+
+			* $State[$State.Tether.Range] = $Tether.Range
+
+			* break
+
+			* end
+
+
+			* if not $Menu.Result > 0
+
+			* $State[$State.Tether.Sector] = $Tether.Sector
+
+			* $State[$State.Tether.Range] = $Tether.Range
+
+			* break
+
+			* end
+
+
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Root.Begin
+
+			$State
+			[
+			$State.Tether.Sector
+			]
+			 
+			=
+			 
+			$Tether.Sector
+
+			$State
+			[
+			$State.Tether.Range
+			]
+			 
+			=
+			 
+			$Tether.Range
+
+			* The preload script return array must match args of the cmd script.
+
+			$Output
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			2
+
+			$Output
+			[
+			0
+			]
+			 
+			=
+			 
+			null
+
+			$Output
+			[
+			1
+			]
+			 
+			=
+			 
+			$Directive.Type.Start
+
+			return
+			 
+			$Output
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Root.Tether.Sector
+
+			$Sector
+			 
+			=
+			 
+			$Trader
+			->
+			 
+			get
+			 
+			sector
+
+			$Tether.Sector
+			 
+			=
+			 
+			$Null
+			->
+			 
+			get
+			 
+			user
+			 
+			input
+			 
+			type
+			=
+			[Var/Sector]
+			,
+			 
+			title
+			=
+			null
+			,
+			 
+			sector
+			=
+			$Sector
+
+			$State
+			[
+			$State.Tether.Sector
+			]
+			 
+			=
+			 
+			$Tether.Sector
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Root.Tether.Range
+
+			$Tether.Range
+			 
+			=
+			 
+			$Null
+			->
+			 
+			get
+			 
+			user
+			 
+			input
+			:
+			 
+			type
+			=
+			[Number]
+			,
+			 
+			title
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			$Tether.Range
+
+			$Tether.Range
+			 
+			=
+			 
+			0
+
+			$State
+			[
+			$State.Tether.Range
+			]
+			 
+			=
+			 
+			$Tether.Range
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Root.Settings
+
+			gosub
+			 
+			Menu.Settings
+			:
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Root.Uninstall
+
+			gosub
+			 
+			Menu.Uninstall
+			:
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Root.Balance.Green
+
+			$Menu.Confirm
+			 
+			=
+			 
+			create
+			 
+			custom
+			 
+			menu
+			 
+			array
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Confirm
+			:
+			 
+			text
+			=
+			$Text.No
+			 
+			returnvalue
+			=
+			$Id.No
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Confirm
+			:
+			 
+			text
+			=
+			$Text.Yes
+			 
+			returnvalue
+			=
+			$Id.Yes
+
+			$Menu.Confirm.Result
+			 
+			=
+			 
+			open
+			 
+			custom
+			 
+			menu
+			:
+			 
+			title
+			=
+			$Text.Reset.Trader.Balance
+			 
+			description
+			=
+			$Text.Version
+			 
+			option
+			 
+			array
+			=
+			$Menu.Confirm
+
+			if
+			 
+			$Menu.Confirm.Result
+			 
+			==
+			 
+			$Id.Yes
+
+			$tmp
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			0
+			,
+			 
+			0
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$State
+			[
+			$State.Balance
+			]
+			 
+			=
+			 
+			$tmp
+
+			end
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Root.Balance.Collective.Green
+
+			$Menu.Confirm
+			 
+			=
+			 
+			create
+			 
+			custom
+			 
+			menu
+			 
+			array
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Confirm
+			:
+			 
+			text
+			=
+			$Text.No
+			 
+			returnvalue
+			=
+			$Id.No
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Confirm
+			:
+			 
+			text
+			=
+			$Text.Yes
+			 
+			returnvalue
+			=
+			$Id.Yes
+
+			$Menu.Confirm.Result
+			 
+			=
+			 
+			open
+			 
+			custom
+			 
+			menu
+			:
+			 
+			title
+			=
+			$Text.Reset.Global.Balance
+			 
+			description
+			=
+			$Text.Version
+			 
+			option
+			 
+			array
+			=
+			$Menu.Confirm
+
+			if
+			 
+			$Menu.Confirm.Result
+			 
+			==
+			 
+			$Id.Yes
+
+			$tmp
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			0
+			,
+			 
+			0
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Config
+			[
+			$Config.Global.Balance
+			]
+			 
+			=
+			 
+			$tmp
+
+			end
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Root.Broadcast.Docked
+
+			$Broadcast.Fleet
+			 
+			=
+			 
+			null
+
+			$Broadcast.Station
+			 
+			=
+			 
+			$Trader
+			->
+			 
+			get
+			 
+			user
+			 
+			input
+			:
+			 
+			type
+			=
+			[Var/Station]
+			,
+			 
+			title
+			=
+			$Text.Menu.Root.Broadcast.Docked.Title
+
+			$Broadcast.Ship.Type
+			 
+			=
+			 
+			$Values.Broadcast.Ship.Type
+			[
+			3
+			]
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Broadcast.Station
+
+			gosub
+			 
+			Broadcast
+			:
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Root.Broadcast.Fleet
+
+			$Broadcast.Fleet
+			 
+			=
+			 
+			$Trader
+			->
+			 
+			get
+			 
+			user
+			 
+			input
+			:
+			 
+			type
+			=
+			[Var/Fleet Commander]
+			,
+			 
+			title
+			=
+			$Text.Menu.Root.Title
+
+			$Broadcast.Station
+			 
+			=
+			 
+			null
+
+			$Broadcast.Ship.Type
+			 
+			=
+			 
+			$Values.Broadcast.Ship.Type
+			[
+			3
+			]
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Broadcast.Fleet
+
+			gosub
+			 
+			Broadcast
+			:
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Menu.Root.Basic
+
+			*  Menu when cmd is not enabled. Shows only settings, uninstall and info
+
+			* ******************************************************************************
+
+			Menu.Root.Basic
+			:
+
+			while
+			 
+			1
+
+			* = wait 1 ms
+
+
+			$Menu.Root
+			 
+			=
+			 
+			create
+			 
+			custom
+			 
+			menu
+			 
+			array
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Info.Enable.Homebased
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Info.Enable.Free
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Settings
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Settings
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Root
+			:
+			 
+			text
+			=
+			$Text.Menu.Root.Uninstall
+			 
+			returnvalue
+			=
+			$Id.Menu.Root.Uninstall
+
+
+			$Menu.Result
+			 
+			=
+			 
+			open
+			 
+			custom
+			 
+			menu
+			:
+			 
+			title
+			=
+			$Text.Menu.Root.Title
+			 
+			description
+			=
+			$Text.Version
+			 
+			option
+			 
+			array
+			=
+			$Menu.Root
+
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			null
+			 
+			OR
+			 
+			$Menu.Result
+			 
+			==
+			 
+			-1
+
+			break
+
+			end
+
+
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Root.Settings
+
+			gosub
+			 
+			Menu.Settings
+			:
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Root.Uninstall
+
+			gosub
+			 
+			Menu.Uninstall
+			:
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Menu.Uninstall
+
+			* ******************************************************************************
+
+			Menu.Uninstall
+			:
+
+			$Menu.Uninstall
+			 
+			=
+			 
+			create
+			 
+			custom
+			 
+			menu
+			 
+			array
+
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Uninstall
+			:
+			 
+			text
+			=
+			$Text.Menu.Uninstall.Info
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Uninstall
+			:
+			 
+			text
+			=
+			$Text.Menu.Uninstall.Abort
+			 
+			returnvalue
+			=
+			$Id.Menu.Uninstall.Abort
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Uninstall
+			:
+			 
+			text
+			=
+			$Text.Menu.Uninstall.Uninstall
+			 
+			returnvalue
+			=
+			$Id.Menu.Uninstall.Uninstall
+
+
+			* = wait 1 ms
+
+			$Menu.Result
+			 
+			=
+			 
+			open
+			 
+			custom
+			 
+			menu
+			:
+			 
+			title
+			=
+			$Text.Menu.Uninstall.Title
+			 
+			description
+			=
+			$Text.Version
+			 
+			option
+			 
+			array
+			=
+			$Menu.Uninstall
+
+
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Uninstall.Uninstall
+
+			=
+			 
+			$Null
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Uninstall
+			 
+			Arg1
+			=
+			$Null
+			 
+			Arg2
+			=
+			$Null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			return
+			 
+			null
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Menu.Settings
+
+			* ******************************************************************************
+
+			Menu.Settings
+			:
+
+			while
+			 
+			[TRUE]
+
+			$Equip.Config
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Equip
+			]
+
+			$Menu.Settings
+			 
+			=
+			 
+			create
+			 
+			custom
+			 
+			menu
+			 
+			array
+
+
+			$default
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Auto.Rename
+			]
+
+			$values.auto.rename
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Auto.Rename
+			,
+			 
+			$Values.Off.On
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Auto.Rename
+
+			append
+			 
+			$values.auto.rename
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+			$default
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Alert.Sound
+			]
+
+			$values.alert.sound
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Alert.Sound
+			,
+			 
+			$Values.Off.On
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Alert.Sound
+
+			append
+			 
+			$values.alert.sound
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+			:
+			 
+			text
+			=
+			$Text.Menu.Settings.Blacklist
+			 
+			returnvalue
+			=
+			$Id.Menu.Settings.Blacklist
+
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			heading
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+			:
+			 
+			title
+			=
+			$Text.Menu.Settings.Section.Homebased
+
+			$default
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Trade.Threshold
+			]
+
+			$default
+			 
+			=
+			 
+			$default
+			 
+			/
+			 
+			5
+
+			$Values.Trade.Threshold
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Trade.Threshold
+			,
+			 
+			$Values.Trade.Thresholds
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Trade.Threshold
+
+			append
+			 
+			$Values.Trade.Threshold
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			heading
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+			:
+			 
+			title
+			=
+			$Text.Menu.Settings.Section.Free
+
+			$default
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Trade.Illegal.Wares
+			]
+
+			$values.trade.illegal.wares
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Illegal.Wares
+			,
+			 
+			$Values.Off.On
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Illegal.Wares
+
+			append
+			 
+			$values.trade.illegal.wares
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			heading
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+			:
+			 
+			title
+			=
+			$Text.Menu.Settings.Section.Equipment
+
+			$default
+			 
+			=
+			 
+			$Equip.Config
+			[
+			$Config.Equip.CargoLifeSupport
+			]
+
+			$values.equip.cargolifesupport
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Equipment.CargoLifeSupport
+			,
+			 
+			$Values.Off.On
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Equipment.CargoLifeSupport
+
+			append
+			 
+			$values.equip.cargolifesupport
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+			$default
+			 
+			=
+			 
+			$Equip.Config
+			[
+			$Config.Equip.DockingComputer
+			]
+
+			$values.equip.docking
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Equipment.DockingComputer
+			,
+			 
+			$Values.Off.On
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Equipment.DockingComputer
+
+			append
+			 
+			$values.equip.docking
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+			$default
+			 
+			=
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Drones
+			]
+
+			$values.equip.drones
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Equipment.Drones
+			,
+			 
+			$Values.Off.On
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Equipment.Drones
+
+			append
+			 
+			$values.equip.drones
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+			$default
+			 
+			=
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Duplex
+			]
+
+			$values.equip.duplex
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Equipment.Duplex
+			,
+			 
+			$Values.Off.On
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Equipment.Duplex
+
+			append
+			 
+			$values.equip.duplex
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+			$default
+			 
+			=
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Jumpdrive
+			]
+
+			$values.equip.jumpdrive
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Equipment.Jumpdrive
+			,
+			 
+			$Values.Off.On
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Equipment.Jumpdrive
+
+			append
+			 
+			$values.equip.jumpdrive
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+			$default
+			 
+			=
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Lasers
+			]
+
+			$values.equip.lasers
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Equipment.Lasers
+			,
+			 
+			$Values.Off.On
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Equipment.Lasers
+
+			append
+			 
+			$values.equip.lasers
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+			$default
+			 
+			=
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Missiles
+			]
+
+			$values.equip.missiles
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Equipment.Missiles
+			,
+			 
+			$Values.Off.On
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Equipment.Missiles
+
+			append
+			 
+			$values.equip.missiles
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+			$default
+			 
+			=
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Rudder
+			]
+
+			$values.equip.rudder
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Equipment.Rudder
+			,
+			 
+			$Values.Off.On
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Equipment.Rudder
+
+			append
+			 
+			$values.equip.rudder
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+			$default
+			 
+			=
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Shields
+			]
+
+			$values.equip.shields
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Equipment.Shields
+			,
+			 
+			$Values.Off.On
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Equipment.Shields
+
+			append
+			 
+			$values.equip.shields
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+			$default
+			 
+			=
+			 
+			$Equip.Config
+			[
+			$Config.Equip.Triplex
+			]
+
+			$values.equip.triplex
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Equipment.Triplex
+			,
+			 
+			$Values.Off.On
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Equipment.Triplex
+
+			append
+			 
+			$values.equip.triplex
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			heading
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+			:
+			 
+			title
+			=
+			$Text.Menu.Settings.Section.Debugging
+
+			$default
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			$values.debug.enabled
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Logging.Enabled
+			,
+			 
+			$Values.Off.On
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Logging.Enabled
+
+			append
+			 
+			$values.debug.enabled
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+
+			$default
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Debug.Verbosity
+			]
+
+			$values.debug.verbosity
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Settings.Logging.Verbosity
+			,
+			 
+			$Values.Logging.Verbosity
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Settings.Logging.Verbosity
+
+			append
+			 
+			$values.debug.verbosity
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+
+
+			$target
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Debug.Target
+			]
+
+			if
+			 
+			not
+			 
+			$target
+			->
+			 
+			exists
+
+			$target
+			 
+			=
+			 
+			null
+
+			$Config
+			[
+			$Config.Debug.Target
+			]
+			 
+			=
+			 
+			null
+
+			end
+
+			skip
+			 
+			if
+			 
+			$target
+
+			$target
+			 
+			=
+			 
+			$Text.Menu.Settings.Logging.Target.All
+
+			$text
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Id.Menu.Settings.Logging.Target
+			,
+			 
+			$target
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Settings
+			:
+			 
+			text
+			=
+			$text
+			 
+			returnvalue
+			=
+			$Id.Menu.Settings.Logging.Target
+
+
+			* = wait 1 ms
+
+			$Menu.Result
+			 
+			=
+			 
+			open
+			 
+			custom
+			 
+			menu
+			:
+			 
+			title
+			=
+			$Text.Menu.Settings.Title
+			 
+			description
+			=
+			$Text.Version
+			 
+			option
+			 
+			array
+			=
+			$Menu.Settings
+
+
+			* Save off selection values
+
+			$Config
+			[
+			$Config.Auto.Rename
+			]
+			 
+			=
+			 
+			$values.auto.rename
+			[
+			3
+			]
+
+			$Config
+			[
+			$Config.Alert.Sound
+			]
+			 
+			=
+			 
+			$values.alert.sound
+			[
+			3
+			]
+
+			$Config
+			[
+			$Config.Trade.Illegal.Wares
+			]
+			 
+			=
+			 
+			$values.trade.illegal.wares
+			[
+			3
+			]
+
+			$Equip.Config
+			[
+			$Config.Equip.Lasers
+			]
+			 
+			=
+			 
+			$values.equip.lasers
+			[
+			3
+			]
+
+			$Equip.Config
+			[
+			$Config.Equip.Shields
+			]
+			 
+			=
+			 
+			$values.equip.shields
+			[
+			3
+			]
+
+			$Equip.Config
+			[
+			$Config.Equip.Missiles
+			]
+			 
+			=
+			 
+			$values.equip.missiles
+			[
+			3
+			]
+
+			$Equip.Config
+			[
+			$Config.Equip.Drones
+			]
+			 
+			=
+			 
+			$values.equip.drones
+			[
+			3
+			]
+
+			$Equip.Config
+			[
+			$Config.Equip.DockingComputer
+			]
+			 
+			=
+			 
+			$values.equip.docking
+			[
+			3
+			]
+
+			$Equip.Config
+			[
+			$Config.Equip.Jumpdrive
+			]
+			 
+			=
+			 
+			$values.equip.jumpdrive
+			[
+			3
+			]
+
+			$Equip.Config
+			[
+			$Config.Equip.Triplex
+			]
+			 
+			=
+			 
+			$values.equip.triplex
+			[
+			3
+			]
+
+			$Equip.Config
+			[
+			$Config.Equip.Rudder
+			]
+			 
+			=
+			 
+			$values.equip.rudder
+			[
+			3
+			]
+
+			$Equip.Config
+			[
+			$Config.Equip.CargoLifeSupport
+			]
+			 
+			=
+			 
+			$values.equip.cargolifesupport
+			[
+			3
+			]
+
+			$Equip.Config
+			[
+			$Config.Equip.Duplex
+			]
+			 
+			=
+			 
+			$values.equip.duplex
+			[
+			3
+			]
+
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+			 
+			=
+			 
+			$values.debug.enabled
+			[
+			3
+			]
+
+			$Config
+			[
+			$Config.Debug.Verbosity
+			]
+			 
+			=
+			 
+			$values.debug.verbosity
+			[
+			3
+			]
+
+			$tmp
+			 
+			=
+			 
+			$Values.Trade.Threshold
+			[
+			3
+			]
+
+			$tmp
+			 
+			=
+			 
+			$tmp
+			 
+			*
+			 
+			5
+
+			$Config
+			[
+			$Config.Trade.Threshold
+			]
+			 
+			=
+			 
+			$tmp
+
+
+			skip
+			 
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$Menu.Result
+			]
+			 
+			==
+			 
+			[DATATYPE_ARRAY]
+
+			break
+
+
+			$Menu.Result
+			 
+			=
+			 
+			$Menu.Result
+			[
+			0
+			]
+
+			skip
+			 
+			if
+			 
+			$Menu.Result
+			 
+			>
+			 
+			0
+
+			break
+
+
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Settings.Logging.Target
+
+			$target
+			 
+			=
+			 
+			$Trader
+			->
+			 
+			get
+			 
+			user
+			 
+			input
+			:
+			 
+			type
+			=
+			[Var/Ship]
+			,
+			 
+			title
+			=
+			$Text.Menu.Settings.Select.Logging.Target
+
+			$Config
+			[
+			$Config.Debug.Target
+			]
+			 
+			=
+			 
+			$target
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Settings.Blacklist
+
+			gosub
+			 
+			Menu.Blacklist
+			:
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Menu.Blacklist
+
+			* ******************************************************************************
+
+			Menu.Blacklist
+			:
+
+			$Width
+			 
+			=
+			 
+			200
+
+
+			* Trim out the dead wood
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Blacklist
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Entry
+			 
+			=
+			 
+			$Blacklist
+			[
+			$idx
+			]
+
+			skip
+			 
+			if
+			 
+			$Entry
+			->
+			 
+			exists
+
+			remove
+			 
+			element
+			 
+			from
+			 
+			array
+			 
+			$Blacklist
+			 
+			at
+			 
+			index
+			 
+			$idx
+
+			end
+
+
+			while
+			 
+			1
+
+			* = wait 1 ms
+
+
+			$Menu.Blacklist
+			 
+			=
+			 
+			create
+			 
+			custom
+			 
+			menu
+			 
+			array
+
+			$Row
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			0
+			,
+			 
+			$Text.Menu.Blacklist.Sector
+			,
+			 
+			$Width
+			,
+			 
+			$Text.Menu.Blacklist.Race
+			,
+			 
+			null
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Blacklist
+			:
+			 
+			text
+			=
+			$Row
+			 
+			returnvalue
+			=
+			null
+
+			add
+			 
+			section
+			 
+			to
+			 
+			custom
+			 
+			menu
+			:
+			 
+			$Menu.Blacklist
+
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Blacklist
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Entry
+			 
+			=
+			 
+			$Blacklist
+			[
+			$idx
+			]
+
+			skip
+			 
+			if
+			 
+			$Entry
+			->
+			 
+			exists
+
+			continue
+
+
+			$Owner
+			 
+			=
+			 
+			$Entry
+			->
+			 
+			get
+			 
+			owner
+			 
+			race
+
+			$ReturnValue
+			 
+			=
+			 
+			$idx
+			 
+			+
+			 
+			10000
+
+			$Row
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			0
+			,
+			 
+			$Entry
+			,
+			 
+			$Width
+			,
+			 
+			$Owner
+			,
+			 
+			null
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Blacklist
+			:
+			 
+			text
+			=
+			$Row
+			 
+			returnvalue
+			=
+			$ReturnValue
+
+			end
+
+
+			add
+			 
+			section
+			 
+			to
+			 
+			custom
+			 
+			menu
+			:
+			 
+			$Menu.Blacklist
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Blacklist
+			:
+			 
+			text
+			=
+			$Text.Menu.Blacklist.Add.Sector
+			 
+			returnvalue
+			=
+			$Id.Menu.Blacklist.Add.Sector
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Blacklist
+			:
+			 
+			text
+			=
+			$Text.Menu.Blacklist.Add.Station
+			 
+			returnvalue
+			=
+			$Id.Menu.Blacklist.Add.Station
+
+			add
+			 
+			section
+			 
+			to
+			 
+			custom
+			 
+			menu
+			:
+			 
+			$Menu.Blacklist
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Blacklist
+			:
+			 
+			text
+			=
+			$Text.Menu.Blacklist.Add.Pirate
+			 
+			returnvalue
+			=
+			$Id.Menu.Blacklist.Add.Pirate
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Is.AP
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Blacklist
+			:
+			 
+			text
+			=
+			$Text.Menu.Blacklist.Add.War
+			 
+			returnvalue
+			=
+			$Id.Menu.Blacklist.Add.War
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Blacklist
+			:
+			 
+			text
+			=
+			$Text.Menu.Blacklist.Add.Non.Jumpable
+			 
+			returnvalue
+			=
+			$Id.Menu.Blacklist.Add.Non.Jumpable
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Blacklist
+			:
+			 
+			text
+			=
+			$Text.Menu.Blacklist.Add.Race
+			 
+			returnvalue
+			=
+			$Id.Menu.Blacklist.Add.Race
+
+			add
+			 
+			section
+			 
+			to
+			 
+			custom
+			 
+			menu
+			:
+			 
+			$Menu.Blacklist
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Blacklist
+			:
+			 
+			text
+			=
+			$Text.Menu.Blacklist.Clear
+			 
+			returnvalue
+			=
+			$Id.Menu.Blacklist.Clear
+
+
+			$Menu.Result
+			 
+			=
+			 
+			open
+			 
+			custom
+			 
+			info
+			 
+			menu
+			:
+			 
+			title
+			=
+			$Text.Menu.Blacklist.Title
+			 
+			description
+			=
+			$Text.Version
+			 
+			option
+			 
+			array
+			=
+			$Menu.Blacklist
+			 
+			maxoptions
+			=
+			0
+
+
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			null
+			 
+			OR
+			 
+			$Menu.Result
+			 
+			<=
+			 
+			0
+
+			break
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Blacklist.Add.Sector
+
+			$Entry
+			 
+			=
+			 
+			$Trader
+			->
+			 
+			get
+			 
+			user
+			 
+			input
+			:
+			 
+			type
+			=
+			[Var/Sector]
+			,
+			 
+			title
+			=
+			$Text.Menu.Blacklist.Add.Message
+
+			gosub
+			 
+			Add.Blacklist.Entry
+			:
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Blacklist.Add.Station
+
+			$Entry
+			 
+			=
+			 
+			$Trader
+			->
+			 
+			get
+			 
+			user
+			 
+			input
+			:
+			 
+			type
+			=
+			[Var/Station]
+			,
+			 
+			title
+			=
+			$Text.Menu.Blacklist.Add.Message
+
+			gosub
+			 
+			Add.Blacklist.Entry
+			:
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Blacklist.Add.War
+			 
+			OR
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Blacklist.Add.Pirate
+			 
+			OR
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Blacklist.Add.Non.Jumpable
+			 
+			OR
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Blacklist.Add.Race
+
+			$Race
+			 
+			=
+			 
+			[Pirates]
+
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Blacklist.Add.Race
+
+			$Race
+			 
+			=
+			 
+			$Trader
+			->
+			 
+			get
+			 
+			user
+			 
+			input
+			:
+			 
+			type
+			=
+			[Var/Race]
+			,
+			 
+			title
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			$Race
+
+			continue
+
+			end
+
+
+			$x
+			 
+			=
+			 
+			get
+			 
+			max
+			 
+			sectors
+			 
+			in
+			 
+			x
+			 
+			direction
+
+			while
+			 
+			$x
+
+			dec
+			 
+			$x
+
+
+			$y
+			 
+			=
+			 
+			get
+			 
+			max
+			 
+			sectors
+			 
+			in
+			 
+			y
+			 
+			direction
+
+			while
+			 
+			$y
+
+			dec
+			 
+			$y
+
+			$Sector
+			 
+			=
+			 
+			get
+			 
+			sector
+			 
+			from
+			 
+			universe
+			 
+			index
+			:
+			 
+			x
+			=
+			$x
+			,
+			 
+			y
+			=
+			$y
+
+			skip
+			 
+			if
+			 
+			$Sector
+
+			continue
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			find
+			 
+			$Sector
+			 
+			in
+			 
+			array
+			:
+			 
+			$Blacklist
+
+			continue
+
+
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Blacklist.Add.War
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Sector
+			->
+			 
+			get
+			 
+			WarObject
+			 
+			ID
+
+			append
+			 
+			$Sector
+			 
+			to
+			 
+			array
+			 
+			$Blacklist
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Blacklist.Add.Pirate
+			 
+			OR
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Blacklist.Add.Race
+
+			$Owner
+			 
+			=
+			 
+			$Sector
+			->
+			 
+			get
+			 
+			owner
+			 
+			race
+
+			skip
+			 
+			if
+			 
+			$Owner
+			 
+			!=
+			 
+			$Race
+
+			append
+			 
+			$Sector
+			 
+			to
+			 
+			array
+			 
+			$Blacklist
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Blacklist.Add.Non.Jumpable
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			find
+			 
+			gate
+			:
+			 
+			flags
+			=
+			[Find.JumpableGate]
+			,
+			 
+			refobj
+			=
+			$Sector
+			,
+			 
+			max
+			 
+			dist
+			=
+			null
+			,
+			 
+			refpos
+			=
+			null
+
+			continue
+
+			if
+			 
+			$Is.AP
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			find
+			 
+			ship
+			:
+			 
+			sector
+			=
+			$Sector
+			 
+			class
+			 
+			or
+			 
+			type
+			=
+			{Neutral Race Jump Beacon}
+			 
+			race
+			=
+			null
+			 
+			flags
+			=
+			null
+			 
+			refobj
+			=
+			null
+			 
+			maxdist
+			=
+			null
+			 
+			maxnum
+			=
+			null
+			 
+			refpos
+			=
+			null
+
+			continue
+
+			end
+
+			append
+			 
+			$Sector
+			 
+			to
+			 
+			array
+			 
+			$Blacklist
+
+			end
+
+			end
+
+			end
+
+
+			$Blacklist
+			 
+			=
+			 
+			sort
+			 
+			array
+			 
+			$Blacklist
+
+			$Blacklist
+			 
+			=
+			 
+			reverse
+			 
+			array
+			 
+			$Blacklist
+
+			$Config
+			[
+			$Config.Blacklist
+			]
+			 
+			=
+			 
+			$Blacklist
+
+			else
+			 
+			if
+			 
+			$Menu.Result
+			 
+			==
+			 
+			$Id.Menu.Blacklist.Clear
+
+			$Blacklist
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Config
+			[
+			$Config.Blacklist
+			]
+			 
+			=
+			 
+			$Blacklist
+
+			else
+
+			$idx
+			 
+			=
+			 
+			$Menu.Result
+			 
+			-
+			 
+			10000
+
+			gosub
+			 
+			Remove.Blacklist.Entry
+			:
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Add.Blacklist.Entry
+
+			* ******************************************************************************
+
+			Add.Blacklist.Entry
+			:
+
+			if
+			 
+			$Entry
+			->
+			 
+			exists
+
+			if
+			 
+			not
+			 
+			find
+			 
+			$Entry
+			 
+			in
+			 
+			array
+			:
+			 
+			$Blacklist
+
+			append
+			 
+			$Entry
+			 
+			to
+			 
+			array
+			 
+			$Blacklist
+
+			$Blacklist
+			 
+			=
+			 
+			sort
+			 
+			array
+			 
+			$Blacklist
+
+			$Blacklist
+			 
+			=
+			 
+			reverse
+			 
+			array
+			 
+			$Blacklist
+
+			$Config
+			[
+			$Config.Blacklist
+			]
+			 
+			=
+			 
+			$Blacklist
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Remove.Blacklist.Entry
+
+			* ******************************************************************************
+
+			Remove.Blacklist.Entry
+			:
+
+			$size
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Blacklist
+
+			dec
+			 
+			$size
+
+			skip
+			 
+			if
+			 
+			$idx
+			 
+			==
+			 
+			$size
+
+			$Blacklist
+			[
+			$idx
+			]
+			 
+			=
+			 
+			$Blacklist
+			[
+			$size
+			]
+
+			resize
+			 
+			array
+			 
+			$Blacklist
+			 
+			to
+			 
+			$size
+
+			$Blacklist
+			 
+			=
+			 
+			sort
+			 
+			array
+			 
+			$Blacklist
+
+			$Blacklist
+			 
+			=
+			 
+			reverse
+			 
+			array
+			 
+			$Blacklist
+
+			$Config
+			[
+			$Config.Blacklist
+			]
+			 
+			=
+			 
+			$Blacklist
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Format.Trader.Balance:
+
+			*  Format free trader balance text
+
+			* ******************************************************************************
+
+			Format.Trader.Balance
+			:
+
+			$Balance
+			 
+			=
+			 
+			$State
+			[
+			$State.Balance
+			]
+
+			$TextId.Red
+			 
+			=
+			 
+			$Id.Menu.Root.Balance.Red
+
+			$TextId.Green
+			 
+			=
+			 
+			$Id.Menu.Root.Balance.Green
+
+			gosub
+			 
+			Format.Balance
+			:
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Format.Trader.Balance:
+
+			*  Format global free trader balance text
+
+			* ******************************************************************************
+
+			Format.Global.Balance
+			:
+
+			$Balance
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Global.Balance
+			]
+
+			$TextId.Red
+			 
+			=
+			 
+			$Id.Menu.Root.Balance.Collective.Red
+
+			$TextId.Green
+			 
+			=
+			 
+			$Id.Menu.Root.Balance.Collective.Green
+
+			gosub
+			 
+			Format.Balance
+			:
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Format.Balance:
+
+			*  Common formatting routinefor trader balance
+
+			* ******************************************************************************
+
+			Format.Balance
+			:
+
+			if
+			 
+			is
+			 
+			datatype
+			[
+			$Balance
+			]
+			 
+			==
+			 
+			[DATATYPE_ARRAY]
+
+			$HI
+			 
+			=
+			 
+			$Balance
+			[
+			0
+			]
+
+			$LO
+			 
+			=
+			 
+			$Balance
+			[
+			1
+			]
+
+			$Negative
+			 
+			=
+			 
+			(
+			$HI
+			 
+			<
+			 
+			0
+			 
+			OR
+			 
+			$LO
+			 
+			<
+			 
+			0
+			)
+
+			else
+
+			$Negative
+			 
+			=
+			 
+			(
+			$Balance
+			 
+			<
+			 
+			0
+			)
+
+			end
+
+
+			$Text.Balance
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.BigInt.Format
+			 
+			Arg1
+			=
+			$Balance
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			$Negative
+
+			$Text.Balance
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$TextId.Red
+			,
+			 
+			$Text.Balance
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			else
+
+			$Text.Balance
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$TextId.Green
+			,
+			 
+			$Text.Balance
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Broadcast
+
+			* ******************************************************************************
+
+			Broadcast
+			:
+
+			* $Monitor.Task = $Config[$Config.Monitor.Task]
+
+			$Homebase
+			 
+			=
+			 
+			$Trader
+			->
+			 
+			get
+			 
+			homebase
+
+
+			if
+			 
+			$Broadcast.Station
+
+			$Ships
+			 
+			=
+			 
+			$Broadcast.Station
+			->
+			 
+			get
+			 
+			ship
+			 
+			array
+			 
+			from
+			 
+			sector
+			/
+			ship
+			/
+			station
+
+			else
+			 
+			if
+			 
+			$Broadcast.Fleet
+
+			skip
+			 
+			if
+			 
+			$Broadcast.Fleet
+			->
+			 
+			is
+			 
+			in
+			 
+			fleet
+
+			endsub
+
+			$Ships
+			 
+			=
+			 
+			$Broadcast.Fleet
+			->
+			 
+			get
+			 
+			fleet
+			 
+			ships
+			:
+			 
+			only
+			 
+			currently
+			 
+			with
+			 
+			fleet
+			:
+			 
+			[FALSE]
+
+			else
+			 
+			if
+			 
+			$Homebase
+
+			$Ships
+			 
+			=
+			 
+			$Homebase
+			->
+			 
+			get
+			 
+			owned
+			 
+			ships
+			:
+			 
+			class
+			/
+			type
+			=
+			[Moveable Ship]
+
+			else
+
+			endsub
+
+			end
+
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Ships
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ship
+			 
+			=
+			 
+			$Ships
+			[
+			$idx
+			]
+
+
+			skip
+			 
+			if
+			 
+			$Ship
+			->
+			 
+			exists
+
+			continue
+
+
+			skip
+			 
+			if
+			 
+			$Ship
+			 
+			!=
+			 
+			[PLAYERSHIP]
+
+			continue
+
+
+			$Owner
+			 
+			=
+			 
+			$Ship
+			->
+			 
+			get
+			 
+			owner
+			 
+			race
+
+			skip
+			 
+			if
+			 
+			$Owner
+			 
+			==
+			 
+			[Player]
+
+			continue
+
+
+			skip
+			 
+			if
+			 
+			$Null
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Check.Cmd.Enabled
+			 
+			Arg1
+			=
+			$Ship
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			continue
+
+
+			if
+			 
+			$Broadcast.Ship.Type
+
+			skip
+			 
+			if
+			 
+			$Ship
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Freighter]
+
+			continue
+
+			end
+
+
+			gosub
+			 
+			Broadcast.Ship
+			:
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Broadcast.Ship
+
+			* ******************************************************************************
+
+			Broadcast.Ship
+			:
+
+			$Ship.Homebase
+			 
+			=
+			 
+			$Ship
+			->
+			 
+			get
+			 
+			homebase
+
+
+			if
+			 
+			$Homebase
+			 
+			==
+			 
+			null
+
+			$Ship
+			->
+			 
+			set
+			 
+			homebase
+			 
+			to
+			 
+			null
+
+			else
+			 
+			if
+			 
+			$Homebase
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Station]
+
+			$Ship
+			->
+			 
+			set
+			 
+			homebase
+			 
+			to
+			 
+			$Homebase
+
+			else
+
+			endsub
+
+			end
+
+
+			$Ship.State
+			 
+			=
+			 
+			$Ship
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Fetch
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+
+			if
+			 
+			$Homebase
+
+			$Ware.Idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Ware.Entries
+
+			$Dupe.Ware.Entries
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			$Ware.Idx
+
+			$Ship.State
+			[
+			$State.Ware.Entries
+			]
+			 
+			=
+			 
+			$Dupe.Ware.Entries
+
+			while
+			 
+			$Ware.Idx
+
+			dec
+			 
+			$Ware.Idx
+
+			$Ware.Entry
+			 
+			=
+			 
+			$Ware.Entries
+			[
+			$Ware.Idx
+			]
+
+			$Dupe.Ware.Entry
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			2
+
+			$Dupe.Ware.Entries
+			[
+			$Ware.Idx
+			]
+			 
+			=
+			 
+			$Dupe.Ware.Entry
+
+			$Dupe.Ware.Entry
+			[
+			0
+			]
+			 
+			=
+			 
+			$Ware.Entry
+			[
+			0
+			]
+
+			$Dupe.Ware.Entry
+			[
+			1
+			]
+			 
+			=
+			 
+			$Ware.Entry
+			[
+			1
+			]
+
+			end
+
+			else
+
+			$Ship.State
+			[
+			$State.Trade.Mode
+			]
+			 
+			=
+			 
+			$State
+			[
+			$State.Trade.Mode
+			]
+
+			$Ship.State
+			[
+			$State.Tether.Sector
+			]
+			 
+			=
+			 
+			$State
+			[
+			$State.Tether.Sector
+			]
+
+			$Ship.State
+			[
+			$State.Tether.Range
+			]
+			 
+			=
+			 
+			$State
+			[
+			$State.Tether.Range
+			]
+
+			end
+
+
+			if
+			 
+			$Ship
+			->
+			 
+			is
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			on
+			 
+			stack
+			 
+			of
+			 
+			task
+			=
+			0
+
+			if
+			 
+			$Ship.Homebase
+			 
+			==
+			 
+			$Homebase
+
+			skip
+			 
+			if
+			 
+			$Ship.Homebase
+			 
+			==
+			 
+			$Homebase
+
+			=
+			 
+			$Ship
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.None
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+
+			$Ship
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			$Directive.Type.Resume
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			else
+
+			$Ship
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			$Directive.Type.Start
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			else
+
+			$Ship
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			$Directive.Type.Start
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			$Trader
+			 
+			!=
+			 
+			$Ship
+
+			$Cmd.Already.Running
+			 
+			=
+			 
+			1
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Menu.Limits
+
+			* ******************************************************************************
+
+			Menu.Limits
+			:
+
+
+			$C1
+			 
+			=
+			 
+			0
+
+			$C2
+			 
+			=
+			 
+			150
+
+			$C3
+			 
+			=
+			 
+			225
+
+			$C4
+			 
+			=
+			 
+			300
+
+
+			while
+			 
+			1
+
+			$Menu.Limits
+			 
+			=
+			 
+			create
+			 
+			custom
+			 
+			menu
+			 
+			array
+
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Limits
+			:
+			 
+			text
+			=
+			$Text.Menu.Limits.Desc1
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Limits
+			:
+			 
+			text
+			=
+			' '
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Limits
+			:
+			 
+			text
+			=
+			$Text.Menu.Limits.Desc2
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Limits
+			:
+			 
+			text
+			=
+			' '
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			info
+			 
+			line
+			 
+			to
+			 
+			array
+			 
+			$Menu.Limits
+			:
+			 
+			text
+			=
+			$Text.Menu.Limits.Desc3
+
+
+			* Header row
+
+			$Row
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$C1
+			,
+			 
+			$Text.Menu.Limits.Ware
+			,
+			 
+			$C2
+			,
+			 
+			$Text.Menu.Limits.Min.Perc
+			,
+			 
+			$C3
+
+			append
+			 
+			$Text.Menu.Limits.Max.Perc
+			 
+			to
+			 
+			array
+			 
+			$Row
+
+			append
+			 
+			$C4
+			 
+			to
+			 
+			array
+			 
+			$Row
+
+			append
+			 
+			$Text.Menu.Limits.Dockware.Limit
+			 
+			to
+			 
+			array
+			 
+			$Row
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Limits
+			:
+			 
+			text
+			=
+			$Row
+			 
+			returnvalue
+			=
+			null
+
+
+			$Station.Config
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Station.Config
+			 
+			Arg1
+			=
+			[HOMEBASE]
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Wares
+			 
+			=
+			 
+			$Station.Config
+			[
+			1
+			]
+
+			$Mins
+			 
+			=
+			 
+			$Station.Config
+			[
+			2
+			]
+
+			$Maxes
+			 
+			=
+			 
+			$Station.Config
+			[
+			3
+			]
+
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares
+
+			$Options
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			$idx
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+
+			$Ware
+			 
+			=
+			 
+			$Wares
+			[
+			$idx
+			]
+
+			$Min
+			 
+			=
+			 
+			$Mins
+			[
+			$idx
+			]
+
+			$Max
+			 
+			=
+			 
+			$Maxes
+			[
+			$idx
+			]
+
+			$ReturnValue
+			 
+			=
+			 
+			$idx
+			 
+			+
+			 
+			10000
+
+
+			$Text
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Id.BluePrefix
+			,
+			 
+			$Ware
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Row
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$C1
+			,
+			 
+			$Text
+			,
+			 
+			$C2
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$text
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			fmt
+			=
+			'%s'
+			,
+			 
+			$Min
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			append
+			 
+			$text
+			 
+			to
+			 
+			array
+			 
+			$Row
+
+			append
+			 
+			$C3
+			 
+			to
+			 
+			array
+			 
+			$Row
+
+			$text
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			fmt
+			=
+			'%s'
+			,
+			 
+			$Max
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			append
+			 
+			$text
+			 
+			to
+			 
+			array
+			 
+			$Row
+
+			append
+			 
+			$C4
+			 
+			to
+			 
+			array
+			 
+			$Row
+
+			$Dockware.Limit
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.config
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Config.Get.Dockware.Limit
+			 
+			Arg1
+			=
+			[HOMEBASE]
+			 
+			Arg2
+			=
+			$Ware
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			$Dockware.Limit
+			 
+			!=
+			 
+			null
+
+			$Dockware.Limit
+			 
+			=
+			 
+			'-'
+
+
+			$text
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			fmt
+			=
+			'%s'
+			,
+			 
+			$Dockware.Limit
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			append
+			 
+			$text
+			 
+			to
+			 
+			array
+			 
+			$Row
+
+
+			add
+			 
+			custom
+			 
+			menu
+			 
+			item
+			 
+			to
+			 
+			array
+			 
+			$Menu.Limits
+			:
+			 
+			text
+			=
+			$Row
+			 
+			returnvalue
+			=
+			$ReturnValue
+
+			end
+
+
+			$rc
+			 
+			=
+			 
+			open
+			 
+			custom
+			 
+			info
+			 
+			menu
+			:
+			 
+			title
+			=
+			$Text.Menu.Limits.Title
+			 
+			description
+			=
+			$Text.Version
+			 
+			option
+			 
+			array
+			=
+			$Menu.Limits
+			 
+			maxoptions
+			=
+			0
+
+
+			if
+			 
+			$rc
+			 
+			==
+			 
+			-1
+			 
+			OR
+			 
+			$rc
+			 
+			==
+			 
+			null
+
+			endsub
+
+			end
+
+
+			$rc
+			 
+			=
+			 
+			$rc
+			 
+			-
+			 
+			10000
+
+
+			$Menu.Limits.Ware
+			 
+			=
+			 
+			create
+			 
+			custom
+			 
+			menu
+			 
+			array
+
+
+			$default
+			 
+			=
+			 
+			$Mins
+			[
+			$rc
+			]
+
+			$default
+			 
+			=
+			 
+			$default
+			 
+			/
+			 
+			5
+
+			$Values.Min
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Limits.Min.Perc
+			,
+			 
+			$Values.Trade.Min
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Limits.Min.Perc
+
+			append
+			 
+			$Values.Min
+			 
+			to
+			 
+			array
+			 
+			$Menu.Limits.Ware
+
+
+			$default
+			 
+			=
+			 
+			$Maxes
+			[
+			$rc
+			]
+
+			$default
+			 
+			=
+			 
+			(
+			$default
+			 
+			/
+			 
+			5
+			)
+			 
+			-
+			 
+			4
+
+			$Values.Max
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			-4
+			,
+			 
+			$Text.Menu.Limits.Max.Perc
+			,
+			 
+			$Values.Trade.Max
+			,
+			 
+			$default
+			,
+			 
+			$Id.Menu.Limits.Max.Perc
+
+			append
+			 
+			$Values.Max
+			 
+			to
+			 
+			array
+			 
+			$Menu.Limits.Ware
+
+
+			$Ware
+			 
+			=
+			 
+			$Wares
+			[
+			$rc
+			]
+
+			=
+			 
+			open
+			 
+			custom
+			 
+			menu
+			:
+			 
+			title
+			=
+			$Ware
+			 
+			description
+			=
+			$Text.Version
+			 
+			option
+			 
+			array
+			=
+			$Menu.Limits.Ware
+
+
+			$tmp
+			 
+			=
+			 
+			$Values.Min
+			[
+			3
+			]
+
+			$tmp
+			 
+			=
+			 
+			$tmp
+			 
+			*
+			 
+			5
+
+			$Mins
+			[
+			$rc
+			]
+			 
+			=
+			 
+			$tmp
+
+
+			$tmp
+			 
+			=
+			 
+			$Values.Max
+			[
+			3
+			]
+
+			$tmp
+			 
+			=
+			 
+			(
+			$tmp
+			 
+			+
+			 
+			4
+			)
+			 
+			*
+			 
+			5
+
+			$Maxes
+			[
+			$rc
+			]
+			 
+			=
+			 
+			$tmp
+
+
+			end
+
+			endsub
+

--- a/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.monitor.x3s
+++ b/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.monitor.x3s
@@ -1,0 +1,5775 @@
+#name: glen.trade.ok.monitor
+#lang: 44
+#origin_mod: OKTraders1_7_1
+#source: mods/OKTraders1_7_1/scripts/glen.trade.ok.monitor.xml
+
+
+			* ******************************************************************************
+
+			* OK Trade
+
+			*  Scans for trouble and changes mission accordingly
+
+			* ******************************************************************************
+
+
+			$Comp
+			 
+			=
+			 
+			'Monitor'
+
+
+			$Config
+			 
+			=
+			 
+			get
+			 
+			global
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+
+			skip
+			 
+			if
+			 
+			$Config
+
+			return
+			 
+			null
+
+
+			* Text IDs
+
+			$Text.Attacked.Missile
+			 
+			=
+			 
+			1200
+
+			$Text.Attacked.Attacker
+			 
+			=
+			 
+			1201
+
+			$Text.Attacked.Targetted
+			 
+			=
+			 
+			1202
+
+
+			* Global settings
+
+			$Config.Ver.Internal
+			 
+			=
+			 
+			3
+
+			$Config.PageId
+			 
+			=
+			 
+			4
+
+			$Config.Debug.Enabled
+			 
+			=
+			 
+			5
+
+			$Config.Alert.Sound
+			 
+			=
+			 
+			21
+
+
+			* State contents
+
+			$State.Version
+			 
+			=
+			 
+			0
+
+			$State.Mission
+			 
+			=
+			 
+			1
+
+			$State.Dest
+			 
+			=
+			 
+			2
+
+			$State.Ware
+			 
+			=
+			 
+			3
+
+			$State.Price
+			 
+			=
+			 
+			4
+
+			$State.Ware.Entries
+			 
+			=
+			 
+			5
+
+			$State.Fleeing
+			 
+			=
+			 
+			6
+
+			$State.Balance
+			 
+			=
+			 
+			7
+
+			$State.Tether.Sector
+			 
+			=
+			 
+			9
+
+			$State.Tether.Range
+			 
+			=
+			 
+			10
+
+			$State.Ver.Cmd
+			 
+			=
+			 
+			11
+
+			$State.Ver.Monitor
+			 
+			=
+			 
+			12
+
+			$State.Dest2
+			 
+			=
+			 
+			16
+
+
+			* Library functions
+
+			$Lib.Restart.Cmd
+			 
+			=
+			 
+			1
+
+			$Lib.Can.Trade.At
+			 
+			=
+			 
+			7
+
+			$Lib.Can.Trade.Ware
+			 
+			=
+			 
+			8
+
+			$Lib.Restart.Monitor
+			 
+			=
+			 
+			15
+
+			$Lib.Find.Station
+			 
+			=
+			 
+			16
+
+			$Lib.Get.Needs.Refuel
+			 
+			=
+			 
+			26
+
+			$Lib.Get.Refuel.Dest
+			 
+			=
+			 
+			27
+
+			$Lib.Get.Fleeing.Sector
+			 
+			=
+			 
+			28
+
+			$Lib.Get.Threats
+			 
+			=
+			 
+			32
+
+			$Lib.Check.Dest2
+			 
+			=
+			 
+			37
+
+
+			$Lib.Generic.Clone.Array
+			 
+			=
+			 
+			3
+
+
+			* Action functions
+
+			$Cmd.Launch.Countermeasures
+			 
+			=
+			 
+			8
+
+
+			* State functions
+
+			$Lib.State.Fetch
+			 
+			=
+			 
+			0
+
+			$Lib.State.Publish
+			 
+			=
+			 
+			1
+
+			$Lib.State.Get.Excludes
+			 
+			=
+			 
+			4
+
+
+			* Ware entry members
+
+			$Ware.Entry.Ware
+			 
+			=
+			 
+			0
+
+			$Ware.Entry.Mode
+			 
+			=
+			 
+			1
+
+
+			* Mission types. Maps from Ware.Entry.Mode
+
+			$Mission.Type.None
+			 
+			=
+			 
+			0
+
+			$Mission.Type.Buy
+			 
+			=
+			 
+			1
+
+			$Mission.Type.Sell
+			 
+			=
+			 
+			2
+
+			$Mission.Type.Move.Station
+			 
+			=
+			 
+			3
+
+
+			* Find flags
+
+			$Find.Ignore.Competition
+			 
+			=
+			 
+			1
+
+			$Find.Force.Best.Price
+			 
+			=
+			 
+			2
+
+
+			* Whether the cmd script should resume an existing mission
+
+			$Directive.Type.Start
+			 
+			=
+			 
+			0
+
+			$Directive.Type.Resume
+			 
+			=
+			 
+			1
+
+
+			* Defined to avoid warnings, compiler doesn't follow gosubs
+
+			$Mission.Type
+			 
+			=
+			 
+			$Mission.Type.None
+
+			$Mission.Dest
+			 
+			=
+			 
+			null
+
+			$Mission.Ware
+			 
+			=
+			 
+			null
+
+			$Mission.Price
+			 
+			=
+			 
+			null
+
+			$Ware.Entries
+			 
+			=
+			 
+			null
+
+			$rc
+			 
+			=
+			 
+			0
+
+
+			$Ver.Internal
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			$PageId
+			 
+			=
+			 
+			$Config
+			[
+			$Config.PageId
+			]
+
+			$Null
+			 
+			=
+			 
+			null
+
+			$State
+			 
+			=
+			 
+			null
+
+			$Fleeing
+			 
+			=
+			 
+			null
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Start: Version=%s'
+			 
+			arg1
+			=
+			$Ver.Internal
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			gosub
+			 
+			State.Get
+			:
+
+			$State
+			[
+			$State.Ver.Monitor
+			]
+			 
+			=
+			 
+			$Ver.Internal
+
+
+			* ******************************************************************************
+
+			* Main loop
+
+			* ******************************************************************************
+
+			while
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Monitor: Environment=%s'
+			 
+			arg1
+			=
+			[ENVIRONMENT]
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			is
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			on
+			 
+			stack
+			 
+			of
+			 
+			task
+			=
+			0
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Terminating monitor; cmd script not running'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			return
+			 
+			null
+
+			end
+
+
+			$Ver.Global
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			if
+			 
+			$Ver.Internal
+			 
+			!=
+			 
+			$Ver.Global
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Restarting monitor; global version %s differs from script version %s.'
+			 
+			arg1
+			=
+			$Ver.Global
+			 
+			arg2
+			=
+			$Ver.Internal
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			START
+			 
+			$Null
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Restart.Monitor
+			 
+			Arg1
+			=
+			[THIS]
+			 
+			Arg2
+			=
+			200
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			return
+			 
+			null
+
+			end
+
+
+			gosub
+			 
+			State.Get
+			:
+
+			$Ver.Cmd
+			 
+			=
+			 
+			$State
+			[
+			$State.Ver.Cmd
+			]
+
+
+			if
+			 
+			$Ver.Cmd
+			 
+			!=
+			 
+			$Ver.Global
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Restarting cmd script; global version %s differs from script version %s'
+			 
+			arg1
+			=
+			$Ver.Global
+			 
+			arg2
+			=
+			$Ver.Cmd
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			[THIS]
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			$Directive.Type.Resume
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			=
+			 
+			wait
+			 
+			randomly
+			 
+			from
+			 
+			500
+			 
+			to
+			 
+			1000
+			 
+			ms
+
+			continue
+
+			end
+
+
+			* If no longer in the sector we're fleeing then clear the state
+
+			if
+			 
+			$Fleeing
+			 
+			AND
+			 
+			$Fleeing
+			 
+			!=
+			 
+			[SECTOR]
+
+			$Fleeing
+			 
+			=
+			 
+			null
+
+			$State
+			[
+			$State.Fleeing
+			]
+			 
+			=
+			 
+			null
+
+			end
+
+
+			gosub
+			 
+			Check.DockingComputer
+			:
+
+			gosub
+			 
+			Check.Should.Sleep
+			:
+
+			if
+			 
+			$rc
+
+			=
+			 
+			wait
+			 
+			randomly
+			 
+			from
+			 
+			5000
+			 
+			to
+			 
+			10000
+			 
+			ms
+
+			continue
+
+			end
+
+
+			if
+			 
+			$State
+			[
+			$State.Fleeing
+			]
+
+			$Threats
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Threats
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Threats
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Cmd.Launch.Countermeasures
+			 
+			Arg1
+			=
+			$Threats
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			else
+
+			gosub
+			 
+			Check.Threat
+			:
+
+			if
+			 
+			$Threats
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.action
+			 
+			:
+			 
+			Func
+			=
+			$Cmd.Launch.Countermeasures
+			 
+			Arg1
+			=
+			$Threats
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			=
+			 
+			wait
+			 
+			randomly
+			 
+			from
+			 
+			3000
+			 
+			to
+			 
+			5000
+			 
+			ms
+
+			continue
+
+			end
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			[DOCKEDAT]
+
+			gosub
+			 
+			Check.Mission
+			:
+
+
+			=
+			 
+			wait
+			 
+			randomly
+			 
+			from
+			 
+			4000
+			 
+			to
+			 
+			8000
+			 
+			ms
+
+			end
+
+
+			* ******************************************************************************
+
+			* State.Get:
+
+			*  Read state from local variable
+
+			* ******************************************************************************
+
+			State.Get
+			:
+
+			$State
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Fetch
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+
+			$Mission.Type
+			 
+			=
+			 
+			$State
+			[
+			$State.Mission
+			]
+
+			$Mission.Dest
+			 
+			=
+			 
+			$State
+			[
+			$State.Dest
+			]
+
+			$Mission.Dest2
+			 
+			=
+			 
+			$State
+			[
+			$State.Dest2
+			]
+
+			$Mission.Ware
+			 
+			=
+			 
+			$State
+			[
+			$State.Ware
+			]
+
+			$Mission.Price
+			 
+			=
+			 
+			$State
+			[
+			$State.Price
+			]
+
+			$Ware.Entries
+			 
+			=
+			 
+			$State
+			[
+			$State.Ware.Entries
+			]
+
+			$Fleeing
+			 
+			=
+			 
+			$State
+			[
+			$State.Fleeing
+			]
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Check.Threat:
+
+			*  Scan sector for threats to this ship
+
+			* ******************************************************************************
+
+			Check.Threat
+			:
+
+			$Threats
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Threats
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			$Threats
+
+			$My.Name
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			name
+
+			$My.Id
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			ID
+			 
+			code
+
+			$Missiles
+			 
+			=
+			 
+			$Threats
+			[
+			1
+			]
+
+			$Enemies
+			 
+			=
+			 
+			$Threats
+			[
+			2
+			]
+
+
+			while
+			 
+			1
+
+			if
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Missiles
+
+			$Msg
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Text.Attacked.Missile
+			,
+			 
+			$My.Name
+			,
+			 
+			$My.Id
+			,
+			 
+			[SECTOR]
+			,
+			 
+			null
+			,
+			 
+			null
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Check.Threat: Incoming missile'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			if
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Enemies
+
+			$Enemy
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			attacker
+
+			if
+			 
+			$Enemy
+
+			if
+			 
+			find
+			 
+			$Enemy
+			 
+			in
+			 
+			array
+			:
+			 
+			$Enemies
+
+			$Their.Name
+			 
+			=
+			 
+			$Enemy
+			->
+			 
+			get
+			 
+			name
+
+			$Msg
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Text.Attacked.Attacker
+			,
+			 
+			$My.Name
+			,
+			 
+			$My.Id
+			,
+			 
+			$Their.Name
+			,
+			 
+			[SECTOR]
+			,
+			 
+			null
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Check.Threat: Attack target of %s'
+			 
+			arg1
+			=
+			$Enemy
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+
+			$Enemy
+			 
+			=
+			 
+			$Enemies
+			[
+			0
+			]
+
+			$Their.Name
+			 
+			=
+			 
+			$Enemy
+			->
+			 
+			get
+			 
+			name
+
+			$Msg
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Text.Attacked.Targetted
+			,
+			 
+			$My.Name
+			,
+			 
+			$My.Id
+			,
+			 
+			$Their.Name
+			,
+			 
+			[SECTOR]
+			,
+			 
+			null
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Check.Threat: Command target of %s'
+			 
+			arg1
+			=
+			$Enemy
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+
+			break
+
+			end
+
+
+			if
+			 
+			$Config
+			[
+			$Config.Alert.Sound
+			]
+
+			play
+			 
+			sample
+			 
+			972
+
+			end
+
+			display
+			 
+			subtitle
+			 
+			text
+			:
+			 
+			text
+			=
+			$Msg
+			 
+			duration
+			=
+			6000
+			 
+			ms
+
+			$State
+			[
+			$State.Fleeing
+			]
+			 
+			=
+			 
+			[SECTOR]
+
+
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Sell
+			 
+			OR
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+			gosub
+			 
+			Reroute.Trade
+			:
+
+			else
+
+			gosub
+			 
+			Flee
+			:
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Check.Should.Sleep:
+
+			*  The monitor task should sleep when docked etc
+
+			* ******************************************************************************
+
+			Check.Should.Sleep
+			:
+
+			$rc
+			 
+			=
+			 
+			1
+
+			while
+			 
+			1
+
+			if
+			 
+			[THIS]
+			->
+			 
+			is
+			 
+			docked
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Check.Should.Sleep: docked'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			if
+			 
+			[THIS]
+			->
+			 
+			is
+			 
+			starting
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Check.Should.Sleep: launching'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			if
+			 
+			[THIS]
+			->
+			 
+			is
+			 
+			landing
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Check.Should.Sleep: landing'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			$rc
+			 
+			=
+			 
+			0
+
+			break
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Stop.And.Think:
+
+			*  Set the ship to action type none
+
+			* ******************************************************************************
+
+			Stop.And.Think
+			:
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Stop.And.Think: clearing mission state and restarting'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.None
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			[THIS]
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			$Ware.Entries
+			 
+			arg2
+			=
+			$Directive.Type.Resume
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Flee
+
+			* ******************************************************************************
+
+			Flee
+			:
+
+			while
+			 
+			1
+
+			$Fleeing.Sector
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Fleeing.Sector
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			$Fleeing.Sector
+			 
+			==
+			 
+			[SECTOR]
+
+			break
+
+
+			* Move to nearest fuel outside of sector
+
+			$Station
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Refuel.Dest
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			$Station
+			->
+			 
+			exists
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Flee: moving to %s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.Move.Station
+			 
+			Arg2
+			=
+			$Station
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			[THIS]
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			$Ware.Entries
+			 
+			arg2
+			=
+			$Directive.Type.Resume
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			* Move home
+
+			if
+			 
+			[HOMEBASE]
+
+			$Homebase.Sector
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			sector
+
+			if
+			 
+			$Homebase.Sector
+			 
+			!=
+			 
+			$Fleeing.Sector
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Flee: moving to homebase'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.Move.Station
+			 
+			Arg2
+			=
+			[HOMEBASE]
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			[THIS]
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			$Ware.Entries
+			 
+			arg2
+			=
+			$Directive.Type.Resume
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+
+			* Try for a short range jump out of the sector
+
+			$Flags
+			 
+			=
+			 
+			[Find.Random]
+			 
+			|
+			 
+			[Find.Known]
+			 
+			|
+			 
+			[Find.DockingAllowed]
+			 
+			|
+			 
+			[Find.ExactJumps]
+
+			$Station
+			 
+			=
+			 
+			find
+			 
+			station
+			 
+			in
+			 
+			galaxy
+			:
+			 
+			startsector
+			=
+			[SECTOR]
+			 
+			class
+			 
+			or
+			 
+			type
+			=
+			null
+			 
+			race
+			=
+			null
+			 
+			flags
+			=
+			$Flags
+			 
+			refobj
+			=
+			[THIS]
+			 
+			serial
+			=
+			null
+			 
+			max.jumps
+			=
+			1
+
+			if
+			 
+			not
+			 
+			$Station
+
+			* Find any dockable station within jumprange
+
+			$Fuel
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Energy Cells}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			$Fuel.Unit.Jump
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			needed
+			 
+			jump
+			 
+			drive
+			 
+			energy
+			 
+			for
+			 
+			jump
+			 
+			to
+			 
+			sector
+			 
+			[SECTOR]
+
+			$Range
+			 
+			=
+			 
+			0
+
+			if
+			 
+			$Fuel.Unit.Jump
+
+			$Range
+			 
+			=
+			 
+			(
+			$Fuel
+			 
+			/
+			 
+			$Fuel.Unit.Jump
+			)
+			 
+			-
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			$Range
+			 
+			>
+			 
+			0
+
+			$Range
+			 
+			=
+			 
+			0
+
+			end
+
+			$Flags
+			 
+			=
+			 
+			[Find.Random]
+			 
+			|
+			 
+			[Find.Known]
+			 
+			|
+			 
+			[Find.DockingAllowed]
+
+			$Station
+			 
+			=
+			 
+			find
+			 
+			station
+			 
+			in
+			 
+			galaxy
+			:
+			 
+			startsector
+			=
+			[SECTOR]
+			 
+			class
+			 
+			or
+			 
+			type
+			=
+			null
+			 
+			race
+			=
+			null
+			 
+			flags
+			=
+			$Flags
+			 
+			refobj
+			=
+			[THIS]
+			 
+			serial
+			=
+			null
+			 
+			max.jumps
+			=
+			$Range
+
+			end
+
+
+			if
+			 
+			$Station
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Flee: moving to %s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.Move.Station
+			 
+			Arg2
+			=
+			$Station
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			[THIS]
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			$Ware.Entries
+			 
+			arg2
+			=
+			$Directive.Type.Resume
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Flee: nowhere to run'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			break
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Return.Home:
+
+			*  Return to homebase.
+
+			* ******************************************************************************
+
+			Return.Home
+			:
+
+			if
+			 
+			[HOMEBASE]
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Return.Home: returning home'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.Move.Station
+			 
+			Arg2
+			=
+			[HOMEBASE]
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			[THIS]
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			$Ware.Entries
+			 
+			arg2
+			=
+			$Directive.Type.Resume
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			else
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Return.Home: no homebase'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Return.Home:
+
+			*  Check if mission needs adjusted
+
+			* ******************************************************************************
+
+			Check.Mission
+			:
+
+			while
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Buy
+			 
+			OR
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Sell
+
+			break
+
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Can.Trade.Ware
+			 
+			Arg1
+			=
+			$Mission.Ware
+			 
+			Arg2
+			=
+			$Mission.Type
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Replan mission: Lib.Can.Trade.Ware says no for ware %s (sell)'
+			 
+			arg1
+			=
+			$Mission.Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			if
+			 
+			[HOMEBASE]
+
+			gosub
+			 
+			Return.Home
+			:
+
+			else
+
+			gosub
+			 
+			Stop.And.Think
+			:
+
+			end
+
+			break
+
+			end
+
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Can.Trade.At
+			 
+			Arg1
+			=
+			$Mission.Dest
+			 
+			Arg2
+			=
+			$Mission.Type
+			 
+			Arg3
+			=
+			$Mission.Ware
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Replan mission: lib.can.trade.at says no for ware %s destination %s'
+			 
+			arg1
+			=
+			$Mission.Ware
+			 
+			arg2
+			=
+			$Mission.Dest
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			gosub
+			 
+			Reroute.Trade
+			:
+
+			break
+
+			end
+
+
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Sell
+
+
+			if
+			 
+			not
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Mission.Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Abort mission: no %s in bay to sell'
+			 
+			arg1
+			=
+			$Mission.Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			if
+			 
+			[HOMEBASE]
+
+			gosub
+			 
+			Return.Home
+			:
+
+			else
+
+			gosub
+			 
+			Stop.And.Think
+			:
+
+			end
+
+			break
+
+			end
+
+
+			$Price.Dest
+			 
+			=
+			 
+			$Mission.Dest
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Mission.Ware
+
+			$Price.Ask
+			 
+			=
+			 
+			$Mission.Price
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			[HOMEBASE]
+
+			$Price.Ask
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Mission.Ware
+
+
+			if
+			 
+			$Price.Dest
+			 
+			<
+			 
+			$Price.Ask
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Replan mission: Price %s of ware %s at destination %s lower than desired price %s'
+			 
+			arg1
+			=
+			$Price.Dest
+			 
+			arg2
+			=
+			$Mission.Ware
+			 
+			arg3
+			=
+			$Mission.Dest
+			 
+			arg4
+			=
+			$Price.Ask
+			 
+			arg5
+			=
+			null
+
+			gosub
+			 
+			Reroute.Trade
+			:
+
+			break
+
+			end
+
+
+			else
+			 
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+
+			* Hack to avoid profit checking when buying a jumpdrive
+
+			* skip if $Mission.Ware != {Jumpdrive}
+
+			* break
+
+
+			$Price.Dest
+			 
+			=
+			 
+			$Mission.Dest
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Mission.Ware
+
+			$Price.Ask
+			 
+			=
+			 
+			$Mission.Price
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			[HOMEBASE]
+
+			$Price.Ask
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Mission.Ware
+
+
+			if
+			 
+			$Price.Dest
+			 
+			>
+			 
+			$Price.Ask
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Replan mission: Price %s of ware %s at destination %s greater than desired price %s'
+			 
+			arg1
+			=
+			$Price.Dest
+			 
+			arg2
+			=
+			$Mission.Ware
+			 
+			arg3
+			=
+			$Mission.Dest
+			 
+			arg4
+			=
+			$Price.Ask
+			 
+			arg5
+			=
+			null
+
+			gosub
+			 
+			Stop.And.Think
+			:
+
+			break
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			[HOMEBASE]
+
+			break
+
+
+			$Mission.Dest2
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Check.Dest2
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			not
+			 
+			$Mission.Dest2
+			->
+			 
+			exists
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Replan mission: No alternative Dest2 found for ware %s. Aborting purchase.'
+			 
+			arg1
+			=
+			$Mission.Ware
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			gosub
+			 
+			Stop.And.Think
+			:
+
+			break
+
+			end
+
+
+			end
+
+
+			break
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Reroute.Trade:
+
+			*  Trade the ware elsewhere or return home
+
+			* ******************************************************************************
+
+			Reroute.Trade
+			:
+
+			$Excludes
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Get.Excludes
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			append
+			 
+			$Mission.Dest
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			[HOMEBASE]
+
+			append
+			 
+			[HOMEBASE]
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+
+			$Station
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Find.Station
+			 
+			Arg1
+			=
+			$Mission.Ware
+			 
+			Arg2
+			=
+			$Mission.Type
+			 
+			Arg3
+			=
+			$Excludes
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			0
+			 
+			Arg6
+			=
+			null
+
+
+			while
+			 
+			1
+
+
+			$Price.Dest
+			 
+			=
+			 
+			$Mission.Dest
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Mission.Ware
+
+
+			if
+			 
+			not
+			 
+			$Station
+			->
+			 
+			exists
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Reroute.Trade: No alternative station found. Ware=%s, Mission=%s'
+			 
+			arg1
+			=
+			$Mission.Ware
+			 
+			arg2
+			=
+			$Mission.Type
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+			 
+			argument9
+			=
+			null
+			 
+			argument10
+			=
+			null
+
+			if
+			 
+			[HOMEBASE]
+
+			gosub
+			 
+			Return.Home
+			:
+
+			else
+			 
+			if
+			 
+			$State
+			[
+			$State.Fleeing
+			]
+
+			gosub
+			 
+			Flee
+			:
+
+			else
+			 
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Sell
+
+			* Update the price so we don't hit this case again next time
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.Sell
+			 
+			Arg2
+			=
+			$Mission.Dest
+			 
+			Arg3
+			=
+			$Mission.Ware
+			 
+			Arg4
+			=
+			$Price.Dest
+			 
+			Arg5
+			=
+			null
+
+			else
+
+			gosub
+			 
+			Stop.And.Think
+			:
+
+			end
+
+			break
+
+			end
+
+
+			$Price.Alt
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Mission.Ware
+
+			$Price.Limit
+			 
+			=
+			 
+			$Mission.Price
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			[HOMEBASE]
+
+			$Price.Limit
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Mission.Ware
+
+
+			* If the alternative meets price criteria then go there
+
+			if
+			 
+			(
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Buy
+			 
+			AND
+			 
+			$Price.Alt
+			 
+			<=
+			 
+			$Price.Limit
+			)
+			 
+			OR
+			 
+			(
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Sell
+			 
+			AND
+			 
+			$Price.Alt
+			 
+			>=
+			 
+			$Price.Limit
+			)
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Reroute.Trade: Rerouting to buy %s at %s for %s which meets price limit %s'
+			 
+			arg1
+			=
+			$Mission.Ware
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Price.Alt
+			 
+			arg4
+			=
+			$Price.Limit
+			 
+			arg5
+			=
+			null
+			 
+			argument9
+			=
+			null
+			 
+			argument10
+			=
+			null
+
+			gosub
+			 
+			Reroute.Or.Refuel
+			:
+
+			break
+
+			end
+
+
+
+			if
+			 
+			[HOMEBASE]
+
+			if
+			 
+			$State
+			[
+			$State.Fleeing
+			]
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Reroute.Trade: Price not met elsewhere. Fleeing. Ware=%s, Dest.Price=%s, Alt.Price=%s, Limit=%s'
+			 
+			arg1
+			=
+			$Mission.Ware
+			 
+			arg2
+			=
+			$Price.Dest
+			 
+			arg3
+			=
+			$Price.Alt
+			 
+			arg4
+			=
+			$Price.Limit
+			 
+			arg5
+			=
+			null
+
+			gosub
+			 
+			Flee
+			:
+
+			else
+			 
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Reroute.Trade: Price not met elsewhere, abort mission. Ware=%s, Dest.Price=%s, Alt.Price=%s, Limit=%s'
+			 
+			arg1
+			=
+			$Mission.Ware
+			 
+			arg2
+			=
+			$Price.Dest
+			 
+			arg3
+			=
+			$Price.Alt
+			 
+			arg4
+			=
+			$Price.Limit
+			 
+			arg5
+			=
+			null
+
+			gosub
+			 
+			Stop.And.Think
+			:
+
+			else
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Reroute.Trade: Price not met elsewhere, return home. Returning home. Ware=%s, Dest.Price=%s, Alt.Price=%s, Limit=%s'
+			 
+			arg1
+			=
+			$Mission.Ware
+			 
+			arg2
+			=
+			$Price.Dest
+			 
+			arg3
+			=
+			$Price.Alt
+			 
+			arg4
+			=
+			$Price.Limit
+			 
+			arg5
+			=
+			null
+
+			gosub
+			 
+			Return.Home
+			:
+
+			end
+
+			break
+
+			end
+
+
+			if
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+			if
+			 
+			$State
+			[
+			$State.Fleeing
+			]
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Reroute.Trade: Price is worse elsewhere, abort mission and flee. Ware=%s, Dest.Price=%s, Alt.Price=%s, Limit=%s'
+			 
+			arg1
+			=
+			$Mission.Ware
+			 
+			arg2
+			=
+			$Price.Dest
+			 
+			arg3
+			=
+			$Price.Alt
+			 
+			arg4
+			=
+			$Price.Limit
+			 
+			arg5
+			=
+			null
+
+			gosub
+			 
+			Flee
+			:
+
+			else
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Reroute.Trade: Price is worse elsewhere, abort mission. Ware=%s, Dest.Price=%s, Alt.Price=%s, Limit=%s'
+			 
+			arg1
+			=
+			$Mission.Ware
+			 
+			arg2
+			=
+			$Price.Dest
+			 
+			arg3
+			=
+			$Price.Alt
+			 
+			arg4
+			=
+			$Price.Limit
+			 
+			arg5
+			=
+			null
+
+			gosub
+			 
+			Stop.And.Think
+			:
+
+			end
+
+			break
+
+			end
+
+
+			if
+			 
+			$State
+			[
+			$State.Fleeing
+			]
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Reroute.Trade: Rerouting sale to %s as fleeing. Ware=%s, Dest.Price=%s, Alt.Price=%s, Limit=%s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			$Mission.Ware
+			 
+			arg3
+			=
+			$Price.Dest
+			 
+			arg4
+			=
+			$Price.Alt
+			 
+			arg5
+			=
+			$Price.Limit
+
+			gosub
+			 
+			Reroute.Or.Refuel
+			:
+
+			break
+
+			end
+
+
+			if
+			 
+			$Price.Alt
+			 
+			>
+			 
+			$Price.Dest
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Reroute.Trade: Rerouting sale to %s with least worst price. Ware=%s, Dest.Price=%s, Alt.Price=%s, Limit=%s'
+			 
+			arg1
+			=
+			$Station
+			 
+			arg2
+			=
+			$Mission.Ware
+			 
+			arg3
+			=
+			$Price.Dest
+			 
+			arg4
+			=
+			$Price.Alt
+			 
+			arg5
+			=
+			$Price.Limit
+
+			gosub
+			 
+			Reroute.Or.Refuel
+			:
+
+			break
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Reroute.Trade: Continuing with existing sale mission, alt price is worse. Ware=%s, Dest.Price=%s, Alt.Price=%s, Limit=%s'
+			 
+			arg1
+			=
+			$Mission.Ware
+			 
+			arg2
+			=
+			$Price.Dest
+			 
+			arg3
+			=
+			$Price.Alt
+			 
+			arg4
+			=
+			$Price.Limit
+			 
+			arg5
+			=
+			null
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type
+			 
+			Arg2
+			=
+			$Mission.Dest
+			 
+			Arg3
+			=
+			$Mission.Ware
+			 
+			Arg4
+			=
+			$Price.Alt
+			 
+			Arg5
+			=
+			null
+
+			break
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Reroute.Or.Refuel:
+
+			*  Decide whether to reroute or refuel
+
+			* ******************************************************************************
+
+			Reroute.Or.Refuel
+			:
+
+			while
+			 
+			1
+
+			if
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Needs.Refuel
+			 
+			Arg1
+			=
+			$Station
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Fuel
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Refuel.Dest
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			$Fuel
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Reroute.Or.Refuel: Refuel at %s'
+			 
+			arg1
+			=
+			$Fuel
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type.Move.Station
+			 
+			Arg2
+			=
+			$Fuel
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			[THIS]
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			$Ware.Entries
+			 
+			arg2
+			=
+			$Directive.Type.Resume
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			end
+
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Publish
+			 
+			Arg1
+			=
+			$Mission.Type
+			 
+			Arg2
+			=
+			$Station
+			 
+			Arg3
+			=
+			$Mission.Ware
+			 
+			Arg4
+			=
+			$Price.Alt
+			 
+			Arg5
+			=
+			$Mission.Dest2
+
+			[THIS]
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			$Ware.Entries
+			 
+			arg2
+			=
+			$Directive.Type.Resume
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Check.DockingComputer:
+
+			*  Use docking computer
+
+			* ******************************************************************************
+
+			Check.DockingComputer
+			:
+
+			while
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			{Docking Computer}
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			break
+
+
+			skip
+			 
+			if
+			 
+			(
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Buy
+			 
+			OR
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Sell
+			 
+			OR
+			 
+			$Mission.Type
+			 
+			==
+			 
+			$Mission.Type.Move.Station
+			)
+
+			break
+
+
+			skip
+			 
+			if
+			 
+			$Mission.Dest
+			->
+			 
+			exists
+
+			break
+
+
+			skip
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			has
+			 
+			same
+			 
+			environment
+			 
+			as
+			 
+			$Mission.Dest
+
+			break
+
+
+			skip
+			 
+			if
+			 
+			[THIS]
+			->
+			 
+			is
+			 
+			docking
+			 
+			allowed
+			 
+			at
+			 
+			$Mission.Dest
+
+			break
+
+
+			skip
+			 
+			if
+			 
+			$Mission.Dest
+			->
+			 
+			is
+			 
+			docking
+			 
+			possible
+			 
+			of
+			 
+			[THIS]
+
+			break
+
+
+			$Dist
+			 
+			=
+			 
+			get
+			 
+			distance
+			 
+			between
+			 
+			[THIS]
+			 
+			and
+			 
+			$Mission.Dest
+
+			if
+			 
+			$Dist
+			 
+			<=
+			 
+			5000
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Check.DockingComputer: Using docking computer to dock at %s, range %s'
+			 
+			arg1
+			=
+			$Mission.Dest
+			 
+			arg2
+			=
+			$Dist
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			[THIS]
+			->
+			 
+			put
+			 
+			into
+			 
+			environment
+			 
+			$Mission.Dest
+			->
+
+			[THIS]
+			->
+			 
+			begin
+			 
+			task
+			 
+			0
+			 
+			with
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			and
+			 
+			priority
+			 
+			0
+			:
+			 
+			arg1
+			=
+			$Ware.Entries
+			 
+			arg2
+			=
+			$Directive.Type.Resume
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+
+			break
+
+			end
+
+			endsub
+
+			return
+			 
+			null

--- a/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.state.x3s
+++ b/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.state.x3s
@@ -1,0 +1,6728 @@
+#name: glen.trade.ok.state
+#lang: 44
+#origin_mod: OKTraders1_7_1
+#source: mods/OKTraders1_7_1/scripts/glen.trade.ok.state.xml
+
+
+			* ******************************************************************************
+
+			* OK Trade
+
+			*  Trader state
+
+			* ******************************************************************************
+
+
+			$Comp
+			 
+			=
+			 
+			'State'
+
+
+			$Config
+			 
+			=
+			 
+			get
+			 
+			global
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+
+			skip
+			 
+			if
+			 
+			$Config
+
+			return
+			 
+			null
+
+
+			$Lib.Get.Reserve.Jump.Energy
+			 
+			=
+			 
+			2
+
+			$Lib.Get.Non.Transportable.Wares
+			 
+			=
+			 
+			9
+
+			$Lib.Get.Reserved.Amount
+			 
+			=
+			 
+			30
+
+
+			$Lib.Generic.Get.Minimum
+			 
+			=
+			 
+			1
+
+			$Lib.Generic.Join.Arrays
+			 
+			=
+			 
+			2
+
+			$Lib.Generic.Clone.Array
+			 
+			=
+			 
+			3
+
+			$Lib.Generic.Get.Jump.Energy.For.Trip
+			 
+			=
+			 
+			4
+
+
+			$Lib.State.Fetch
+			 
+			=
+			 
+			0
+
+			$Lib.State.Publish
+			 
+			=
+			 
+			1
+
+			$Lib.State.Reset.Config
+			 
+			=
+			 
+			2
+
+			$Lib.State.Update.Config
+			 
+			=
+			 
+			3
+
+			$Lib.State.Get.Excludes
+			 
+			=
+			 
+			4
+
+			$Lib.State.Check.Competition
+			 
+			=
+			 
+			5
+
+
+			$Internal.Trade.Cache.Add
+			 
+			=
+			 
+			20
+
+			$Internal.Trade.Cache.Remove
+			 
+			=
+			 
+			21
+
+
+			* Global config
+
+			$Config.Ver.Internal
+			 
+			=
+			 
+			3
+
+			$Config.PageId
+			 
+			=
+			 
+			4
+
+			$Config.Debug.Enabled
+			 
+			=
+			 
+			5
+
+			$Config.Auto.Rename
+			 
+			=
+			 
+			9
+
+			$Config.Blacklist
+			 
+			=
+			 
+			10
+
+			$Config.Trade.Cache
+			 
+			=
+			 
+			19
+
+
+			* Trader mission state
+
+			$Mission.Type.None
+			 
+			=
+			 
+			0
+
+			$Mission.Type.Buy
+			 
+			=
+			 
+			1
+
+			$Mission.Type.Sell
+			 
+			=
+			 
+			2
+
+			$Mission.Type.Move.Station
+			 
+			=
+			 
+			3
+
+
+			* State contents
+
+			$State.Version
+			 
+			=
+			 
+			0
+
+			$State.Mission
+			 
+			=
+			 
+			1
+
+			$State.Dest
+			 
+			=
+			 
+			2
+
+			$State.Ware
+			 
+			=
+			 
+			3
+
+			$State.Price
+			 
+			=
+			 
+			4
+
+			$State.Ware.Entries
+			 
+			=
+			 
+			5
+
+			$State.Fleeing
+			 
+			=
+			 
+			6
+
+			$State.Balance
+			 
+			=
+			 
+			7
+
+			$State.Trade.Mode
+			 
+			=
+			 
+			8
+
+			$State.Tether.Sector
+			 
+			=
+			 
+			9
+
+			$State.Tether.Range
+			 
+			=
+			 
+			10
+
+			$State.Ver.Cmd
+			 
+			=
+			 
+			11
+
+			$State.Ver.Monitor
+			 
+			=
+			 
+			12
+
+			$State.Last.Mission
+			 
+			=
+			 
+			13
+
+			$State.Last.Dest
+			 
+			=
+			 
+			14
+
+			$State.Last.Ware
+			 
+			=
+			 
+			15
+
+			$State.Dest2
+			 
+			=
+			 
+			16
+
+			$State.Reserve.Fuel
+			 
+			=
+			 
+			17
+
+
+			$Trade.Mode.Normal
+			 
+			=
+			 
+			0
+
+			$Trade.Mode.Economy
+			 
+			=
+			 
+			1
+
+			$Trade.Mode.Player
+			 
+			=
+			 
+			2
+
+
+			$State
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			local
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Func=%s, arg1=%s, arg2=%s, arg3=%s, arg4=%s'
+			 
+			arg1
+			=
+			$Func
+			 
+			arg2
+			=
+			$Arg1
+			 
+			arg3
+			=
+			$Arg2
+			 
+			arg4
+			=
+			$Arg3
+			 
+			arg5
+			=
+			$Arg4
+
+
+			$rc
+			 
+			=
+			 
+			null
+
+
+			* ******************************************************************************
+
+			* Options
+
+			* ******************************************************************************
+
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.State.Fetch
+
+			gosub
+			 
+			Lib.State.Fetch
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.State.Get.Excludes
+
+			gosub
+			 
+			Lib.State.Get.Excludes
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.State.Publish
+
+			gosub
+			 
+			Lib.State.Publish
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.State.Reset.Config
+
+			gosub
+			 
+			Lib.State.Reset.Config
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.State.Update.Config
+
+			gosub
+			 
+			Lib.State.Update.Config
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Lib.State.Check.Competition
+
+			gosub
+			 
+			Lib.State.Check.Competition
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Internal.Trade.Cache.Add
+
+			gosub
+			 
+			Internal.Trade.Cache.Add
+			:
+
+			else
+			 
+			if
+			 
+			$Func
+			 
+			==
+			 
+			$Internal.Trade.Cache.Remove
+
+			gosub
+			 
+			Internal.Trade.Cache.Remove
+			:
+
+			else
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			0
+			 
+			fmt
+			=
+			'Unknown function %s'
+			 
+			arg1
+			=
+			$Func
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+
+			return
+			 
+			$rc
+
+
+			* ******************************************************************************
+
+			* Lib.State.Fetch:
+
+			*  Create, upgrade, and return trader state
+
+			* ******************************************************************************
+
+			Lib.State.Fetch
+			:
+
+			while
+			 
+			1
+
+
+			if
+			 
+			not
+			 
+			$State
+
+			gosub
+			 
+			Internal.State.Create
+			:
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Lib.State.Fetch: Created trader state data'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			$Ver.State
+			 
+			=
+			 
+			$State
+			[
+			$State.Version
+			]
+
+			$Ver.Config
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			if
+			 
+			$Ver.Config
+			 
+			>
+			 
+			$Ver.State
+
+			gosub
+			 
+			Internal.State.Upgrade
+			:
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Lib.State.Fetch: Upgraded trader state data from %s to %s'
+			 
+			arg1
+			=
+			$Ver.State
+			 
+			arg2
+			=
+			$Ver.Config
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			break
+
+			end
+
+
+			if
+			 
+			$Ver.Config
+			 
+			<
+			 
+			$Ver.State
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			4
+			 
+			fmt
+			=
+			'Lib.State.Fetch: Trader state data version %s is higher than installed version %s'
+			 
+			arg1
+			=
+			$Ver.State
+			 
+			arg2
+			=
+			$Ver.Config
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+
+			break
+
+			end
+
+
+			$rc
+			 
+			=
+			 
+			$State
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Lib.State.Fetch: rc=%s'
+			 
+			arg1
+			=
+			$rc
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Lib.State.Publish:
+
+			*  Advertise current command/mission state
+
+			* ******************************************************************************
+
+			Lib.State.Publish
+			:
+
+			$Mission
+			 
+			=
+			 
+			$Arg1
+
+			$Dest
+			 
+			=
+			 
+			$Arg2
+
+			$Ware
+			 
+			=
+			 
+			$Arg3
+
+			$Price
+			 
+			=
+			 
+			$Arg4
+
+			$Dest2
+			 
+			=
+			 
+			$Arg5
+
+
+			$Old.Mission
+			 
+			=
+			 
+			$State
+			[
+			$State.Mission
+			]
+
+			$Old.Dest
+			 
+			=
+			 
+			$State
+			[
+			$State.Dest
+			]
+
+			$Old.Ware
+			 
+			=
+			 
+			$State
+			[
+			$State.Ware
+			]
+
+			$Old.Dest2
+			 
+			=
+			 
+			$State
+			[
+			$State.Dest2
+			]
+
+
+			$State
+			[
+			$State.Mission
+			]
+			 
+			=
+			 
+			$Mission
+
+			$State
+			[
+			$State.Dest
+			]
+			 
+			=
+			 
+			$Dest
+
+			$State
+			[
+			$State.Ware
+			]
+			 
+			=
+			 
+			$Ware
+
+			$State
+			[
+			$State.Price
+			]
+			 
+			=
+			 
+			$Price
+
+			$State
+			[
+			$State.Dest2
+			]
+			 
+			=
+			 
+			$Dest2
+
+			$State
+			[
+			$State.Last.Mission
+			]
+			 
+			=
+			 
+			$Old.Mission
+
+			$State
+			[
+			$State.Last.Dest
+			]
+			 
+			=
+			 
+			$Old.Dest
+
+			$State
+			[
+			$State.Last.Ware
+			]
+			 
+			=
+			 
+			$Old.Ware
+
+
+			* Update lookup table
+
+			if
+			 
+			(
+			$Mission
+			 
+			!=
+			 
+			$Old.Mission
+			 
+			OR
+			 
+			$Dest
+			 
+			!=
+			 
+			$Old.Dest
+			 
+			OR
+			 
+			$Ware
+			 
+			!=
+			 
+			$Old.Ware
+			 
+			OR
+			 
+			$Dest2
+			 
+			!=
+			 
+			$Old.Dest2
+			)
+
+			gosub
+			 
+			Auto.Rename
+			:
+
+
+			* Clear previous lookup state
+
+			if
+			 
+			(
+			$Old.Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+			 
+			OR
+			 
+			$Old.Mission
+			 
+			==
+			 
+			$Mission.Type.Sell
+			)
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Internal.Trade.Cache.Remove
+			 
+			Arg1
+			=
+			$Old.Mission
+			 
+			Arg2
+			=
+			$Old.Dest
+			 
+			Arg3
+			=
+			$Old.Ware
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			if
+			 
+			(
+			$Old.Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+			 
+			AND
+			 
+			$Old.Dest2
+			)
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Internal.Trade.Cache.Remove
+			 
+			Arg1
+			=
+			$Mission.Type.Sell
+			 
+			Arg2
+			=
+			$Old.Dest2
+			 
+			Arg3
+			=
+			$Old.Ware
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			end
+
+			end
+
+
+			* Add new lookup state
+
+			if
+			 
+			(
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+			 
+			OR
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Sell
+			)
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Internal.Trade.Cache.Add
+			 
+			Arg1
+			=
+			$Mission
+			 
+			Arg2
+			=
+			$Dest
+			 
+			Arg3
+			=
+			$Ware
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			if
+			 
+			(
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+			 
+			AND
+			 
+			$Dest2
+			)
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Internal.Trade.Cache.Add
+			 
+			Arg1
+			=
+			$Mission.Type.Sell
+			 
+			Arg2
+			=
+			$Dest2
+			 
+			Arg3
+			=
+			$Ware
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			end
+
+			end
+
+			end
+
+
+
+			if
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Cmd=Buy, Dest=%s, Dest2=%s, Ware=%s, Price=%s, Environment=%s'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			$Dest2
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Price
+			 
+			arg5
+			=
+			[ENVIRONMENT]
+
+			else
+			 
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Sell
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Cmd=Sell, Dest=%s, Ware=%s, Price=%s, Environment=%s'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			$Ware
+			 
+			arg3
+			=
+			$Price
+			 
+			arg4
+			=
+			[ENVIRONMENT]
+			 
+			arg5
+			=
+			null
+
+			else
+			 
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Move.Station
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Cmd=Move to station, Dest=%s, Environment=%s'
+			 
+			arg1
+			=
+			$Dest
+			 
+			arg2
+			=
+			[ENVIRONMENT]
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			else
+			 
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.None
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Cmd=None, Environment=%s'
+			 
+			arg1
+			=
+			[ENVIRONMENT]
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			else
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			5
+			 
+			fmt
+			=
+			'Cmd=%s, Dest=%s, Ware=%s, Price=%s, Environment=%s'
+			 
+			arg1
+			=
+			$Mission
+			 
+			arg2
+			=
+			$Dest
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Price
+			 
+			arg5
+			=
+			[ENVIRONMENT]
+
+			end
+
+			end
+
+
+			* Update jump fuel reserve
+
+			* = [THIS]-> call script 'glen.trade.ok.lib' : Func=$Lib.Get.Reserve.Jump.Energy Arg1=$Dest Arg2=null Arg3=null Arg4=null Arg5=null Arg6=null
+
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Lib.State.Reset.Config:
+
+			*  Reset trader config to defaults
+
+			* ******************************************************************************
+
+			Lib.State.Reset.Config
+			:
+
+			if
+			 
+			[HOMEBASE]
+
+			if
+			 
+			[HOMEBASE]
+			->
+			 
+			is
+			 
+			of
+			 
+			type
+			 
+			[Station]
+
+			$Ware.Entries
+			 
+			=
+			 
+			$State
+			[
+			$State.Ware.Entries
+			]
+
+			skip
+			 
+			if
+			 
+			$Ware.Entries
+
+			$Ware.Entries
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			gosub
+			 
+			Internal.Set.Default.Wares
+			:
+
+			gosub
+			 
+			Internal.Sort.Ware.Entries
+			:
+
+			end
+
+			end
+
+			$State
+			[
+			$State.Trade.Mode
+			]
+			 
+			=
+			 
+			$Trade.Mode.Normal
+
+			$State
+			[
+			$State.Tether.Sector
+			]
+			 
+			=
+			 
+			null
+
+			$State
+			[
+			$State.Tether.Range
+			]
+			 
+			=
+			 
+			0
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Lib.State.Update.Config:
+
+			*  Update ware entries to reflect changes to homebase ware list
+
+			* ******************************************************************************
+
+			Lib.State.Update.Config
+			:
+
+			if
+			 
+			[HOMEBASE]
+
+			if
+			 
+			[HOMEBASE]
+			->
+			 
+			is
+			 
+			of
+			 
+			type
+			 
+			[Station]
+
+			$Ware.Entries
+			 
+			=
+			 
+			$State
+			[
+			$State.Ware.Entries
+			]
+
+			skip
+			 
+			if
+			 
+			$Ware.Entries
+
+			$Ware.Entries
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Updated
+			 
+			=
+			 
+			0
+
+			gosub
+			 
+			Internal.Update.Wares
+			:
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Updated
+
+			gosub
+			 
+			Internal.Sort.Ware.Entries
+			:
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Lib.State.Get.Excludes:
+
+			*  Get sector exclude array
+
+			*   Cache
+
+			*   [0] - Version
+
+			*   [1] - Origin Sector
+
+			*   [2] - Keys array, jump ranges
+
+			*   [3] - Values array, where value [0] Timestamp
+
+			*                                   [1] Exclude sectors
+
+			* ******************************************************************************
+
+			Lib.State.Get.Excludes
+			:
+
+			$Blacklist
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Blacklist
+			]
+
+			$Ver.Config
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			$Ver.Engine
+			 
+			=
+			 
+			script
+			 
+			engine
+			 
+			version
+
+			$Is.AP
+			 
+			=
+			 
+			(
+			$Ver.Engine
+			 
+			>
+			 
+			49
+			)
+
+
+			* Determine if tethered and search for a cache
+
+			if
+			 
+			[HOMEBASE]
+
+			$Tether.Sector
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			sector
+
+			$Tether.Range
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			max
+			 
+			trade
+			 
+			jumps
+
+			$Cache
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			local
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok.excludes'
+
+			else
+
+			$Tether.Sector
+			 
+			=
+			 
+			$State
+			[
+			$State.Tether.Sector
+			]
+
+			if
+			 
+			$Tether.Sector
+
+			$Tether.Range
+			 
+			=
+			 
+			$State
+			[
+			$State.Tether.Range
+			]
+
+			if
+			 
+			$Is.AP
+
+			* Local variables can be stored on sectors in AP
+
+			$Cache
+			 
+			=
+			 
+			$Tether.Sector
+			->
+			 
+			get
+			 
+			local
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok.excludes'
+
+			else
+
+			* Otherwise the cache is stored on the tethered trader in TC
+
+			$Cache
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			local
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok.excludes'
+
+			end
+
+			else
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Clone.Array
+			 
+			Arg1
+			=
+			$Blacklist
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Lib.State.Get.Excludes: Not tethered, blacklist only.'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			return
+			 
+			$rc
+
+			end
+
+			end
+
+
+			* Check cache invalidation and return cached value if good
+
+			while
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			$Cache
+
+			break
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Lib.State.Get.Excludes: Found cache=%s'
+			 
+			arg1
+			=
+			$Cache
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			$Ver.Cache
+			 
+			=
+			 
+			$Cache
+			[
+			0
+			]
+
+			if
+			 
+			$Ver.Cache
+			 
+			>
+			 
+			$Ver.Config
+
+			$Cache
+			 
+			=
+			 
+			null
+
+			break
+
+			end
+
+
+			$Sector
+			 
+			=
+			 
+			$Cache
+			[
+			1
+			]
+
+			if
+			 
+			$Sector
+			 
+			!=
+			 
+			$Tether.Sector
+
+			$Cache
+			 
+			=
+			 
+			null
+
+			break
+
+			end
+
+
+			$Keys
+			 
+			=
+			 
+			$Cache
+			[
+			2
+			]
+
+			$idx
+			 
+			=
+			 
+			get
+			 
+			index
+			 
+			of
+			 
+			$Tether.Range
+			 
+			in
+			 
+			array
+			 
+			$Keys
+			 
+			offset
+			=
+			-1
+
+			skip
+			 
+			if
+			 
+			$idx
+			 
+			>=
+			 
+			0
+
+			break
+
+
+			$Values
+			 
+			=
+			 
+			$Cache
+			[
+			3
+			]
+
+			$Now
+			 
+			=
+			 
+			playing
+			 
+			time
+
+			$Timestamp
+			 
+			=
+			 
+			$Values
+			[
+			$idx
+			]
+			[
+			0
+			]
+
+			if
+			 
+			(
+			$Timestamp
+			 
+			+
+			 
+			30
+			)
+			 
+			<
+			 
+			$Now
+
+			remove
+			 
+			element
+			 
+			from
+			 
+			array
+			 
+			$Keys
+			 
+			at
+			 
+			index
+			 
+			$idx
+
+			remove
+			 
+			element
+			 
+			from
+			 
+			array
+			 
+			$Values
+			 
+			at
+			 
+			index
+			 
+			$idx
+
+			break
+
+			end
+
+
+			$Excludes
+			 
+			=
+			 
+			$Values
+			[
+			$idx
+			]
+			[
+			1
+			]
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Join.Arrays
+			 
+			Arg1
+			=
+			$Blacklist
+			 
+			Arg2
+			=
+			$Excludes
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Lib.State.Get.Excludes: Tethered, cache hit. Excludes=%s'
+			 
+			arg1
+			=
+			$Excludes
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			return
+			 
+			$rc
+
+			end
+
+
+			* Create cache if necessary
+
+			if
+			 
+			not
+			 
+			$Cache
+
+			$Cache
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			15
+
+			$Cache
+			[
+			0
+			]
+			 
+			=
+			 
+			$Ver.Config
+
+			$Cache
+			[
+			1
+			]
+			 
+			=
+			 
+			$Tether.Sector
+
+			$Keys
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Values
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Cache
+			[
+			2
+			]
+			 
+			=
+			 
+			$Keys
+
+			$Cache
+			[
+			3
+			]
+			 
+			=
+			 
+			$Values
+
+			if
+			 
+			[HOMEBASE]
+
+			[HOMEBASE]
+			->
+			 
+			set
+			 
+			local
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok.excludes'
+			 
+			value
+			=
+			$Cache
+
+			else
+			 
+			if
+			 
+			$Is.AP
+
+			$Tether.Sector
+			->
+			 
+			set
+			 
+			local
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok.excludes'
+			 
+			value
+			=
+			$Cache
+
+			else
+
+			[THIS]
+			->
+			 
+			set
+			 
+			local
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok.excludes'
+			 
+			value
+			=
+			$Cache
+
+			end
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Lib.State.Get.Excludes: Created cache=%s'
+			 
+			arg1
+			=
+			$Cache
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+
+			* Get all sectors outside of tether range
+
+			$Includes
+			 
+			=
+			 
+			$Tether.Sector
+			->
+			 
+			find
+			 
+			all
+			 
+			sectors
+			 
+			within
+			 
+			$Tether.Range
+			 
+			jumps
+			:
+			 
+			Only
+			 
+			known
+			 
+			sectors
+			=
+			0
+
+			$Excludes
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+
+			$x
+			 
+			=
+			 
+			get
+			 
+			max
+			 
+			sectors
+			 
+			in
+			 
+			x
+			 
+			direction
+
+			while
+			 
+			$x
+
+			dec
+			 
+			$x
+
+
+			$y
+			 
+			=
+			 
+			get
+			 
+			max
+			 
+			sectors
+			 
+			in
+			 
+			y
+			 
+			direction
+
+			while
+			 
+			$y
+
+			dec
+			 
+			$y
+
+			$Sector
+			 
+			=
+			 
+			get
+			 
+			sector
+			 
+			from
+			 
+			universe
+			 
+			index
+			:
+			 
+			x
+			=
+			$x
+			,
+			 
+			y
+			=
+			$y
+
+			skip
+			 
+			if
+			 
+			$Sector
+
+			continue
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			find
+			 
+			$Sector
+			 
+			in
+			 
+			array
+			:
+			 
+			$Blacklist
+
+			continue
+
+			skip
+			 
+			if
+			 
+			find
+			 
+			$Sector
+			 
+			in
+			 
+			array
+			:
+			 
+			$Includes
+
+			append
+			 
+			$Sector
+			 
+			to
+			 
+			array
+			 
+			$Excludes
+
+			end
+
+			end
+
+
+			$Keys
+			 
+			=
+			 
+			$Cache
+			[
+			2
+			]
+
+			$Values
+			 
+			=
+			 
+			$Cache
+			[
+			3
+			]
+
+			$Now
+			 
+			=
+			 
+			playing
+			 
+			time
+
+			$Value
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Now
+			,
+			 
+			$Excludes
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			append
+			 
+			$Tether.Range
+			 
+			to
+			 
+			array
+			 
+			$Keys
+
+			append
+			 
+			$Value
+			 
+			to
+			 
+			array
+			 
+			$Values
+
+
+			$rc
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib.generic
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Generic.Join.Arrays
+			 
+			Arg1
+			=
+			$Blacklist
+			 
+			Arg2
+			=
+			$Excludes
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			10
+			 
+			fmt
+			=
+			'Lib.State.Get.Excludes: Tethered, cache miss. Excludes=%s'
+			 
+			arg1
+			=
+			$Excludes
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Update.Wares:
+
+			*  Take into account wares added or removed from the homebase
+
+			* ******************************************************************************
+
+			Internal.Update.Wares
+			:
+
+			$Wares.Homebase
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			tradeable
+			 
+			ware
+			 
+			array
+			 
+			from
+			 
+			station
+
+			$Wares.Have
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+
+			* Remove ware entries that are no longer traded by the homebase
+
+			$Count
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Ware.Entries
+
+			$idx
+			 
+			=
+			 
+			0
+
+			while
+			 
+			$idx
+			 
+			<
+			 
+			$Count
+
+			$Entry
+			 
+			=
+			 
+			$Ware.Entries
+			[
+			$idx
+			]
+
+			$Entry.Len
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Entry
+
+			$Ware
+			 
+			=
+			 
+			$Entry
+			[
+			0
+			]
+
+
+			if
+			 
+			not
+			 
+			find
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			:
+			 
+			$Wares.Homebase
+
+			remove
+			 
+			element
+			 
+			from
+			 
+			array
+			 
+			$Ware.Entries
+			 
+			at
+			 
+			index
+			 
+			$idx
+
+			$Updated
+			 
+			=
+			 
+			1
+
+			dec
+			 
+			$Count
+
+			else
+
+			inc
+			 
+			$idx
+
+			append
+			 
+			$Ware
+			 
+			to
+			 
+			array
+			 
+			$Wares.Have
+
+			end
+
+			end
+
+
+			* Add ware entries that have been added to the homebase
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares.Homebase
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ware
+			 
+			=
+			 
+			$Wares.Homebase
+			[
+			$idx
+			]
+
+			if
+			 
+			not
+			 
+			find
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			:
+			 
+			$Wares.Have
+
+			$Ware.Entry
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Ware
+			,
+			 
+			$Mission.Type.None
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			append
+			 
+			$Ware.Entry
+			 
+			to
+			 
+			array
+			 
+			$Ware.Entries
+
+			$Updated
+			 
+			=
+			 
+			1
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Internal.Set.Default.Wares:
+
+			*  Reset hombased trader ware config
+
+			* ******************************************************************************
+
+			Internal.Set.Default.Wares
+			:
+
+			resize
+			 
+			array
+			 
+			$Ware.Entries
+			 
+			to
+			 
+			0
+
+			$Non.Transportable.Wares
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Non.Transportable.Wares
+			 
+			Arg1
+			=
+			[THIS]
+			 
+			Arg2
+			=
+			[HOMEBASE]
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			$Wares
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			tradeable
+			 
+			ware
+			 
+			array
+			 
+			from
+			 
+			station
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ware
+			 
+			=
+			 
+			$Wares
+			[
+			$idx
+			]
+
+
+			if
+			 
+			find
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			:
+			 
+			$Non.Transportable.Wares
+
+			$Ware.Entry
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Ware
+			,
+			 
+			$Mission.Type.None
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			else
+			 
+			if
+			 
+			[HOMEBASE]
+			->
+			 
+			is
+			 
+			of
+			 
+			class
+			 
+			[Dock]
+
+			$Ware.Entry
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Ware
+			,
+			 
+			$Mission.Type.None
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			else
+			 
+			if
+			 
+			[HOMEBASE]
+			->
+			 
+			uses
+			 
+			ware
+			 
+			$Ware
+			 
+			as
+			 
+			secondary
+			 
+			resource
+
+			$Ware.Entry
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Ware
+			,
+			 
+			$Mission.Type.None
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			else
+			 
+			if
+			 
+			[HOMEBASE]
+			->
+			 
+			can
+			 
+			buy
+			 
+			ware
+			 
+			$Ware
+
+			$Ware.Entry
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Ware
+			,
+			 
+			$Mission.Type.Buy
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			else
+			 
+			if
+			 
+			[HOMEBASE]
+			->
+			 
+			can
+			 
+			sell
+			 
+			ware
+			 
+			$Ware
+
+			$Ware.Entry
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Ware
+			,
+			 
+			$Mission.Type.Sell
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			else
+
+			$Ware.Entry
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Ware
+			,
+			 
+			$Mission.Type.None
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			end
+
+
+			append
+			 
+			$Ware.Entry
+			 
+			to
+			 
+			array
+			 
+			$Ware.Entries
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Internal.Set.Default.Wares: Homebase=%s, Ware.Entry=%s'
+			 
+			arg1
+			=
+			[HOMEBASE]
+			 
+			arg2
+			=
+			$Ware.Entry
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Internal.Sort.Ware.Entries:
+
+			*  Sort ware entries by ware name
+
+			* ******************************************************************************
+
+			Internal.Sort.Ware.Entries
+			:
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Ware.Entries
+
+			$Sort.Values
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			$idx
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ware.Entry
+			 
+			=
+			 
+			$Ware.Entries
+			[
+			$idx
+			]
+
+			$Ware
+			 
+			=
+			 
+			$Ware.Entry
+			[
+			0
+			]
+
+			$szWare
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			fmt
+			=
+			'%s'
+			,
+			 
+			$Ware
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Sort.Values
+			[
+			$idx
+			]
+			 
+			=
+			 
+			$szWare
+
+			end
+
+			$Ware.Entries
+			 
+			=
+			 
+			sort
+			 
+			array
+			:
+			 
+			data
+			=
+			$Ware.Entries
+			 
+			sort
+			 
+			values
+			=
+			$Sort.Values
+
+			$State
+			[
+			$State.Ware.Entries
+			]
+			 
+			=
+			 
+			$Ware.Entries
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Internal.State.Create:
+
+			*  Create trader state
+
+			* ******************************************************************************
+
+			Internal.State.Create
+			:
+
+			$State
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			30
+
+			[THIS]
+			->
+			 
+			set
+			 
+			local
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+			 
+			value
+			=
+			$State
+
+
+			$State
+			[
+			$State.Version
+			]
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+			$State
+			[
+			$State.Mission
+			]
+			 
+			=
+			 
+			$Mission.Type.None
+
+			$State
+			[
+			$State.Dest
+			]
+			 
+			=
+			 
+			null
+
+			$State
+			[
+			$State.Ware
+			]
+			 
+			=
+			 
+			null
+
+			$State
+			[
+			$State.Price
+			]
+			 
+			=
+			 
+			null
+
+			$State
+			[
+			$State.Ware.Entries
+			]
+			 
+			=
+			 
+			null
+
+			$State
+			[
+			$State.Fleeing
+			]
+			 
+			=
+			 
+			null
+
+			$State
+			[
+			$State.Balance
+			]
+			 
+			=
+			 
+			0
+
+			$State
+			[
+			$State.Trade.Mode
+			]
+			 
+			=
+			 
+			$Trade.Mode.Normal
+
+			$State
+			[
+			$State.Tether.Sector
+			]
+			 
+			=
+			 
+			null
+
+			$State
+			[
+			$State.Tether.Range
+			]
+			 
+			=
+			 
+			0
+
+			$State
+			[
+			$State.Ver.Cmd
+			]
+			 
+			=
+			 
+			0
+
+			$State
+			[
+			$State.Ver.Monitor
+			]
+			 
+			=
+			 
+			0
+
+			$State
+			[
+			$State.Dest2
+			]
+			 
+			=
+			 
+			null
+
+			$State
+			[
+			$State.Reserve.Fuel
+			]
+			 
+			=
+			 
+			0
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Internal.State.Upgrade:
+
+			*  Upgrade trader state
+
+			* ******************************************************************************
+
+			Internal.State.Upgrade
+			:
+
+
+			if
+			 
+			$Ver.State
+			 
+			<
+			 
+			1001000
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			4
+			 
+			fmt
+			=
+			'Internal.State.Upgrade: Upgrade 1.0.0 state missing ware entry data'
+			 
+			arg1
+			=
+			null
+			 
+			arg2
+			=
+			null
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+			$Tmp
+			 
+			=
+			 
+			null
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			[HOMEBASE]
+
+			$Tmp
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$State
+			[
+			$State.Ware.Entries
+			]
+			 
+			=
+			 
+			$Tmp
+
+			$State
+			[
+			$State.Fleeing
+			]
+			 
+			=
+			 
+			null
+
+			end
+
+
+			if
+			 
+			$Ver.State
+			 
+			<
+			 
+			1002000
+
+			$State
+			[
+			$State.Balance
+			]
+			 
+			=
+			 
+			0
+
+			end
+
+
+			if
+			 
+			$Ver.State
+			 
+			<
+			 
+			1004000
+
+			resize
+			 
+			array
+			 
+			$State
+			 
+			to
+			 
+			30
+
+			$State
+			[
+			$State.Trade.Mode
+			]
+			 
+			=
+			 
+			$Trade.Mode.Normal
+
+			$State
+			[
+			$State.Tether.Sector
+			]
+			 
+			=
+			 
+			null
+
+			$State
+			[
+			$State.Tether.Range
+			]
+			 
+			=
+			 
+			0
+
+			$State
+			[
+			$State.Ver.Cmd
+			]
+			 
+			=
+			 
+			0
+
+			$State
+			[
+			$State.Ver.Monitor
+			]
+			 
+			=
+			 
+			0
+
+			end
+
+
+			if
+			 
+			$Ver.State
+			 
+			<
+			 
+			1004001
+
+			$State
+			[
+			$State.Last.Mission
+			]
+			 
+			=
+			 
+			$Mission.Type.None
+
+			$State
+			[
+			$State.Last.Dest
+			]
+			 
+			=
+			 
+			null
+
+			$State
+			[
+			$State.Last.Ware
+			]
+			 
+			=
+			 
+			null
+
+			end
+
+
+			if
+			 
+			$Ver.State
+			 
+			<
+			 
+			1004003
+
+			$State
+			[
+			$State.Dest2
+			]
+			 
+			=
+			 
+			null
+
+			end
+
+
+			if
+			 
+			$Ver.State
+			 
+			<
+			 
+			1006005
+
+			$State
+			[
+			$State.Reserve.Fuel
+			]
+			 
+			=
+			 
+			0
+
+			* Infinite loop, pass in state
+
+			* = [THIS]-> call script 'glen.trade.ok.lib' : Func=$Lib.Get.Reserve.Jump.Energy Arg1=null Arg2=null Arg3=null Arg4=null Arg5=null Arg6=null
+
+			end
+
+
+			$State
+			[
+			$State.Version
+			]
+			 
+			=
+			 
+			$Ver.Config
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Internal.Trade.Cache.Add:
+
+			*  Add state cache entry
+
+			* ******************************************************************************
+
+			$Key
+			 
+			=
+			 
+			null
+
+			Internal.Trade.Cache.Add
+			:
+
+			$Mission
+			 
+			=
+			 
+			$Arg1
+
+			$Station
+			 
+			=
+			 
+			$Arg2
+
+			$Ware
+			 
+			=
+			 
+			$Arg3
+
+
+			skip
+			 
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+			 
+			OR
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Sell
+
+			return
+			 
+			null
+
+
+			gosub
+			 
+			Make.Cache.Key
+			:
+
+
+			$Cache
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Trade.Cache
+			]
+
+			$Keys
+			 
+			=
+			 
+			$Cache
+			[
+			1
+			]
+
+			$Values
+			 
+			=
+			 
+			$Cache
+			[
+			2
+			]
+
+			$Key.idx
+			 
+			=
+			 
+			get
+			 
+			index
+			 
+			of
+			 
+			$Key
+			 
+			in
+			 
+			array
+			 
+			$Keys
+			 
+			offset
+			=
+			-1
+
+
+			if
+			 
+			$Key.idx
+			 
+			<
+			 
+			0
+
+			$Ships
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			[THIS]
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			append
+			 
+			$Key
+			 
+			to
+			 
+			array
+			 
+			$Keys
+
+			append
+			 
+			$Ships
+			 
+			to
+			 
+			array
+			 
+			$Values
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Trade.Cache.Add: Added cache and ship entry. Mission=%s, Station=%s, Ware=%s, Key=%s'
+			 
+			arg1
+			=
+			$Mission
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Key
+			 
+			arg5
+			=
+			null
+
+			else
+
+			$Ships
+			 
+			=
+			 
+			$Values
+			[
+			$Key.idx
+			]
+
+			if
+			 
+			not
+			 
+			find
+			 
+			[THIS]
+			 
+			in
+			 
+			array
+			:
+			 
+			$Ships
+
+			append
+			 
+			[THIS]
+			 
+			to
+			 
+			array
+			 
+			$Ships
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Trade.Cache.Add: Added ship entry. Mission=%s, Station=%s, Ware=%s, Key=%s, Ships=%s'
+			 
+			arg1
+			=
+			$Mission
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Key
+			 
+			arg5
+			=
+			$Ships
+
+			else
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Trade.Cache.Add: Already exists. Mission=%s, Station=%s, Ware=%s, Key=%s, Ships=%s'
+			 
+			arg1
+			=
+			$Mission
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Key
+			 
+			arg5
+			=
+			$Ships
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Internal.Trade.Cache.Remove:
+
+			*  Remove state cache entry.
+
+			* ******************************************************************************
+
+			Internal.Trade.Cache.Remove
+			:
+
+			$Mission
+			 
+			=
+			 
+			$Arg1
+
+			$Station
+			 
+			=
+			 
+			$Arg2
+
+			$Ware
+			 
+			=
+			 
+			$Arg3
+
+
+			skip
+			 
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+			 
+			OR
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Sell
+
+			return
+			 
+			null
+
+
+			gosub
+			 
+			Make.Cache.Key
+			:
+
+
+			$Cache
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Trade.Cache
+			]
+
+			$Keys
+			 
+			=
+			 
+			$Cache
+			[
+			1
+			]
+
+			$Key.idx
+			 
+			=
+			 
+			get
+			 
+			index
+			 
+			of
+			 
+			$Key
+			 
+			in
+			 
+			array
+			 
+			$Keys
+			 
+			offset
+			=
+			-1
+
+			if
+			 
+			$Key.idx
+			 
+			<
+			 
+			0
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Trade.Cache.Remove: No cache entry exists. Mission=%s, Station=%s, Ware=%s, Key=%s'
+			 
+			arg1
+			=
+			$Mission
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Key
+			 
+			arg5
+			=
+			null
+
+			return
+			 
+			null
+
+			end
+
+
+			$Values
+			 
+			=
+			 
+			$Cache
+			[
+			2
+			]
+
+			$Ships
+			 
+			=
+			 
+			$Values
+			[
+			$Key.idx
+			]
+
+			$idx
+			 
+			=
+			 
+			get
+			 
+			index
+			 
+			of
+			 
+			[THIS]
+			 
+			in
+			 
+			array
+			 
+			$Ships
+			 
+			offset
+			=
+			-1
+
+			if
+			 
+			$idx
+			 
+			>=
+			 
+			0
+
+			remove
+			 
+			element
+			 
+			from
+			 
+			array
+			 
+			$Ships
+			 
+			at
+			 
+			index
+			 
+			$idx
+
+			if
+			 
+			not
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Ships
+
+			remove
+			 
+			element
+			 
+			from
+			 
+			array
+			 
+			$Keys
+			 
+			at
+			 
+			index
+			 
+			$Key.idx
+
+			remove
+			 
+			element
+			 
+			from
+			 
+			array
+			 
+			$Values
+			 
+			at
+			 
+			index
+			 
+			$Key.idx
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Trade.Cache.Remove: Removed ship and cache entries. Mission=%s, Station=%s, Ware=%s, Key=%s'
+			 
+			arg1
+			=
+			$Mission
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Key
+			 
+			arg5
+			=
+			null
+
+			else
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Trade.Cache.Remove: Removed ship entry. Mission=%s, Station=%s, Ware=%s, Key=%s. Remaining ships=%s'
+			 
+			arg1
+			=
+			$Mission
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Key
+			 
+			arg5
+			=
+			$Ships
+
+			end
+
+			else
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Trade.Cache.Remove: No ship entry exists. Mission=%s, Station=%s, Ware=%s, Key=%s, Ships=%s'
+			 
+			arg1
+			=
+			$Mission
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Key
+			 
+			arg5
+			=
+			$Ships
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Check.Competition
+
+			*  Check if another OK trader is performing the same trade at a factory.
+
+			* ******************************************************************************
+
+			Lib.State.Check.Competition
+			:
+
+			$rc
+			 
+			=
+			 
+			0
+
+			$Mission
+			 
+			=
+			 
+			$Arg1
+
+			$Station
+			 
+			=
+			 
+			$Arg2
+
+			$Ware
+			 
+			=
+			 
+			$Arg3
+
+
+			skip
+			 
+			if
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+			 
+			OR
+			 
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Sell
+
+			return
+			 
+			null
+
+
+			gosub
+			 
+			Make.Cache.Key
+			:
+
+
+			$Cache
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Trade.Cache
+			]
+
+			$Keys
+			 
+			=
+			 
+			$Cache
+			[
+			1
+			]
+
+			$Key.idx
+			 
+			=
+			 
+			get
+			 
+			index
+			 
+			of
+			 
+			$Key
+			 
+			in
+			 
+			array
+			 
+			$Keys
+			 
+			offset
+			=
+			-1
+
+			if
+			 
+			$Key.idx
+			 
+			<
+			 
+			0
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Trade.Cache.Test: No cache entry exists. Mission=%s, Station=%s, Ware=%s, Key=%s'
+			 
+			arg1
+			=
+			$Mission
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Key
+			 
+			arg5
+			=
+			null
+
+			return
+			 
+			0
+
+			end
+
+
+			$Values
+			 
+			=
+			 
+			$Cache
+			[
+			2
+			]
+
+			$Ships
+			 
+			=
+			 
+			$Values
+			[
+			$Key.idx
+			]
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Ships
+
+			while
+			 
+			$idx
+			 
+			>
+			 
+			0
+
+			dec
+			 
+			$idx
+
+			$Ship
+			 
+			=
+			 
+			$Ships
+			[
+			$idx
+			]
+
+
+			$Stale
+			 
+			=
+			 
+			1
+
+			while
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			$Ship
+			->
+			 
+			exists
+
+			break
+
+			skip
+			 
+			if
+			 
+			$Ship
+			->
+			 
+			is
+			 
+			script
+			 
+			glen.trade.ok.cmd
+			 
+			on
+			 
+			stack
+			 
+			of
+			 
+			task
+			=
+			0
+
+			break
+
+			$Ship.State
+			 
+			=
+			 
+			$Ship
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.state
+			 
+			:
+			 
+			Func
+			=
+			$Lib.State.Fetch
+			 
+			Arg1
+			=
+			null
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+
+			$Ship.Ware
+			 
+			=
+			 
+			$Ship.State
+			[
+			$State.Ware
+			]
+
+			skip
+			 
+			if
+			 
+			$Ship.Ware
+			 
+			==
+			 
+			$Ware
+
+			break
+
+
+			$Ship.Mission
+			 
+			=
+			 
+			$Ship.State
+			[
+			$State.Mission
+			]
+
+			$Ship.Dest
+			 
+			=
+			 
+			$Ship.State
+			[
+			$State.Dest
+			]
+
+			$Ship.Dest2
+			 
+			=
+			 
+			$Ship.State
+			[
+			$State.Dest2
+			]
+
+
+			if
+			 
+			$Ship.Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+			if
+			 
+			(
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+			 
+			AND
+			 
+			$Ship.Dest
+			 
+			!=
+			 
+			$Station
+			)
+			 
+			OR
+			 
+			(
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Sell
+			 
+			AND
+			 
+			$Ship.Dest2
+			 
+			!=
+			 
+			$Station
+			)
+
+			break
+
+			end
+
+			else
+			 
+			if
+			 
+			$Ship.Mission
+			 
+			!=
+			 
+			$Mission
+			 
+			OR
+			 
+			$Ship.Dest
+			 
+			!=
+			 
+			$Station
+
+			break
+
+			end
+
+			$Stale
+			 
+			=
+			 
+			0
+
+			skip
+			 
+			if
+			 
+			$Ship
+			 
+			!=
+			 
+			[THIS]
+
+			break
+
+			$rc
+			 
+			=
+			 
+			1
+
+			break
+
+			end
+
+
+			if
+			 
+			$Stale
+
+			remove
+			 
+			element
+			 
+			from
+			 
+			array
+			 
+			$Ships
+			 
+			at
+			 
+			index
+			 
+			$idx
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Trade.Cache.Test: Removed stale ship entry. Mission=%s, Station=%s, Ware=%s, Key=%s, Ship=%s'
+			 
+			arg1
+			=
+			$Mission
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Key
+			 
+			arg5
+			=
+			$Ship
+
+			end
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$rc
+
+			break
+
+			end
+
+
+			if
+			 
+			not
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Ships
+
+			remove
+			 
+			element
+			 
+			from
+			 
+			array
+			 
+			$Keys
+			 
+			at
+			 
+			index
+			 
+			$Key.idx
+
+			remove
+			 
+			element
+			 
+			from
+			 
+			array
+			 
+			$Values
+			 
+			at
+			 
+			index
+			 
+			$Key.idx
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Trade.Cache.Test: Removed stale cache entry. Mission=%s, Station=%s, Ware=%s, Key=%s'
+			 
+			arg1
+			=
+			$Mission
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Key
+			 
+			arg5
+			=
+			null
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			8
+			 
+			fmt
+			=
+			'Trade.Cache.Test: Mission=%s, Station=%s, Ware=%s, Key=%s, rc=%s'
+			 
+			arg1
+			=
+			$Mission
+			 
+			arg2
+			=
+			$Station
+			 
+			arg3
+			=
+			$Ware
+			 
+			arg4
+			=
+			$Key
+			 
+			arg5
+			=
+			$rc
+
+			endsub
+
+
+			* ******************************************************************************
+
+			*
+
+			*  Check if another OK trader is performing the same trade at a factory.
+
+			* ******************************************************************************
+
+			Make.Cache.Key
+			:
+
+			$Station.Id
+			 
+			=
+			 
+			$Station
+			->
+			 
+			get
+			 
+			ID
+			 
+			code
+
+			$Ware.Maintype
+			 
+			=
+			 
+			get
+			 
+			maintype
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$Ware.Subtype
+			 
+			=
+			 
+			get
+			 
+			subtype
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			$Key
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			fmt
+			=
+			'%s_%s_%s_%s'
+			,
+			 
+			$Mission
+			,
+			 
+			$Station.Id
+			,
+			 
+			$Ware.Maintype
+			,
+			 
+			$Ware.Subtype
+			,
+			 
+			null
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Auto.Rename
+
+			* ******************************************************************************
+
+			Auto.Rename
+			:
+
+			skip
+			 
+			if
+			 
+			$Config
+			[
+			$Config.Auto.Rename
+			]
+
+			endsub
+
+			$PageId
+			 
+			=
+			 
+			$Config
+			[
+			$Config.PageId
+			]
+
+
+			$Name.Old
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			name
+
+			$Name.Job
+			 
+			=
+			 
+			null
+
+			$Name.Home
+			 
+			=
+			 
+			null
+
+
+			if
+			 
+			[HOMEBASE]
+
+			$Name.Home
+			 
+			=
+			 
+			[HOMEBASE]
+			->
+			 
+			get
+			 
+			name
+
+			gosub
+			 
+			Get.Job.Homebased
+			:
+
+			else
+
+			$Tether.Sector
+			 
+			=
+			 
+			$State
+			[
+			$State.Tether.Sector
+			]
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Tether.Sector
+
+			$Name.Home
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			fmt
+			=
+			'%s'
+			,
+			 
+			$Tether.Sector
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Trade.Mode
+			 
+			=
+			 
+			$State
+			[
+			$State.Trade.Mode
+			]
+
+			if
+			 
+			$Trade.Mode
+			 
+			==
+			 
+			$Trade.Mode.Player
+
+			$Name.Job
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			1102
+
+			else
+			 
+			if
+			 
+			$Trade.Mode
+			 
+			==
+			 
+			$Trade.Mode.Economy
+
+			$Name.Job
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			1101
+
+			else
+
+			$Name.Job
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			$PageId
+			 
+			id
+			=
+			1100
+
+			end
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			$Name.Job
+
+			endsub
+
+			if
+			 
+			$Name.Home
+
+			$Name.New
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			fmt
+			=
+			'%s (%s)'
+			,
+			 
+			$Name.Job
+			,
+			 
+			$Name.Home
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			else
+
+			$Name.New
+			 
+			=
+			 
+			$Name.Job
+
+			end
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.trace
+			 
+			:
+			 
+			comp
+			=
+			$Comp
+			 
+			lvl
+			=
+			7
+			 
+			fmt
+			=
+			'Auto-rename: Old=%s, New=%s'
+			 
+			arg1
+			=
+			$Name.Old
+			 
+			arg2
+			=
+			$Name.New
+			 
+			arg3
+			=
+			null
+			 
+			arg4
+			=
+			null
+			 
+			arg5
+			=
+			null
+
+
+			[THIS]
+			->
+			 
+			set
+			 
+			name
+			 
+			to
+			 
+			$Name.New
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Get.Job.Homebased
+
+			* Input: $Mission, $Ware
+
+			* ******************************************************************************
+
+			Get.Job.Homebased
+			:
+
+
+			$Ware.Naming
+			 
+			=
+			 
+			null
+
+			* Identify which ware trader is bringing home
+
+			if
+			 
+			(
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Move.Station
+			)
+			 
+			AND
+			 
+			(
+			$Dest
+			 
+			==
+			 
+			[HOMEBASE]
+			)
+
+			$Ware.Entries
+			 
+			=
+			 
+			$State
+			[
+			$State.Ware.Entries
+			]
+
+			skip
+			 
+			if
+			 
+			$Ware.Entries
+
+			endsub
+
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Ware.Entries
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ware.Entry
+			 
+			=
+			 
+			$Ware.Entries
+			[
+			$idx
+			]
+
+			$Entry.Ware
+			 
+			=
+			 
+			$Ware.Entry
+			[
+			0
+			]
+
+			$Entry.Mode
+			 
+			=
+			 
+			$Ware.Entry
+			[
+			1
+			]
+
+			if
+			 
+			$Entry.Mode
+			 
+			==
+			 
+			$Mission.Type.Buy
+
+			$Entry.Have
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			get
+			 
+			amount
+			 
+			of
+			 
+			ware
+			 
+			$Entry.Ware
+			 
+			in
+			 
+			cargo
+			 
+			bay
+
+			if
+			 
+			$Entry.Have
+
+			$Entry.Reserved
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.Get.Reserved.Amount
+			 
+			Arg1
+			=
+			$Entry.Ware
+			 
+			Arg2
+			=
+			null
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			if
+			 
+			$Entry.Have
+			 
+			>
+			 
+			$Entry.Reserved
+
+			$Ware.Naming
+			 
+			=
+			 
+			$Entry.Ware
+
+			break
+
+			end
+
+			end
+
+			end
+
+			end
+
+
+			else
+			 
+			if
+			 
+			(
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Buy
+			)
+			 
+			OR
+			 
+			(
+			$Mission
+			 
+			==
+			 
+			$Mission.Type.Sell
+			)
+
+			$Ware.Naming
+			 
+			=
+			 
+			$Ware
+
+			end
+
+
+			* [8] -- W - Lasers   10021 Weapons Dealer
+
+			* [9] -- W - Shields  10026 High Tech Transporter
+
+			* [10] - W - Missiles 10021 Weapons Dealer
+
+			* [11] - W - Energy   10022 Energy Transporter
+
+			* [12] - W - Naturals 10003 Freight Transporter
+
+			* [13] - W - Bio      10024 Bio Transporter
+
+			* [14] - W - Food     10025 Food Transporter
+
+			* [15] - W - Mineral  10023 Ore Transporter
+
+			* [16] - W - Tech     10026 High Tech Transporter
+
+
+			$Job.TextId
+			 
+			=
+			 
+			10003
+
+			if
+			 
+			$Ware.Naming
+
+			$MainType
+			 
+			=
+			 
+			get
+			 
+			maintype
+			 
+			of
+			 
+			ware
+			 
+			$Ware.Naming
+
+
+			if
+			 
+			(
+			$MainType
+			 
+			==
+			 
+			8
+			)
+			 
+			OR
+			 
+			(
+			$MainType
+			 
+			==
+			 
+			10
+			)
+
+			$Job.TextId
+			 
+			=
+			 
+			10021
+
+			else
+			 
+			if
+			 
+			(
+			$MainType
+			 
+			==
+			 
+			9
+			)
+			 
+			OR
+			 
+			(
+			$MainType
+			 
+			==
+			 
+			16
+			)
+
+			$Job.TextId
+			 
+			=
+			 
+			10026
+
+			else
+			 
+			if
+			 
+			$MainType
+			 
+			==
+			 
+			11
+
+			$Job.TextId
+			 
+			=
+			 
+			10022
+
+			else
+			 
+			if
+			 
+			$MainType
+			 
+			==
+			 
+			13
+
+			$Job.TextId
+			 
+			=
+			 
+			10024
+
+			else
+			 
+			if
+			 
+			$MainType
+			 
+			==
+			 
+			14
+
+			$Job.TextId
+			 
+			=
+			 
+			10025
+
+			else
+			 
+			if
+			 
+			$MainType
+			 
+			==
+			 
+			15
+
+			$Job.TextId
+			 
+			=
+			 
+			10023
+
+			end
+
+			end
+
+
+			$Name.Job
+			 
+			=
+			 
+			read
+			 
+			text
+			:
+			 
+			page
+			=
+			1000
+			 
+			id
+			=
+			$Job.TextId
+
+			endsub

--- a/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.trace.x3s
+++ b/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.trace.x3s
@@ -1,0 +1,229 @@
+#name: glen.trade.ok.trace
+#lang: 44
+#origin_mod: OKTraders1_7_1
+#source: mods/OKTraders1_7_1/scripts/glen.trade.ok.trace.xml
+
+
+			* ******************************************************************************
+
+			* OK Trade
+
+			*  Debug tracing
+
+			* ******************************************************************************
+
+
+			$Config
+			 
+			=
+			 
+			get
+			 
+			global
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+
+			skip
+			 
+			if
+			 
+			$Config
+
+			return
+			 
+			null
+
+
+			skip
+			 
+			if
+			 
+			$Config
+			[
+			5
+			]
+
+			return
+			 
+			null
+
+			$Debug.Verbosity
+			 
+			=
+			 
+			$Config
+			[
+			6
+			]
+
+			skip
+			 
+			if
+			 
+			$lvl
+			 
+			<=
+			 
+			$Debug.Verbosity
+
+			return
+			 
+			null
+
+			$Debug.Target
+			 
+			=
+			 
+			$Config
+			[
+			7
+			]
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			(
+			[THIS]
+			 
+			AND
+			 
+			$Debug.Target
+			 
+			AND
+			 
+			(
+			$Debug.Target
+			 
+			!=
+			 
+			[THIS]
+			)
+			)
+
+			return
+			 
+			null
+
+
+			$PageId
+			 
+			=
+			 
+			$Config
+			[
+			4
+			]
+
+			$TaskId
+			 
+			=
+			 
+			get
+			 
+			task
+			 
+			ID
+
+			$Now
+			 
+			=
+			 
+			playing
+			 
+			time
+
+
+			$prefix
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			fmt
+			=
+			'[%s % -2s % -7s % -22s % -52s] '
+			,
+			 
+			$Now
+			,
+			 
+			$lvl
+			,
+			 
+			$comp
+			,
+			 
+			[SECTOR]
+			,
+			 
+			[THIS]
+
+			$suffix
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			fmt
+			=
+			$fmt
+			,
+			 
+			$arg1
+			,
+			 
+			$arg2
+			,
+			 
+			$arg3
+			,
+			 
+			$arg4
+			,
+			 
+			$arg5
+
+			$msg
+			 
+			=
+			 
+			$prefix
+			 
+			+
+			 
+			$suffix
+
+			write
+			 
+			to
+			 
+			log
+			 
+			file
+			 
+			$PageId
+			 
+			append
+			=
+			[TRUE]
+			 
+			value
+			=
+			$msg
+
+
+			return
+			 
+			null
+
+

--- a/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/setup.glen.trade.ok.x3s
+++ b/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/setup.glen.trade.ok.x3s
@@ -1,0 +1,2643 @@
+#name: setup.glen.trade.ok
+#lang: 44
+#origin_mod: OKTraders1_7_1
+#source: mods/OKTraders1_7_1/scripts/setup.glen.trade.ok.xml
+
+
+			* ******************************************************************************
+
+			* OK Trade
+
+			*  Setup script
+
+			* ******************************************************************************
+
+
+			$Ver.Major
+			 
+			=
+			 
+			1
+
+			$Ver.Minor
+			 
+			=
+			 
+			7
+
+			$Ver.Patch
+			 
+			=
+			 
+			1
+
+			$Required.Ware
+			 
+			=
+			 
+			{Trade Command Software MK2}
+
+			$PageId
+			 
+			=
+			 
+			9055
+
+
+			* A combined integer is handy for comparison, e.g. v1.2.3 =
+
+			* |Maj|Min|Pch|
+
+			* |001|002|003|
+
+			$Ver.Internal
+			 
+			=
+			 
+			(
+			$Ver.Major
+			 
+			*
+			 
+			1000000
+			)
+			 
+			+
+			 
+			(
+			$Ver.Minor
+			 
+			*
+			 
+			1000
+			)
+			 
+			+
+			 
+			$Ver.Patch
+
+
+			$Config.Ver.Major
+			 
+			=
+			 
+			0
+
+			$Config.Ver.Minor
+			 
+			=
+			 
+			1
+
+			$Config.Ver.Patch
+			 
+			=
+			 
+			2
+
+			$Config.Ver.Internal
+			 
+			=
+			 
+			3
+
+			$Config.PageId
+			 
+			=
+			 
+			4
+
+			$Config.Debug.Enabled
+			 
+			=
+			 
+			5
+
+			$Config.Debug.Verbosity
+			 
+			=
+			 
+			6
+
+			$Config.Debug.Target
+			 
+			=
+			 
+			7
+
+			$Config.Required.Ware
+			 
+			=
+			 
+			8
+
+			$Config.Auto.Rename
+			 
+			=
+			 
+			9
+
+			$Config.Blacklist
+			 
+			=
+			 
+			10
+
+			$Config.Monitor.Task
+			 
+			=
+			 
+			11
+
+			$Config.Trade.Threshold
+			 
+			=
+			 
+			12
+
+			$Config.All.Wares
+			 
+			=
+			 
+			13
+
+			$Config.Trade.Illegal.Wares
+			 
+			=
+			 
+			14
+
+			$Config.Races
+			 
+			=
+			 
+			15
+
+			$Config.Illegal.Wares
+			 
+			=
+			 
+			16
+
+			$Config.Refuel.Percent
+			 
+			=
+			 
+			17
+
+			$Config.Global.Balance
+			 
+			=
+			 
+			18
+
+			$Config.Trade.Cache
+			 
+			=
+			 
+			19
+
+			$Config.Equip
+			 
+			=
+			 
+			20
+
+			$Config.Alert.Sound
+			 
+			=
+			 
+			21
+
+
+			$State.Version
+			 
+			=
+			 
+			0
+
+			$State.Balance
+			 
+			=
+			 
+			7
+
+
+			$Lib.BigInt.Add
+			 
+			=
+			 
+			33
+
+
+			$Id.Logfile.Header
+			 
+			=
+			 
+			1000
+
+			$Id.Logbook.Installed
+			 
+			=
+			 
+			1001
+
+			$Id.Logbook.Upgraded
+			 
+			=
+			 
+			1002
+
+			$Id.Logbook.Downgraded
+			 
+			=
+			 
+			1003
+
+
+			$Config.Equip.Ver
+			 
+			=
+			 
+			0
+
+			$Config.Equip.Lasers
+			 
+			=
+			 
+			1
+
+			$Config.Equip.Shields
+			 
+			=
+			 
+			2
+
+			$Config.Equip.Missiles
+			 
+			=
+			 
+			3
+
+			$Config.Equip.Drones
+			 
+			=
+			 
+			4
+
+			$Config.Equip.DockingComputer
+			 
+			=
+			 
+			5
+
+			$Config.Equip.Jumpdrive
+			 
+			=
+			 
+			6
+
+			$Config.Equip.Triplex
+			 
+			=
+			 
+			7
+
+			$Config.Equip.Rudder
+			 
+			=
+			 
+			8
+
+			$Config.Equip.CargoLifeSupport
+			 
+			=
+			 
+			9
+
+			$Config.Equip.Duplex
+			 
+			=
+			 
+			10
+
+
+			$Null
+			 
+			=
+			 
+			null
+
+
+			load
+			 
+			text
+			:
+			 
+			id
+			=
+			$PageId
+
+			$Config
+			 
+			=
+			 
+			get
+			 
+			global
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+
+
+			write
+			 
+			to
+			 
+			log
+			 
+			file
+			 
+			$PageId
+			 
+			append
+			=
+			0
+			 
+			printf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Id.Logfile.Header
+			,
+			 
+			$Ver.Major
+			,
+			 
+			$Ver.Minor
+			,
+			 
+			$Ver.Patch
+			,
+			 
+			$Ver.Internal
+			,
+			 
+			null
+
+
+			if
+			 
+			not
+			 
+			$Config
+
+			gosub
+			 
+			Create.Config
+			:
+
+			write
+			 
+			to
+			 
+			log
+			 
+			file
+			 
+			$PageId
+			 
+			append
+			=
+			1
+			 
+			printf
+			:
+			 
+			fmt
+			=
+			'New install'
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			write
+			 
+			to
+			 
+			player
+			 
+			logbook
+			:
+			 
+			printf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Id.Logbook.Installed
+			,
+			 
+			$Ver.Major
+			,
+			 
+			$Ver.Minor
+			,
+			 
+			$Ver.Patch
+			,
+			 
+			null
+			,
+			 
+			null
+
+			else
+
+			$Existing.Ver.Internal
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+
+
+			if
+			 
+			$Ver.Internal
+			 
+			<
+			 
+			$Existing.Ver.Internal
+
+			gosub
+			 
+			Create.Config
+			:
+
+			write
+			 
+			to
+			 
+			log
+			 
+			file
+			 
+			$PageId
+			 
+			append
+			=
+			1
+			 
+			printf
+			:
+			 
+			fmt
+			=
+			'Rollback from %s'
+			,
+			 
+			$Existing.Ver.Internal
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			write
+			 
+			to
+			 
+			player
+			 
+			logbook
+			:
+			 
+			printf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Id.Logbook.Downgraded
+			,
+			 
+			$Ver.Major
+			,
+			 
+			$Ver.Minor
+			,
+			 
+			$Ver.Patch
+			,
+			 
+			null
+			,
+			 
+			null
+
+			else
+			 
+			if
+			 
+			$Ver.Internal
+			 
+			>
+			 
+			$Existing.Ver.Internal
+
+			gosub
+			 
+			Upgrade.Config
+			:
+
+			write
+			 
+			to
+			 
+			log
+			 
+			file
+			 
+			$PageId
+			 
+			append
+			=
+			1
+			 
+			printf
+			:
+			 
+			fmt
+			=
+			'Upgrade from %s'
+			,
+			 
+			$Existing.Ver.Internal
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			write
+			 
+			to
+			 
+			player
+			 
+			logbook
+			:
+			 
+			printf
+			:
+			 
+			pageid
+			=
+			$PageId
+			 
+			textid
+			=
+			$Id.Logbook.Upgraded
+			,
+			 
+			$Ver.Major
+			,
+			 
+			$Ver.Minor
+			,
+			 
+			$Ver.Patch
+			,
+			 
+			null
+			,
+			 
+			null
+
+			end
+
+			end
+
+
+			* Refresh this each time as mods can change
+
+			gosub
+			 
+			Enumerate.Races
+			:
+
+			gosub
+			 
+			Enumerate.Wares
+			:
+
+			gosub
+			 
+			Enumerate.Illegal.Wares
+			:
+
+			* Prune out dead blacklist entries
+
+			gosub
+			 
+			Clean.Blacklist
+			:
+
+
+			* The menu will show limited options when command requirements are not met
+
+			set
+			 
+			script
+			 
+			command
+			 
+			upgrade
+			:
+			 
+			command
+			=
+			[GLEN_OK_TRADE]
+			  
+			upgrade
+			=
+			[TRUE]
+
+			global
+			 
+			script
+			 
+			map
+			:
+			 
+			set
+			:
+			 
+			key
+			=
+			[GLEN_OK_TRADE]
+			,
+			 
+			class
+			=
+			[Moveable Ship]
+			,
+			 
+			race
+			=
+			[Player]
+			,
+			 
+			script
+			=
+			glen.trade.ok.cmd
+			,
+			 
+			prio
+			=
+			0
+
+			set
+			 
+			ship
+			 
+			command
+			 
+			preload
+			 
+			script
+			:
+			 
+			command
+			=
+			[GLEN_OK_TRADE]
+			 
+			script
+			=
+			glen.trade.ok.menu
+
+
+			return
+			 
+			null
+
+
+			* ******************************************************************************
+
+			* Create.Config
+
+			*  Create the global config array
+
+			* ******************************************************************************
+
+			Create.Config
+			:
+
+			$Config
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			100
+
+			set
+			 
+			global
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+			 
+			value
+			=
+			$Config
+
+			$Config
+			[
+			$Config.Ver.Major
+			]
+			 
+			=
+			 
+			$Ver.Major
+
+			$Config
+			[
+			$Config.Ver.Minor
+			]
+			 
+			=
+			 
+			$Ver.Minor
+
+			$Config
+			[
+			$Config.Ver.Patch
+			]
+			 
+			=
+			 
+			$Ver.Patch
+
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+			 
+			=
+			 
+			$Ver.Internal
+
+			$Config
+			[
+			$Config.PageId
+			]
+			 
+			=
+			 
+			$PageId
+
+			$Config
+			[
+			$Config.Debug.Enabled
+			]
+			 
+			=
+			 
+			0
+
+			$Config
+			[
+			$Config.Debug.Verbosity
+			]
+			 
+			=
+			 
+			10
+
+			$Config
+			[
+			$Config.Debug.Target
+			]
+			 
+			=
+			 
+			null
+
+			$Config
+			[
+			$Config.Required.Ware
+			]
+			 
+			=
+			 
+			$Required.Ware
+
+			$Config
+			[
+			$Config.Auto.Rename
+			]
+			 
+			=
+			 
+			0
+
+			$tmp
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Config
+			[
+			$Config.Blacklist
+			]
+			 
+			=
+			 
+			$tmp
+
+			$Config
+			[
+			$Config.Monitor.Task
+			]
+			 
+			=
+			 
+			9040
+
+			$Config
+			[
+			$Config.Trade.Threshold
+			]
+			 
+			=
+			 
+			10
+
+			$Config
+			[
+			$Config.Trade.Illegal.Wares
+			]
+			 
+			=
+			 
+			0
+
+			$Config
+			[
+			$Config.Refuel.Percent
+			]
+			 
+			=
+			 
+			15
+
+			$tmp
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			0
+			,
+			 
+			0
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Config
+			[
+			$Config.Global.Balance
+			]
+			 
+			=
+			 
+			$tmp
+
+			gosub
+			 
+			Init.Trade.Cache
+			:
+
+			gosub
+			 
+			Init.Equip.Config
+			:
+
+			$Config
+			[
+			$Config.Alert.Sound
+			]
+			 
+			=
+			 
+			1
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Upgrade.Config
+
+			*  Upgrade the global config array
+
+			* ******************************************************************************
+
+			Upgrade.Config
+			:
+
+			$Config
+			[
+			$Config.Ver.Major
+			]
+			 
+			=
+			 
+			$Ver.Major
+
+			$Config
+			[
+			$Config.Ver.Minor
+			]
+			 
+			=
+			 
+			$Ver.Minor
+
+			$Config
+			[
+			$Config.Ver.Patch
+			]
+			 
+			=
+			 
+			$Ver.Patch
+
+			$Config
+			[
+			$Config.Ver.Internal
+			]
+			 
+			=
+			 
+			$Ver.Internal
+
+
+			* Monitor task and stock threshold added in 1.1.0
+
+			if
+			 
+			$Existing.Ver.Internal
+			 
+			<
+			 
+			1001000
+
+			$Config
+			[
+			$Config.Monitor.Task
+			]
+			 
+			=
+			 
+			9040
+
+			$Config
+			[
+			$Config.Trade.Threshold
+			]
+			 
+			=
+			 
+			10
+
+			end
+
+
+			if
+			 
+			$Existing.Ver.Internal
+			 
+			<
+			 
+			1002000
+
+			$Config
+			[
+			$Config.Trade.Illegal.Wares
+			]
+			 
+			=
+			 
+			0
+
+			end
+
+
+			if
+			 
+			$Existing.Ver.Internal
+			 
+			<
+			 
+			1002004
+
+			$Config
+			[
+			$Config.Refuel.Percent
+			]
+			 
+			=
+			 
+			15
+
+			end
+
+
+			if
+			 
+			$Existing.Ver.Internal
+			 
+			<
+			 
+			1003002
+
+			$Global.Balance
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			0
+			,
+			 
+			0
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Config
+			[
+			$Config.Global.Balance
+			]
+			 
+			=
+			 
+			$Global.Balance
+
+			gosub
+			 
+			Set.Initial.Balance
+			:
+
+			end
+
+
+			if
+			 
+			$Existing.Ver.Internal
+			 
+			<
+			 
+			1004000
+
+			gosub
+			 
+			Init.Trade.Cache
+			:
+
+			end
+
+
+			if
+			 
+			$Existing.Ver.Internal
+			 
+			<
+			 
+			1005000
+
+			gosub
+			 
+			Init.Equip.Config
+			:
+
+			end
+
+
+			if
+			 
+			$Existing.Ver.Internal
+			 
+			<
+			 
+			1005001
+
+			$Equip.Config
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Equip
+			]
+
+			$Equip.Config
+			[
+			$Config.Equip.Rudder
+			]
+			 
+			=
+			 
+			1
+
+			$Config
+			[
+			$Config.Alert.Sound
+			]
+			 
+			=
+			 
+			1
+
+			end
+
+
+			if
+			 
+			$Existing.Ver.Internal
+			 
+			<
+			 
+			1005003
+
+			$Equip.Config
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Equip
+			]
+
+			$Equip.Config
+			[
+			$Config.Equip.CargoLifeSupport
+			]
+			 
+			=
+			 
+			1
+
+			$Equip.Config
+			[
+			$Config.Equip.Duplex
+			]
+			 
+			=
+			 
+			1
+
+			end
+
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Enumerate.Races
+
+			*  Make an array of races
+
+			* ******************************************************************************
+
+			Enumerate.Races
+			:
+
+			$Races
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Config
+			[
+			$Config.Races
+			]
+			 
+			=
+			 
+			$Races
+
+			append
+			 
+			[Aldrin (Races)]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			append
+			 
+			[Argon]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			append
+			 
+			[Boron]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			append
+			 
+			[Enemy Race]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			append
+			 
+			[Friendly Race]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			append
+			 
+			[Goner]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			append
+			 
+			[Kha'ak]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			append
+			 
+			[Neutral Race]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			append
+			 
+			[Paranid]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			append
+			 
+			[Pirates]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			append
+			 
+			[Player]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			append
+			 
+			[Split]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			append
+			 
+			[Teladi]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			append
+			 
+			[Terran]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			append
+			 
+			[Xenon]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			append
+			 
+			[Yaki]
+			 
+			to
+			 
+			array
+			 
+			$Races
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Enumerate.Wares
+
+			*  Get every tradeable ware
+
+			* ******************************************************************************
+
+			Enumerate.Wares
+			:
+
+			$All.Wares
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Skip.Wares
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			{Marine}
+			,
+			 
+			{Mercenary}
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Config
+			[
+			$Config.All.Wares
+			]
+			 
+			=
+			 
+			$All.Wares
+
+			$Omits
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			'^$'
+			,
+			 
+			'.*EMP.*'
+			,
+			 
+			'.*UNDEFINED.*'
+			,
+			 
+			'.*ReadText.*'
+			,
+			 
+			null
+
+			$Maintypes
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			8
+			,
+			 
+			9
+			,
+			 
+			10
+			,
+			 
+			11
+			,
+			 
+			12
+
+			append
+			 
+			13
+			 
+			to
+			 
+			array
+			 
+			$Maintypes
+
+			append
+			 
+			14
+			 
+			to
+			 
+			array
+			 
+			$Maintypes
+
+			append
+			 
+			15
+			 
+			to
+			 
+			array
+			 
+			$Maintypes
+
+			append
+			 
+			16
+			 
+			to
+			 
+			array
+			 
+			$Maintypes
+
+
+			$idx.Maintype
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Maintypes
+
+			while
+			 
+			$idx.Maintype
+
+			dec
+			 
+			$idx.Maintype
+
+			$Maintype
+			 
+			=
+			 
+			$Maintypes
+			[
+			$idx.Maintype
+			]
+
+			$Subtype
+			 
+			=
+			 
+			get
+			 
+			number
+			 
+			of
+			 
+			subtypes
+			 
+			of
+			 
+			maintype
+			 
+			$Maintype
+
+			while
+			 
+			$Subtype
+
+			dec
+			 
+			$Subtype
+
+			$Ware
+			 
+			=
+			 
+			get
+			 
+			ware
+			 
+			from
+			 
+			maintype
+			 
+			$Maintype
+			 
+			and
+			 
+			subtype
+			 
+			$Subtype
+
+
+			while
+			 
+			1
+
+			skip
+			 
+			if
+			 
+			$Ware
+
+			break
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			is
+			 
+			upgrade
+			:
+			 
+			ware
+			=
+			$Ware
+
+			break
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			is
+			 
+			inventory
+			:
+			 
+			ware
+			=
+			$Ware
+
+			break
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			is
+			 
+			equipment
+			:
+			 
+			ware
+			=
+			$Ware
+
+			break
+
+			skip
+			 
+			if
+			 
+			get
+			 
+			min
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			break
+
+			$Max
+			 
+			=
+			 
+			get
+			 
+			max
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			skip
+			 
+			if
+			 
+			$Max
+			 
+			>
+			 
+			4
+
+			break
+
+			skip
+			 
+			if
+			 
+			get
+			 
+			average
+			 
+			price
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			break
+
+			skip
+			 
+			if
+			 
+			get
+			 
+			volume
+			 
+			of
+			 
+			ware
+			 
+			$Ware
+
+			break
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			find
+			 
+			$Ware
+			 
+			in
+			 
+			array
+			:
+			 
+			$Skip.Wares
+
+			break
+
+			$idx.Omit
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Omits
+
+			while
+			 
+			$idx.Omit
+
+			dec
+			 
+			$idx.Omit
+
+			$Omit
+			 
+			=
+			 
+			$Omits
+			[
+			$idx.Omit
+			]
+
+			$szWare
+			 
+			=
+			 
+			sprintf
+			:
+			 
+			fmt
+			=
+			'%s'
+			,
+			 
+			$Ware
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+			,
+			 
+			null
+
+			if
+			 
+			match
+			 
+			regular
+			 
+			expression
+			:
+			 
+			$Omit
+			 
+			to
+			 
+			string
+			 
+			$szWare
+
+			$Ware
+			 
+			=
+			 
+			null
+
+			break
+
+			end
+
+			end
+
+			skip
+			 
+			if
+			 
+			$Ware
+
+			break
+
+
+			append
+			 
+			$Ware
+			 
+			to
+			 
+			array
+			 
+			$All.Wares
+
+			break
+
+			end
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Enumerate.Wares
+
+			*  Get illegal wares
+
+			* ******************************************************************************
+
+			Enumerate.Illegal.Wares
+			:
+
+			$Illegal.Wares
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Config
+			[
+			$Config.Illegal.Wares
+			]
+			 
+			=
+			 
+			$Illegal.Wares
+
+
+			$Wares
+			 
+			=
+			 
+			$Config
+			[
+			$Config.All.Wares
+			]
+
+			$Races
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Races
+			]
+
+			$idx.Ware
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Wares
+
+			while
+			 
+			$idx.Ware
+
+			dec
+			 
+			$idx.Ware
+
+			$Ware
+			 
+			=
+			 
+			$Wares
+			[
+			$idx.Ware
+			]
+
+
+			$idx.Race
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Races
+
+			while
+			 
+			$idx.Race
+
+			dec
+			 
+			$idx.Race
+
+			$Race
+			 
+			=
+			 
+			$Races
+			[
+			$idx.Race
+			]
+
+
+			skip
+			 
+			if
+			 
+			not
+			 
+			is
+			 
+			ware
+			 
+			$Ware
+			 
+			illegal
+			 
+			in
+			 
+			$Race
+			 
+			sectors
+
+			append
+			 
+			$Ware
+			 
+			to
+			 
+			array
+			 
+			$Illegal.Wares
+
+			end
+
+			end
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Set.Initial.Balance:
+
+			*  On upgrade to 1.3.2 or layer, set inital global balance value tosum of living trader profit.
+
+			* ******************************************************************************
+
+			Set.Initial.Balance
+			:
+
+			$Global.Balance
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Global.Balance
+			]
+
+
+			$Ships
+			 
+			=
+			 
+			get
+			 
+			ship
+			 
+			array
+			:
+			 
+			of
+			 
+			race
+			 
+			[Player]
+			 
+			class
+			/
+			type
+			=
+			[Moveable Ship]
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Ships
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Ship
+			 
+			=
+			 
+			$Ships
+			[
+			$idx
+			]
+
+			$State
+			 
+			=
+			 
+			$Ship
+			->
+			 
+			get
+			 
+			local
+			 
+			variable
+			:
+			 
+			name
+			=
+			'glen.trade.ok'
+
+			skip
+			 
+			if
+			 
+			$State
+
+			continue
+
+			$State.Ver
+			 
+			=
+			 
+			$State
+			[
+			$State.Version
+			]
+
+			skip
+			 
+			if
+			 
+			$State.Ver
+			 
+			>=
+			 
+			1002000
+
+			continue
+
+			$Ship.Balance
+			 
+			=
+			 
+			$State
+			[
+			$State.Balance
+			]
+
+			$Global.Balance
+			 
+			=
+			 
+			[THIS]
+			->
+			 
+			call
+			 
+			script
+			 
+			glen.trade.ok.lib
+			 
+			:
+			 
+			Func
+			=
+			$Lib.BigInt.Add
+			 
+			Arg1
+			=
+			$Global.Balance
+			 
+			Arg2
+			=
+			$Ship.Balance
+			 
+			Arg3
+			=
+			null
+			 
+			Arg4
+			=
+			null
+			 
+			Arg5
+			=
+			null
+			 
+			Arg6
+			=
+			null
+
+			end
+
+
+			$Config
+			[
+			$Config.Global.Balance
+			]
+			 
+			=
+			 
+			$Global.Balance
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Init.Trade.Cache:
+
+			*  Create global cache of in-play trades, used for checking whether a trade
+
+			*  is already being performed
+
+			*  [0] - Version
+
+			*  [1] - Keys
+
+			*  [2] - Values ... See glen.trade.ok.state for more detail
+
+			* ******************************************************************************
+
+			Init.Trade.Cache
+			:
+
+			$Keys
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Values
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			0
+
+			$Cache
+			 
+			=
+			 
+			create
+			 
+			new
+			 
+			array
+			,
+			 
+			arguments
+			=
+			$Ver.Internal
+			,
+			 
+			$Keys
+			,
+			 
+			$Values
+			,
+			 
+			null
+			,
+			 
+			null
+
+			$Config
+			[
+			$Config.Trade.Cache
+			]
+			 
+			=
+			 
+			$Cache
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Init.Equip.Config:
+
+			* ******************************************************************************
+
+			Init.Equip.Config
+			:
+
+			$Equip.Config
+			 
+			=
+			 
+			array
+			 
+			alloc
+			:
+			 
+			size
+			=
+			20
+
+			$Config
+			[
+			$Config.Equip
+			]
+			 
+			=
+			 
+			$Equip.Config
+
+
+			$Equip.Config
+			[
+			$Config.Equip.Ver
+			]
+			 
+			=
+			 
+			$Ver.Internal
+
+			$Equip.Config
+			[
+			$Config.Equip.Lasers
+			]
+			 
+			=
+			 
+			0
+
+			$Equip.Config
+			[
+			$Config.Equip.Shields
+			]
+			 
+			=
+			 
+			1
+
+			$Equip.Config
+			[
+			$Config.Equip.Missiles
+			]
+			 
+			=
+			 
+			0
+
+			$Equip.Config
+			[
+			$Config.Equip.Drones
+			]
+			 
+			=
+			 
+			1
+
+			$Equip.Config
+			[
+			$Config.Equip.DockingComputer
+			]
+			 
+			=
+			 
+			1
+
+			$Equip.Config
+			[
+			$Config.Equip.Jumpdrive
+			]
+			 
+			=
+			 
+			1
+
+			$Equip.Config
+			[
+			$Config.Equip.Triplex
+			]
+			 
+			=
+			 
+			1
+
+			$Equip.Config
+			[
+			$Config.Equip.Rudder
+			]
+			 
+			=
+			 
+			1
+
+			$Equip.Config
+			[
+			$Config.Equip.CargoLifeSupport
+			]
+			 
+			=
+			 
+			1
+
+			$Equip.Config
+			[
+			$Config.Equip.Duplex
+			]
+			 
+			=
+			 
+			1
+
+			endsub
+
+
+			* ******************************************************************************
+
+			* Clean.Blacklist:
+
+			* ******************************************************************************
+
+			Clean.Blacklist
+			:
+
+			$Blacklist
+			 
+			=
+			 
+			$Config
+			[
+			$Config.Blacklist
+			]
+
+			skip
+			 
+			if
+			 
+			$Blacklist
+
+			endsub
+
+			* Trim out the dead wood
+
+			$idx
+			 
+			=
+			 
+			size
+			 
+			of
+			 
+			array
+			 
+			$Blacklist
+
+			while
+			 
+			$idx
+
+			dec
+			 
+			$idx
+
+			$Entry
+			 
+			=
+			 
+			$Blacklist
+			[
+			$idx
+			]
+
+			skip
+			 
+			if
+			 
+			$Entry
+			->
+			 
+			exists
+
+			remove
+			 
+			element
+			 
+			from
+			 
+			array
+			 
+			$Blacklist
+			 
+			at
+			 
+			index
+			 
+			$idx
+
+			end
+
+			endsub
+
+
+			return
+			 
+			null

--- a/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L007.xml
+++ b/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L007.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Generated using X-Studio -->
+<language id="7">
+
+	<page id="2008" title="Cmd ID" desc="" voice="no">
+		<t id="448">GLEN_OK_TRADE</t>
+	</page>
+
+	<page id="2010" title="Cmd Name" desc="" voice="no">
+		<t id="448">\33COK\33X Trade</t>
+	</page>
+
+	<page id="2011" title="Cmd Shortname" desc="" voice="no">
+		<t id="448">\33COK.T\33X</t>
+	</page>
+
+	<page id="2022" title="Cmd Desc" desc="" voice="no">
+		<t id="448">This command opens the \33COK\33X trade menu</t>
+	</page>
+
+	<page id="9055" title="OK Traders" desc="" voice="no">
+		<t id="0">\33COK\33X Traders</t>
+		<t id="1">\33COK\33X Home Trader</t>
+		<t id="2">\33COK\33X Free Trader</t>
+		<t id="6">Tether Sector: %s</t>
+		<t id="7">Tether Range: %s</t>
+		<t id="10">\33GStart Trading\33X</t>
+		<t id="15">Trader Balance: \33R%s\33X</t>
+		<t id="16">Trader Balance: \33G%s\33X</t>
+		<t id="17">Global Balance: \33R%s\33X</t>
+		<t id="18">Global Balance: \33G%s\33X</t>
+		<t id="20">Global Settings...</t>
+		<t id="21">Broadcast</t>
+		<t id="22">Ship Type</t>
+		<t id="25">Broadcast to docked ships</t>
+		<t id="28">\33MBroadcast:\33X Ships Homebased At: \33Y%s\33X</t>
+		<t id="29">\33MBroadcast:\33X Ships Docked At...</t>
+		<t id="30">\33RUninstall...\33X</t>
+		<t id="31">\33MBroadcast:\33X Fleet...</t>
+		<t id="49">\33Y!!\33X Free trading requires no homebase and %s \33Y!!\33X\n</t>
+		<t id="50">\33Y!!\33X Homebased trading requires a station homebase and %s \33Y!!\33X</t>
+		<t id="51">This ship is already trading. It`s orders can be reviewed and updated below. Changes take effect after the trader`s current action.</t>
+		<t id="52">This ship is already trading.</t>
+		<t id="53">When the trader has a homebase assigned it will trade wares only for its homebase.</t>
+		<t id="54">When the trader has no homebase assigned it will act as a free trader and seek out profitable trades.</t>
+		<t id="55">The broadcast command applies OK Trade with the selected ware options to multiple ships.</t>
+		<t id="56">Wares with \33Bblue\33X names cannot fit in this trader`s cargobay.</t>
+		<t id="70">Mode</t>
+		<t id="71">Normal \(Standard Free Trading\)</t>
+		<t id="72">\33GEconomy\33X \(Prefer Stalled NPC Stations\)</t>
+		<t id="73">\33OPlayer\33X \(Prefer Player Stations\)</t>
+		<t id="80">Stock Limits...</t>
+		<t id="81">Stock Limits</t>
+		<t id="82">Stock limits apply to all traders at that homebase.</t>
+		<t id="83">OK traders avoid selling wares below the minimum stock percentage, and avoid buying wares above the maximum stock percentage. Note that this limit only applies to OK Traders and not NPC traders.</t>
+		<t id="84">OK traders observe limits configured in the dockware manager bonus plugin for how much of a ware should be bought by a station, in addition to OK`s own percentage based settings. If both dockware manager and OK trade limits apply to a ware, the minimum of the 2 settings will be used by OK to determine the max stock level.</t>
+		<t id="85">\33WMin Stock %\33X</t>
+		<t id="86">\33WMax Stock %\33X</t>
+		<t id="87">\33WDockware Manager Limit\33X</t>
+		<t id="88">\33WWare\33X</t>
+		<t id="120">\33BBuy\33X</t>
+		<t id="121">\33MSell\33X</t>
+		<t id="122">\33YNo Trade\33X</t>
+		<t id="200">\33COK\33X Global Settings</t>
+		<t id="210">Auto Rename</t>
+		<t id="211">Blacklist...</t>
+		<t id="212">Min Stock Level Trade %</t>
+		<t id="213">Trade Illegal Wares</t>
+		<t id="214">Alert sound when targetted</t>
+		<t id="238">Homebased Traders</t>
+		<t id="239">Free Traders</t>
+		<t id="240">Debugging</t>
+		<t id="241">Logging</t>
+		<t id="242">Logging Target: %s</t>
+		<t id="243">Logging Verbosity</t>
+		<t id="250">&lt;all&gt;</t>
+		<t id="260">Select a logging target</t>
+		<t id="270">Equipment\n</t>
+		<t id="271">Lasers</t>
+		<t id="272">Shields</t>
+		<t id="273">Missiles</t>
+		<t id="274">Drones</t>
+		<t id="275">Docking Computer</t>
+		<t id="276">Jumpdrive</t>
+		<t id="277">Triplex Scanner</t>
+		<t id="278">Rudder Optimization</t>
+		<t id="279">Cargo Life Support</t>
+		<t id="280">Duplex Scanner</t>
+		<t id="300">\33COK\33X Uninstall</t>
+		<t id="310">\33GAbort\33x</t>
+		<t id="311">\33RUninstall\33x</t>
+		<t id="320">To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="330">\33COK\33X Traders - Uninstalling... %s\%</t>
+		<t id="331">\33COK\33X Traders has been uninstalled. To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="400">\33COK\33X Blacklist</t>
+		<t id="410">Add Sector...</t>
+		<t id="411">Add \33MPirate\33X Sectors</t>
+		<t id="412">Add \33BNon-Jumpable\33X Sectors</t>
+		<t id="413">Add \33RWar\33X Sectors</t>
+		<t id="414">\33YClear\33X List</t>
+		<t id="415">Add Station...</t>
+		<t id="416">Add Race Sectors...</t>
+		<t id="420">\33WSector\33X</t>
+		<t id="421">\33WRace\33X</t>
+		<t id="430">Add to blacklist</t>
+		<t id="500">Reset Free Trader Balance</t>
+		<t id="501">Reset Global Free Trader Balance</t>
+		<t id="1000">OK Traders Version=%s.%s.%s, Internal=%s</t>
+		<t id="1001">\33COK\33X Traders v%s.%s.%s installed.</t>
+		<t id="1002">\33COK\33X Traders upgraded to v%s.%s.%s.</t>
+		<t id="1003">\33COK\33X Traders downgraded to v%s.%s.%s.</t>
+		<t id="1050">Off</t>
+		<t id="1051">On</t>
+		<t id="1052">Yes</t>
+		<t id="1053">No</t>
+		<t id="1054">&lt;none&gt;</t>
+		<t id="1056">Any</t>
+		<t id="1059">\33B%s\33X</t>
+		<t id="1060">Freighters</t>
+		<t id="1100">Free Trader</t>
+		<t id="1101">\33GEco\33X Trader</t>
+		<t id="1102">\33OPlayer\33X Trader %s</t>
+		<t id="1200">\33COK\33X: %s \(%s\) - incoming missile in sector %s</t>
+		<t id="1201">\33COK\33X: %s \(%s\) - under attack by %s in sector %s</t>
+		<t id="1202">\33COK\33X: %s \(%s\) - targetted by enemy %s in sector %s</t>
+		<t id="2000">OK Traders %s.%s.%s</t>
+	</page>
+</language>

--- a/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L033.xml
+++ b/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L033.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Generated using X-Studio -->
+<language id="33">
+
+	<page id="2008" title="Cmd ID" desc="" voice="no">
+		<t id="448">GLEN_OK_TRADE</t>
+	</page>
+
+	<page id="2010" title="Cmd Name" desc="" voice="no">
+		<t id="448">\33COK\33X Trade</t>
+	</page>
+
+	<page id="2011" title="Cmd Shortname" desc="" voice="no">
+		<t id="448">\33COK.T\33X</t>
+	</page>
+
+	<page id="2022" title="Cmd Desc" desc="" voice="no">
+		<t id="448">This command opens the \33COK\33X trade menu</t>
+	</page>
+
+	<page id="9055" title="OK Traders" desc="" voice="no">
+		<t id="0">\33COK\33X Traders</t>
+		<t id="1">\33COK\33X Home Trader</t>
+		<t id="2">\33COK\33X Free Trader</t>
+		<t id="6">Tether Sector: %s</t>
+		<t id="7">Tether Range: %s</t>
+		<t id="10">\33GStart Trading\33X</t>
+		<t id="15">Trader Balance: \33R%s\33X</t>
+		<t id="16">Trader Balance: \33G%s\33X</t>
+		<t id="17">Global Balance: \33R%s\33X</t>
+		<t id="18">Global Balance: \33G%s\33X</t>
+		<t id="20">Global Settings...</t>
+		<t id="21">Broadcast</t>
+		<t id="22">Ship Type</t>
+		<t id="25">Broadcast to docked ships</t>
+		<t id="28">\33MBroadcast:\33X Ships Homebased At: \33Y%s\33X</t>
+		<t id="29">\33MBroadcast:\33X Ships Docked At...</t>
+		<t id="30">\33RUninstall...\33X</t>
+		<t id="31">\33MBroadcast:\33X Fleet...</t>
+		<t id="49">\33Y!!\33X Free trading requires no homebase and %s \33Y!!\33X\n</t>
+		<t id="50">\33Y!!\33X Homebased trading requires a station homebase and %s \33Y!!\33X</t>
+		<t id="51">This ship is already trading. It`s orders can be reviewed and updated below. Changes take effect after the trader`s current action.</t>
+		<t id="52">This ship is already trading.</t>
+		<t id="53">When the trader has a homebase assigned it will trade wares only for its homebase.</t>
+		<t id="54">When the trader has no homebase assigned it will act as a free trader and seek out profitable trades.</t>
+		<t id="55">The broadcast command applies OK Trade with the selected ware options to multiple ships.</t>
+		<t id="56">Wares with \33Bblue\33X names cannot fit in this trader`s cargobay.</t>
+		<t id="70">Mode</t>
+		<t id="71">Normal \(Standard Free Trading\)</t>
+		<t id="72">\33GEconomy\33X \(Prefer Stalled NPC Stations\)</t>
+		<t id="73">\33OPlayer\33X \(Prefer Player Stations\)</t>
+		<t id="80">Stock Limits...</t>
+		<t id="81">Stock Limits</t>
+		<t id="82">Stock limits apply to all traders at that homebase.</t>
+		<t id="83">OK traders avoid selling wares below the minimum stock percentage, and avoid buying wares above the maximum stock percentage. Note that this limit only applies to OK Traders and not NPC traders.</t>
+		<t id="84">OK traders observe limits configured in the dockware manager bonus plugin for how much of a ware should be bought by a station, in addition to OK`s own percentage based settings. If both dockware manager and OK trade limits apply to a ware, the minimum of the 2 settings will be used by OK to determine the max stock level.</t>
+		<t id="85">\33WMin Stock %\33X</t>
+		<t id="86">\33WMax Stock %\33X</t>
+		<t id="87">\33WDockware Manager Limit\33X</t>
+		<t id="88">\33WWare\33X</t>
+		<t id="120">\33BBuy\33X</t>
+		<t id="121">\33MSell\33X</t>
+		<t id="122">\33YNo Trade\33X</t>
+		<t id="200">\33COK\33X Global Settings</t>
+		<t id="210">Auto Rename</t>
+		<t id="211">Blacklist...</t>
+		<t id="212">Min Stock Level Trade %</t>
+		<t id="213">Trade Illegal Wares</t>
+		<t id="214">Alert sound when targetted</t>
+		<t id="238">Homebased Traders</t>
+		<t id="239">Free Traders</t>
+		<t id="240">Debugging</t>
+		<t id="241">Logging</t>
+		<t id="242">Logging Target: %s</t>
+		<t id="243">Logging Verbosity</t>
+		<t id="250">&lt;all&gt;</t>
+		<t id="260">Select a logging target</t>
+		<t id="270">Equipment\n</t>
+		<t id="271">Lasers</t>
+		<t id="272">Shields</t>
+		<t id="273">Missiles</t>
+		<t id="274">Drones</t>
+		<t id="275">Docking Computer</t>
+		<t id="276">Jumpdrive</t>
+		<t id="277">Triplex Scanner</t>
+		<t id="278">Rudder Optimization</t>
+		<t id="279">Cargo Life Support</t>
+		<t id="280">Duplex Scanner</t>
+		<t id="300">\33COK\33X Uninstall</t>
+		<t id="310">\33GAbort\33x</t>
+		<t id="311">\33RUninstall\33x</t>
+		<t id="320">To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="330">\33COK\33X Traders - Uninstalling... %s\%</t>
+		<t id="331">\33COK\33X Traders has been uninstalled. To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="400">\33COK\33X Blacklist</t>
+		<t id="410">Add Sector...</t>
+		<t id="411">Add \33MPirate\33X Sectors</t>
+		<t id="412">Add \33BNon-Jumpable\33X Sectors</t>
+		<t id="413">Add \33RWar\33X Sectors</t>
+		<t id="414">\33YClear\33X List</t>
+		<t id="415">Add Station...</t>
+		<t id="416">Add Race Sectors...</t>
+		<t id="420">\33WSector\33X</t>
+		<t id="421">\33WRace\33X</t>
+		<t id="430">Add to blacklist</t>
+		<t id="500">Reset Free Trader Balance</t>
+		<t id="501">Reset Global Free Trader Balance</t>
+		<t id="1000">OK Traders Version=%s.%s.%s, Internal=%s</t>
+		<t id="1001">\33COK\33X Traders v%s.%s.%s installed.</t>
+		<t id="1002">\33COK\33X Traders upgraded to v%s.%s.%s.</t>
+		<t id="1003">\33COK\33X Traders downgraded to v%s.%s.%s.</t>
+		<t id="1050">Off</t>
+		<t id="1051">On</t>
+		<t id="1052">Yes</t>
+		<t id="1053">No</t>
+		<t id="1054">&lt;none&gt;</t>
+		<t id="1056">Any</t>
+		<t id="1059">\33B%s\33X</t>
+		<t id="1060">Freighters</t>
+		<t id="1100">Free Trader</t>
+		<t id="1101">\33GEco\33X Trader</t>
+		<t id="1102">\33OPlayer\33X Trader %s</t>
+		<t id="1200">\33COK\33X: %s \(%s\) - incoming missile in sector %s</t>
+		<t id="1201">\33COK\33X: %s \(%s\) - under attack by %s in sector %s</t>
+		<t id="1202">\33COK\33X: %s \(%s\) - targetted by enemy %s in sector %s</t>
+		<t id="2000">OK Traders %s.%s.%s</t>
+	</page>
+</language>

--- a/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L034.xml
+++ b/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L034.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Generated using X-Studio -->
+<language id="34">
+
+	<page id="2008" title="Cmd ID" desc="" voice="no">
+		<t id="448">GLEN_OK_TRADE</t>
+	</page>
+
+	<page id="2010" title="Cmd Name" desc="" voice="no">
+		<t id="448">\33COK\33X Trade</t>
+	</page>
+
+	<page id="2011" title="Cmd Shortname" desc="" voice="no">
+		<t id="448">\33COK.T\33X</t>
+	</page>
+
+	<page id="2022" title="Cmd Desc" desc="" voice="no">
+		<t id="448">This command opens the \33COK\33X trade menu</t>
+	</page>
+
+	<page id="9055" title="OK Traders" desc="" voice="no">
+		<t id="0">\33COK\33X Traders</t>
+		<t id="1">\33COK\33X Home Trader</t>
+		<t id="2">\33COK\33X Free Trader</t>
+		<t id="6">Tether Sector: %s</t>
+		<t id="7">Tether Range: %s</t>
+		<t id="10">\33GStart Trading\33X</t>
+		<t id="15">Trader Balance: \33R%s\33X</t>
+		<t id="16">Trader Balance: \33G%s\33X</t>
+		<t id="17">Global Balance: \33R%s\33X</t>
+		<t id="18">Global Balance: \33G%s\33X</t>
+		<t id="20">Global Settings...</t>
+		<t id="21">Broadcast</t>
+		<t id="22">Ship Type</t>
+		<t id="25">Broadcast to docked ships</t>
+		<t id="28">\33MBroadcast:\33X Ships Homebased At: \33Y%s\33X</t>
+		<t id="29">\33MBroadcast:\33X Ships Docked At...</t>
+		<t id="30">\33RUninstall...\33X</t>
+		<t id="31">\33MBroadcast:\33X Fleet...</t>
+		<t id="49">\33Y!!\33X Free trading requires no homebase and %s \33Y!!\33X\n</t>
+		<t id="50">\33Y!!\33X Homebased trading requires a station homebase and %s \33Y!!\33X</t>
+		<t id="51">This ship is already trading. It`s orders can be reviewed and updated below. Changes take effect after the trader`s current action.</t>
+		<t id="52">This ship is already trading.</t>
+		<t id="53">When the trader has a homebase assigned it will trade wares only for its homebase.</t>
+		<t id="54">When the trader has no homebase assigned it will act as a free trader and seek out profitable trades.</t>
+		<t id="55">The broadcast command applies OK Trade with the selected ware options to multiple ships.</t>
+		<t id="56">Wares with \33Bblue\33X names cannot fit in this trader`s cargobay.</t>
+		<t id="70">Mode</t>
+		<t id="71">Normal \(Standard Free Trading\)</t>
+		<t id="72">\33GEconomy\33X \(Prefer Stalled NPC Stations\)</t>
+		<t id="73">\33OPlayer\33X \(Prefer Player Stations\)</t>
+		<t id="80">Stock Limits...</t>
+		<t id="81">Stock Limits</t>
+		<t id="82">Stock limits apply to all traders at that homebase.</t>
+		<t id="83">OK traders avoid selling wares below the minimum stock percentage, and avoid buying wares above the maximum stock percentage. Note that this limit only applies to OK Traders and not NPC traders.</t>
+		<t id="84">OK traders observe limits configured in the dockware manager bonus plugin for how much of a ware should be bought by a station, in addition to OK`s own percentage based settings. If both dockware manager and OK trade limits apply to a ware, the minimum of the 2 settings will be used by OK to determine the max stock level.</t>
+		<t id="85">\33WMin Stock %\33X</t>
+		<t id="86">\33WMax Stock %\33X</t>
+		<t id="87">\33WDockware Manager Limit\33X</t>
+		<t id="88">\33WWare\33X</t>
+		<t id="120">\33BBuy\33X</t>
+		<t id="121">\33MSell\33X</t>
+		<t id="122">\33YNo Trade\33X</t>
+		<t id="200">\33COK\33X Global Settings</t>
+		<t id="210">Auto Rename</t>
+		<t id="211">Blacklist...</t>
+		<t id="212">Min Stock Level Trade %</t>
+		<t id="213">Trade Illegal Wares</t>
+		<t id="214">Alert sound when targetted</t>
+		<t id="238">Homebased Traders</t>
+		<t id="239">Free Traders</t>
+		<t id="240">Debugging</t>
+		<t id="241">Logging</t>
+		<t id="242">Logging Target: %s</t>
+		<t id="243">Logging Verbosity</t>
+		<t id="250">&lt;all&gt;</t>
+		<t id="260">Select a logging target</t>
+		<t id="270">Equipment\n</t>
+		<t id="271">Lasers</t>
+		<t id="272">Shields</t>
+		<t id="273">Missiles</t>
+		<t id="274">Drones</t>
+		<t id="275">Docking Computer</t>
+		<t id="276">Jumpdrive</t>
+		<t id="277">Triplex Scanner</t>
+		<t id="278">Rudder Optimization</t>
+		<t id="279">Cargo Life Support</t>
+		<t id="280">Duplex Scanner</t>
+		<t id="300">\33COK\33X Uninstall</t>
+		<t id="310">\33GAbort\33x</t>
+		<t id="311">\33RUninstall\33x</t>
+		<t id="320">To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="330">\33COK\33X Traders - Uninstalling... %s\%</t>
+		<t id="331">\33COK\33X Traders has been uninstalled. To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="400">\33COK\33X Blacklist</t>
+		<t id="410">Add Sector...</t>
+		<t id="411">Add \33MPirate\33X Sectors</t>
+		<t id="412">Add \33BNon-Jumpable\33X Sectors</t>
+		<t id="413">Add \33RWar\33X Sectors</t>
+		<t id="414">\33YClear\33X List</t>
+		<t id="415">Add Station...</t>
+		<t id="416">Add Race Sectors...</t>
+		<t id="420">\33WSector\33X</t>
+		<t id="421">\33WRace\33X</t>
+		<t id="430">Add to blacklist</t>
+		<t id="500">Reset Free Trader Balance</t>
+		<t id="501">Reset Global Free Trader Balance</t>
+		<t id="1000">OK Traders Version=%s.%s.%s, Internal=%s</t>
+		<t id="1001">\33COK\33X Traders v%s.%s.%s installed.</t>
+		<t id="1002">\33COK\33X Traders upgraded to v%s.%s.%s.</t>
+		<t id="1003">\33COK\33X Traders downgraded to v%s.%s.%s.</t>
+		<t id="1050">Off</t>
+		<t id="1051">On</t>
+		<t id="1052">Yes</t>
+		<t id="1053">No</t>
+		<t id="1054">&lt;none&gt;</t>
+		<t id="1056">Any</t>
+		<t id="1059">\33B%s\33X</t>
+		<t id="1060">Freighters</t>
+		<t id="1100">Free Trader</t>
+		<t id="1101">\33GEco\33X Trader</t>
+		<t id="1102">\33OPlayer\33X Trader %s</t>
+		<t id="1200">\33COK\33X: %s \(%s\) - incoming missile in sector %s</t>
+		<t id="1201">\33COK\33X: %s \(%s\) - under attack by %s in sector %s</t>
+		<t id="1202">\33COK\33X: %s \(%s\) - targetted by enemy %s in sector %s</t>
+		<t id="2000">OK Traders %s.%s.%s</t>
+	</page>
+</language>

--- a/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L039.xml
+++ b/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L039.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Generated using X-Studio -->
+<language id="39">
+
+	<page id="2008" title="Cmd ID" desc="" voice="no">
+		<t id="448">GLEN_OK_TRADE</t>
+	</page>
+
+	<page id="2010" title="Cmd Name" desc="" voice="no">
+		<t id="448">\33COK\33X Trade</t>
+	</page>
+
+	<page id="2011" title="Cmd Shortname" desc="" voice="no">
+		<t id="448">\33COK.T\33X</t>
+	</page>
+
+	<page id="2022" title="Cmd Desc" desc="" voice="no">
+		<t id="448">This command opens the \33COK\33X trade menu</t>
+	</page>
+
+	<page id="9055" title="OK Traders" desc="" voice="no">
+		<t id="0">\33COK\33X Traders</t>
+		<t id="1">\33COK\33X Home Trader</t>
+		<t id="2">\33COK\33X Free Trader</t>
+		<t id="6">Tether Sector: %s</t>
+		<t id="7">Tether Range: %s</t>
+		<t id="10">\33GStart Trading\33X</t>
+		<t id="15">Trader Balance: \33R%s\33X</t>
+		<t id="16">Trader Balance: \33G%s\33X</t>
+		<t id="17">Global Balance: \33R%s\33X</t>
+		<t id="18">Global Balance: \33G%s\33X</t>
+		<t id="20">Global Settings...</t>
+		<t id="21">Broadcast</t>
+		<t id="22">Ship Type</t>
+		<t id="25">Broadcast to docked ships</t>
+		<t id="28">\33MBroadcast:\33X Ships Homebased At: \33Y%s\33X</t>
+		<t id="29">\33MBroadcast:\33X Ships Docked At...</t>
+		<t id="30">\33RUninstall...\33X</t>
+		<t id="31">\33MBroadcast:\33X Fleet...</t>
+		<t id="49">\33Y!!\33X Free trading requires no homebase and %s \33Y!!\33X\n</t>
+		<t id="50">\33Y!!\33X Homebased trading requires a station homebase and %s \33Y!!\33X</t>
+		<t id="51">This ship is already trading. It`s orders can be reviewed and updated below. Changes take effect after the trader`s current action.</t>
+		<t id="52">This ship is already trading.</t>
+		<t id="53">When the trader has a homebase assigned it will trade wares only for its homebase.</t>
+		<t id="54">When the trader has no homebase assigned it will act as a free trader and seek out profitable trades.</t>
+		<t id="55">The broadcast command applies OK Trade with the selected ware options to multiple ships.</t>
+		<t id="56">Wares with \33Bblue\33X names cannot fit in this trader`s cargobay.</t>
+		<t id="70">Mode</t>
+		<t id="71">Normal \(Standard Free Trading\)</t>
+		<t id="72">\33GEconomy\33X \(Prefer Stalled NPC Stations\)</t>
+		<t id="73">\33OPlayer\33X \(Prefer Player Stations\)</t>
+		<t id="80">Stock Limits...</t>
+		<t id="81">Stock Limits</t>
+		<t id="82">Stock limits apply to all traders at that homebase.</t>
+		<t id="83">OK traders avoid selling wares below the minimum stock percentage, and avoid buying wares above the maximum stock percentage. Note that this limit only applies to OK Traders and not NPC traders.</t>
+		<t id="84">OK traders observe limits configured in the dockware manager bonus plugin for how much of a ware should be bought by a station, in addition to OK`s own percentage based settings. If both dockware manager and OK trade limits apply to a ware, the minimum of the 2 settings will be used by OK to determine the max stock level.</t>
+		<t id="85">\33WMin Stock %\33X</t>
+		<t id="86">\33WMax Stock %\33X</t>
+		<t id="87">\33WDockware Manager Limit\33X</t>
+		<t id="88">\33WWare\33X</t>
+		<t id="120">\33BBuy\33X</t>
+		<t id="121">\33MSell\33X</t>
+		<t id="122">\33YNo Trade\33X</t>
+		<t id="200">\33COK\33X Global Settings</t>
+		<t id="210">Auto Rename</t>
+		<t id="211">Blacklist...</t>
+		<t id="212">Min Stock Level Trade %</t>
+		<t id="213">Trade Illegal Wares</t>
+		<t id="214">Alert sound when targetted</t>
+		<t id="238">Homebased Traders</t>
+		<t id="239">Free Traders</t>
+		<t id="240">Debugging</t>
+		<t id="241">Logging</t>
+		<t id="242">Logging Target: %s</t>
+		<t id="243">Logging Verbosity</t>
+		<t id="250">&lt;all&gt;</t>
+		<t id="260">Select a logging target</t>
+		<t id="270">Equipment\n</t>
+		<t id="271">Lasers</t>
+		<t id="272">Shields</t>
+		<t id="273">Missiles</t>
+		<t id="274">Drones</t>
+		<t id="275">Docking Computer</t>
+		<t id="276">Jumpdrive</t>
+		<t id="277">Triplex Scanner</t>
+		<t id="278">Rudder Optimization</t>
+		<t id="279">Cargo Life Support</t>
+		<t id="280">Duplex Scanner</t>
+		<t id="300">\33COK\33X Uninstall</t>
+		<t id="310">\33GAbort\33x</t>
+		<t id="311">\33RUninstall\33x</t>
+		<t id="320">To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="330">\33COK\33X Traders - Uninstalling... %s\%</t>
+		<t id="331">\33COK\33X Traders has been uninstalled. To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="400">\33COK\33X Blacklist</t>
+		<t id="410">Add Sector...</t>
+		<t id="411">Add \33MPirate\33X Sectors</t>
+		<t id="412">Add \33BNon-Jumpable\33X Sectors</t>
+		<t id="413">Add \33RWar\33X Sectors</t>
+		<t id="414">\33YClear\33X List</t>
+		<t id="415">Add Station...</t>
+		<t id="416">Add Race Sectors...</t>
+		<t id="420">\33WSector\33X</t>
+		<t id="421">\33WRace\33X</t>
+		<t id="430">Add to blacklist</t>
+		<t id="500">Reset Free Trader Balance</t>
+		<t id="501">Reset Global Free Trader Balance</t>
+		<t id="1000">OK Traders Version=%s.%s.%s, Internal=%s</t>
+		<t id="1001">\33COK\33X Traders v%s.%s.%s installed.</t>
+		<t id="1002">\33COK\33X Traders upgraded to v%s.%s.%s.</t>
+		<t id="1003">\33COK\33X Traders downgraded to v%s.%s.%s.</t>
+		<t id="1050">Off</t>
+		<t id="1051">On</t>
+		<t id="1052">Yes</t>
+		<t id="1053">No</t>
+		<t id="1054">&lt;none&gt;</t>
+		<t id="1056">Any</t>
+		<t id="1059">\33B%s\33X</t>
+		<t id="1060">Freighters</t>
+		<t id="1100">Free Trader</t>
+		<t id="1101">\33GEco\33X Trader</t>
+		<t id="1102">\33OPlayer\33X Trader %s</t>
+		<t id="1200">\33COK\33X: %s \(%s\) - incoming missile in sector %s</t>
+		<t id="1201">\33COK\33X: %s \(%s\) - under attack by %s in sector %s</t>
+		<t id="1202">\33COK\33X: %s \(%s\) - targetted by enemy %s in sector %s</t>
+		<t id="2000">OK Traders %s.%s.%s</t>
+	</page>
+</language>

--- a/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L042.xml
+++ b/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L042.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Generated using X-Studio -->
+<language id="42">
+
+	<page id="2008" title="Cmd ID" desc="" voice="no">
+		<t id="448">GLEN_OK_TRADE</t>
+	</page>
+
+	<page id="2010" title="Cmd Name" desc="" voice="no">
+		<t id="448">\33COK\33X Trade</t>
+	</page>
+
+	<page id="2011" title="Cmd Shortname" desc="" voice="no">
+		<t id="448">\33COK.T\33X</t>
+	</page>
+
+	<page id="2022" title="Cmd Desc" desc="" voice="no">
+		<t id="448">This command opens the \33COK\33X trade menu</t>
+	</page>
+
+	<page id="9055" title="OK Traders" desc="" voice="no">
+		<t id="0">\33COK\33X Traders</t>
+		<t id="1">\33COK\33X Home Trader</t>
+		<t id="2">\33COK\33X Free Trader</t>
+		<t id="6">Tether Sector: %s</t>
+		<t id="7">Tether Range: %s</t>
+		<t id="10">\33GStart Trading\33X</t>
+		<t id="15">Trader Balance: \33R%s\33X</t>
+		<t id="16">Trader Balance: \33G%s\33X</t>
+		<t id="17">Global Balance: \33R%s\33X</t>
+		<t id="18">Global Balance: \33G%s\33X</t>
+		<t id="20">Global Settings...</t>
+		<t id="21">Broadcast</t>
+		<t id="22">Ship Type</t>
+		<t id="25">Broadcast to docked ships</t>
+		<t id="28">\33MBroadcast:\33X Ships Homebased At: \33Y%s\33X</t>
+		<t id="29">\33MBroadcast:\33X Ships Docked At...</t>
+		<t id="30">\33RUninstall...\33X</t>
+		<t id="31">\33MBroadcast:\33X Fleet...</t>
+		<t id="49">\33Y!!\33X Free trading requires no homebase and %s \33Y!!\33X\n</t>
+		<t id="50">\33Y!!\33X Homebased trading requires a station homebase and %s \33Y!!\33X</t>
+		<t id="51">This ship is already trading. It`s orders can be reviewed and updated below. Changes take effect after the trader`s current action.</t>
+		<t id="52">This ship is already trading.</t>
+		<t id="53">When the trader has a homebase assigned it will trade wares only for its homebase.</t>
+		<t id="54">When the trader has no homebase assigned it will act as a free trader and seek out profitable trades.</t>
+		<t id="55">The broadcast command applies OK Trade with the selected ware options to multiple ships.</t>
+		<t id="56">Wares with \33Bblue\33X names cannot fit in this trader`s cargobay.</t>
+		<t id="70">Mode</t>
+		<t id="71">Normal \(Standard Free Trading\)</t>
+		<t id="72">\33GEconomy\33X \(Prefer Stalled NPC Stations\)</t>
+		<t id="73">\33OPlayer\33X \(Prefer Player Stations\)</t>
+		<t id="80">Stock Limits...</t>
+		<t id="81">Stock Limits</t>
+		<t id="82">Stock limits apply to all traders at that homebase.</t>
+		<t id="83">OK traders avoid selling wares below the minimum stock percentage, and avoid buying wares above the maximum stock percentage. Note that this limit only applies to OK Traders and not NPC traders.</t>
+		<t id="84">OK traders observe limits configured in the dockware manager bonus plugin for how much of a ware should be bought by a station, in addition to OK`s own percentage based settings. If both dockware manager and OK trade limits apply to a ware, the minimum of the 2 settings will be used by OK to determine the max stock level.</t>
+		<t id="85">\33WMin Stock %\33X</t>
+		<t id="86">\33WMax Stock %\33X</t>
+		<t id="87">\33WDockware Manager Limit\33X</t>
+		<t id="88">\33WWare\33X</t>
+		<t id="120">\33BBuy\33X</t>
+		<t id="121">\33MSell\33X</t>
+		<t id="122">\33YNo Trade\33X</t>
+		<t id="200">\33COK\33X Global Settings</t>
+		<t id="210">Auto Rename</t>
+		<t id="211">Blacklist...</t>
+		<t id="212">Min Stock Level Trade %</t>
+		<t id="213">Trade Illegal Wares</t>
+		<t id="214">Alert sound when targetted</t>
+		<t id="238">Homebased Traders</t>
+		<t id="239">Free Traders</t>
+		<t id="240">Debugging</t>
+		<t id="241">Logging</t>
+		<t id="242">Logging Target: %s</t>
+		<t id="243">Logging Verbosity</t>
+		<t id="250">&lt;all&gt;</t>
+		<t id="260">Select a logging target</t>
+		<t id="270">Equipment\n</t>
+		<t id="271">Lasers</t>
+		<t id="272">Shields</t>
+		<t id="273">Missiles</t>
+		<t id="274">Drones</t>
+		<t id="275">Docking Computer</t>
+		<t id="276">Jumpdrive</t>
+		<t id="277">Triplex Scanner</t>
+		<t id="278">Rudder Optimization</t>
+		<t id="279">Cargo Life Support</t>
+		<t id="280">Duplex Scanner</t>
+		<t id="300">\33COK\33X Uninstall</t>
+		<t id="310">\33GAbort\33x</t>
+		<t id="311">\33RUninstall\33x</t>
+		<t id="320">To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="330">\33COK\33X Traders - Uninstalling... %s\%</t>
+		<t id="331">\33COK\33X Traders has been uninstalled. To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="400">\33COK\33X Blacklist</t>
+		<t id="410">Add Sector...</t>
+		<t id="411">Add \33MPirate\33X Sectors</t>
+		<t id="412">Add \33BNon-Jumpable\33X Sectors</t>
+		<t id="413">Add \33RWar\33X Sectors</t>
+		<t id="414">\33YClear\33X List</t>
+		<t id="415">Add Station...</t>
+		<t id="416">Add Race Sectors...</t>
+		<t id="420">\33WSector\33X</t>
+		<t id="421">\33WRace\33X</t>
+		<t id="430">Add to blacklist</t>
+		<t id="500">Reset Free Trader Balance</t>
+		<t id="501">Reset Global Free Trader Balance</t>
+		<t id="1000">OK Traders Version=%s.%s.%s, Internal=%s</t>
+		<t id="1001">\33COK\33X Traders v%s.%s.%s installed.</t>
+		<t id="1002">\33COK\33X Traders upgraded to v%s.%s.%s.</t>
+		<t id="1003">\33COK\33X Traders downgraded to v%s.%s.%s.</t>
+		<t id="1050">Off</t>
+		<t id="1051">On</t>
+		<t id="1052">Yes</t>
+		<t id="1053">No</t>
+		<t id="1054">&lt;none&gt;</t>
+		<t id="1056">Any</t>
+		<t id="1059">\33B%s\33X</t>
+		<t id="1060">Freighters</t>
+		<t id="1100">Free Trader</t>
+		<t id="1101">\33GEco\33X Trader</t>
+		<t id="1102">\33OPlayer\33X Trader %s</t>
+		<t id="1200">\33COK\33X: %s \(%s\) - incoming missile in sector %s</t>
+		<t id="1201">\33COK\33X: %s \(%s\) - under attack by %s in sector %s</t>
+		<t id="1202">\33COK\33X: %s \(%s\) - targetted by enemy %s in sector %s</t>
+		<t id="2000">OK Traders %s.%s.%s</t>
+	</page>
+</language>

--- a/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L044.xml
+++ b/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L044.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Generated using X-Studio -->
+<language id="44">
+
+	<page id="2008" title="Cmd ID" desc="" voice="no">
+		<t id="448">GLEN_OK_TRADE</t>
+	</page>
+
+	<page id="2010" title="Cmd Name" desc="" voice="no">
+		<t id="448">\33COK\33X Trade</t>
+	</page>
+
+	<page id="2011" title="Cmd Shortname" desc="" voice="no">
+		<t id="448">\33COK.T\33X</t>
+	</page>
+
+	<page id="2022" title="Cmd Desc" desc="" voice="no">
+		<t id="448">This command opens the \33COK\33X trade menu</t>
+	</page>
+
+	<page id="9055" title="OK Traders" desc="" voice="no">
+		<t id="0">\33COK\33X Traders</t>
+		<t id="1">\33COK\33X Home Trader</t>
+		<t id="2">\33COK\33X Free Trader</t>
+		<t id="6">Tether Sector: %s</t>
+		<t id="7">Tether Range: %s</t>
+		<t id="10">\33GStart Trading\33X</t>
+		<t id="15">Trader Balance: \33R%s\33X</t>
+		<t id="16">Trader Balance: \33G%s\33X</t>
+		<t id="17">Global Balance: \33R%s\33X</t>
+		<t id="18">Global Balance: \33G%s\33X</t>
+		<t id="20">Global Settings...</t>
+		<t id="21">Broadcast</t>
+		<t id="22">Ship Type</t>
+		<t id="25">Broadcast to docked ships</t>
+		<t id="28">\33MBroadcast:\33X Ships Homebased At: \33Y%s\33X</t>
+		<t id="29">\33MBroadcast:\33X Ships Docked At...</t>
+		<t id="30">\33RUninstall...\33X</t>
+		<t id="31">\33MBroadcast:\33X Fleet...</t>
+		<t id="49">\33Y!!\33X Free trading requires no homebase and %s \33Y!!\33X\n</t>
+		<t id="50">\33Y!!\33X Homebased trading requires a station homebase and %s \33Y!!\33X</t>
+		<t id="51">This ship is already trading. It`s orders can be reviewed and updated below. Changes take effect after the trader`s current action.</t>
+		<t id="52">This ship is already trading.</t>
+		<t id="53">When the trader has a homebase assigned it will trade wares only for its homebase.</t>
+		<t id="54">When the trader has no homebase assigned it will act as a free trader and seek out profitable trades.</t>
+		<t id="55">The broadcast command applies OK Trade with the selected ware options to multiple ships.</t>
+		<t id="56">Wares with \33Bblue\33X names cannot fit in this trader`s cargobay.</t>
+		<t id="70">Mode</t>
+		<t id="71">Normal \(Standard Free Trading\)</t>
+		<t id="72">\33GEconomy\33X \(Prefer Stalled NPC Stations\)</t>
+		<t id="73">\33OPlayer\33X \(Prefer Player Stations\)</t>
+		<t id="80">Stock Limits...</t>
+		<t id="81">Stock Limits</t>
+		<t id="82">Stock limits apply to all traders at that homebase.</t>
+		<t id="83">OK traders avoid selling wares below the minimum stock percentage, and avoid buying wares above the maximum stock percentage. Note that this limit only applies to OK Traders and not NPC traders.</t>
+		<t id="84">OK traders observe limits configured in the dockware manager bonus plugin for how much of a ware should be bought by a station, in addition to OK`s own percentage based settings. If both dockware manager and OK trade limits apply to a ware, the minimum of the 2 settings will be used by OK to determine the max stock level.</t>
+		<t id="85">\33WMin Stock %\33X</t>
+		<t id="86">\33WMax Stock %\33X</t>
+		<t id="87">\33WDockware Manager Limit\33X</t>
+		<t id="88">\33WWare\33X</t>
+		<t id="120">\33BBuy\33X</t>
+		<t id="121">\33MSell\33X</t>
+		<t id="122">\33YNo Trade\33X</t>
+		<t id="200">\33COK\33X Global Settings</t>
+		<t id="210">Auto Rename</t>
+		<t id="211">Blacklist...</t>
+		<t id="212">Min Stock Level Trade %</t>
+		<t id="213">Trade Illegal Wares</t>
+		<t id="214">Alert sound when targetted</t>
+		<t id="238">Homebased Traders</t>
+		<t id="239">Free Traders</t>
+		<t id="240">Debugging</t>
+		<t id="241">Logging</t>
+		<t id="242">Logging Target: %s</t>
+		<t id="243">Logging Verbosity</t>
+		<t id="250">&lt;all&gt;</t>
+		<t id="260">Select a logging target</t>
+		<t id="270">Equipment\n</t>
+		<t id="271">Lasers</t>
+		<t id="272">Shields</t>
+		<t id="273">Missiles</t>
+		<t id="274">Drones</t>
+		<t id="275">Docking Computer</t>
+		<t id="276">Jumpdrive</t>
+		<t id="277">Triplex Scanner</t>
+		<t id="278">Rudder Optimization</t>
+		<t id="279">Cargo Life Support</t>
+		<t id="280">Duplex Scanner</t>
+		<t id="300">\33COK\33X Uninstall</t>
+		<t id="310">\33GAbort\33x</t>
+		<t id="311">\33RUninstall\33x</t>
+		<t id="320">To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="330">\33COK\33X Traders - Uninstalling... %s\%</t>
+		<t id="331">\33COK\33X Traders has been uninstalled. To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="400">\33COK\33X Blacklist</t>
+		<t id="410">Add Sector...</t>
+		<t id="411">Add \33MPirate\33X Sectors</t>
+		<t id="412">Add \33BNon-Jumpable\33X Sectors</t>
+		<t id="413">Add \33RWar\33X Sectors</t>
+		<t id="414">\33YClear\33X List</t>
+		<t id="415">Add Station...</t>
+		<t id="416">Add Race Sectors...</t>
+		<t id="420">\33WSector\33X</t>
+		<t id="421">\33WRace\33X</t>
+		<t id="430">Add to blacklist</t>
+		<t id="500">Reset Free Trader Balance</t>
+		<t id="501">Reset Global Free Trader Balance</t>
+		<t id="1000">OK Traders Version=%s.%s.%s, Internal=%s</t>
+		<t id="1001">\33COK\33X Traders v%s.%s.%s installed.</t>
+		<t id="1002">\33COK\33X Traders upgraded to v%s.%s.%s.</t>
+		<t id="1003">\33COK\33X Traders downgraded to v%s.%s.%s.</t>
+		<t id="1050">Off</t>
+		<t id="1051">On</t>
+		<t id="1052">Yes</t>
+		<t id="1053">No</t>
+		<t id="1054">&lt;none&gt;</t>
+		<t id="1056">Any</t>
+		<t id="1059">\33B%s\33X</t>
+		<t id="1060">Freighters</t>
+		<t id="1100">Free Trader</t>
+		<t id="1101">\33GEco\33X Trader</t>
+		<t id="1102">\33OPlayer\33X Trader %s</t>
+		<t id="1200">\33COK\33X: %s \(%s\) - incoming missile in sector %s</t>
+		<t id="1201">\33COK\33X: %s \(%s\) - under attack by %s in sector %s</t>
+		<t id="1202">\33COK\33X: %s \(%s\) - targetted by enemy %s in sector %s</t>
+		<t id="2000">OK Traders %s.%s.%s</t>
+	</page>
+</language>

--- a/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L048.xml
+++ b/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L048.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Generated using X-Studio -->
+<language id="48">
+
+	<page id="2008" title="Cmd ID" desc="" voice="no">
+		<t id="448">GLEN_OK_TRADE</t>
+	</page>
+
+	<page id="2010" title="Cmd Name" desc="" voice="no">
+		<t id="448">\33COK\33X Trade</t>
+	</page>
+
+	<page id="2011" title="Cmd Shortname" desc="" voice="no">
+		<t id="448">\33COK.T\33X</t>
+	</page>
+
+	<page id="2022" title="Cmd Desc" desc="" voice="no">
+		<t id="448">This command opens the \33COK\33X trade menu</t>
+	</page>
+
+	<page id="9055" title="OK Traders" desc="" voice="no">
+		<t id="0">\33COK\33X Traders</t>
+		<t id="1">\33COK\33X Home Trader</t>
+		<t id="2">\33COK\33X Free Trader</t>
+		<t id="6">Tether Sector: %s</t>
+		<t id="7">Tether Range: %s</t>
+		<t id="10">\33GStart Trading\33X</t>
+		<t id="15">Trader Balance: \33R%s\33X</t>
+		<t id="16">Trader Balance: \33G%s\33X</t>
+		<t id="17">Global Balance: \33R%s\33X</t>
+		<t id="18">Global Balance: \33G%s\33X</t>
+		<t id="20">Global Settings...</t>
+		<t id="21">Broadcast</t>
+		<t id="22">Ship Type</t>
+		<t id="25">Broadcast to docked ships</t>
+		<t id="28">\33MBroadcast:\33X Ships Homebased At: \33Y%s\33X</t>
+		<t id="29">\33MBroadcast:\33X Ships Docked At...</t>
+		<t id="30">\33RUninstall...\33X</t>
+		<t id="31">\33MBroadcast:\33X Fleet...</t>
+		<t id="49">\33Y!!\33X Free trading requires no homebase and %s \33Y!!\33X\n</t>
+		<t id="50">\33Y!!\33X Homebased trading requires a station homebase and %s \33Y!!\33X</t>
+		<t id="51">This ship is already trading. It`s orders can be reviewed and updated below. Changes take effect after the trader`s current action.</t>
+		<t id="52">This ship is already trading.</t>
+		<t id="53">When the trader has a homebase assigned it will trade wares only for its homebase.</t>
+		<t id="54">When the trader has no homebase assigned it will act as a free trader and seek out profitable trades.</t>
+		<t id="55">The broadcast command applies OK Trade with the selected ware options to multiple ships.</t>
+		<t id="56">Wares with \33Bblue\33X names cannot fit in this trader`s cargobay.</t>
+		<t id="70">Mode</t>
+		<t id="71">Normal \(Standard Free Trading\)</t>
+		<t id="72">\33GEconomy\33X \(Prefer Stalled NPC Stations\)</t>
+		<t id="73">\33OPlayer\33X \(Prefer Player Stations\)</t>
+		<t id="80">Stock Limits...</t>
+		<t id="81">Stock Limits</t>
+		<t id="82">Stock limits apply to all traders at that homebase.</t>
+		<t id="83">OK traders avoid selling wares below the minimum stock percentage, and avoid buying wares above the maximum stock percentage. Note that this limit only applies to OK Traders and not NPC traders.</t>
+		<t id="84">OK traders observe limits configured in the dockware manager bonus plugin for how much of a ware should be bought by a station, in addition to OK`s own percentage based settings. If both dockware manager and OK trade limits apply to a ware, the minimum of the 2 settings will be used by OK to determine the max stock level.</t>
+		<t id="85">\33WMin Stock %\33X</t>
+		<t id="86">\33WMax Stock %\33X</t>
+		<t id="87">\33WDockware Manager Limit\33X</t>
+		<t id="88">\33WWare\33X</t>
+		<t id="120">\33BBuy\33X</t>
+		<t id="121">\33MSell\33X</t>
+		<t id="122">\33YNo Trade\33X</t>
+		<t id="200">\33COK\33X Global Settings</t>
+		<t id="210">Auto Rename</t>
+		<t id="211">Blacklist...</t>
+		<t id="212">Min Stock Level Trade %</t>
+		<t id="213">Trade Illegal Wares</t>
+		<t id="214">Alert sound when targetted</t>
+		<t id="238">Homebased Traders</t>
+		<t id="239">Free Traders</t>
+		<t id="240">Debugging</t>
+		<t id="241">Logging</t>
+		<t id="242">Logging Target: %s</t>
+		<t id="243">Logging Verbosity</t>
+		<t id="250">&lt;all&gt;</t>
+		<t id="260">Select a logging target</t>
+		<t id="270">Equipment\n</t>
+		<t id="271">Lasers</t>
+		<t id="272">Shields</t>
+		<t id="273">Missiles</t>
+		<t id="274">Drones</t>
+		<t id="275">Docking Computer</t>
+		<t id="276">Jumpdrive</t>
+		<t id="277">Triplex Scanner</t>
+		<t id="278">Rudder Optimization</t>
+		<t id="279">Cargo Life Support</t>
+		<t id="280">Duplex Scanner</t>
+		<t id="300">\33COK\33X Uninstall</t>
+		<t id="310">\33GAbort\33x</t>
+		<t id="311">\33RUninstall\33x</t>
+		<t id="320">To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="330">\33COK\33X Traders - Uninstalling... %s\%</t>
+		<t id="331">\33COK\33X Traders has been uninstalled. To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="400">\33COK\33X Blacklist</t>
+		<t id="410">Add Sector...</t>
+		<t id="411">Add \33MPirate\33X Sectors</t>
+		<t id="412">Add \33BNon-Jumpable\33X Sectors</t>
+		<t id="413">Add \33RWar\33X Sectors</t>
+		<t id="414">\33YClear\33X List</t>
+		<t id="415">Add Station...</t>
+		<t id="416">Add Race Sectors...</t>
+		<t id="420">\33WSector\33X</t>
+		<t id="421">\33WRace\33X</t>
+		<t id="430">Add to blacklist</t>
+		<t id="500">Reset Free Trader Balance</t>
+		<t id="501">Reset Global Free Trader Balance</t>
+		<t id="1000">OK Traders Version=%s.%s.%s, Internal=%s</t>
+		<t id="1001">\33COK\33X Traders v%s.%s.%s installed.</t>
+		<t id="1002">\33COK\33X Traders upgraded to v%s.%s.%s.</t>
+		<t id="1003">\33COK\33X Traders downgraded to v%s.%s.%s.</t>
+		<t id="1050">Off</t>
+		<t id="1051">On</t>
+		<t id="1052">Yes</t>
+		<t id="1053">No</t>
+		<t id="1054">&lt;none&gt;</t>
+		<t id="1056">Any</t>
+		<t id="1059">\33B%s\33X</t>
+		<t id="1060">Freighters</t>
+		<t id="1100">Free Trader</t>
+		<t id="1101">\33GEco\33X Trader</t>
+		<t id="1102">\33OPlayer\33X Trader %s</t>
+		<t id="1200">\33COK\33X: %s \(%s\) - incoming missile in sector %s</t>
+		<t id="1201">\33COK\33X: %s \(%s\) - under attack by %s in sector %s</t>
+		<t id="1202">\33COK\33X: %s \(%s\) - targetted by enemy %s in sector %s</t>
+		<t id="2000">OK Traders %s.%s.%s</t>
+	</page>
+</language>

--- a/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L049.xml
+++ b/tools/fixtures/known_good/OKTraders1_7_1/t/9055-L049.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Generated using X-Studio -->
+<language id="49">
+
+	<page id="2008" title="Cmd ID" desc="" voice="no">
+		<t id="448">GLEN_OK_TRADE</t>
+	</page>
+
+	<page id="2010" title="Cmd Name" desc="" voice="no">
+		<t id="448">\33COK\33X Trade</t>
+	</page>
+
+	<page id="2011" title="Cmd Shortname" desc="" voice="no">
+		<t id="448">\33COK.T\33X</t>
+	</page>
+
+	<page id="2022" title="Cmd Desc" desc="" voice="no">
+		<t id="448">This command opens the \33COK\33X trade menu</t>
+	</page>
+
+	<page id="9055" title="OK Traders" desc="" voice="no">
+		<t id="0">\33COK\33X Traders</t>
+		<t id="1">\33COK\33X Home Trader</t>
+		<t id="2">\33COK\33X Free Trader</t>
+		<t id="6">Tether Sector: %s</t>
+		<t id="7">Tether Range: %s</t>
+		<t id="10">\33GStart Trading\33X</t>
+		<t id="15">Trader Balance: \33R%s\33X</t>
+		<t id="16">Trader Balance: \33G%s\33X</t>
+		<t id="17">Global Balance: \33R%s\33X</t>
+		<t id="18">Global Balance: \33G%s\33X</t>
+		<t id="20">Global Settings...</t>
+		<t id="21">Broadcast</t>
+		<t id="22">Ship Type</t>
+		<t id="25">Broadcast to docked ships</t>
+		<t id="28">\33MBroadcast:\33X Ships Homebased At: \33Y%s\33X</t>
+		<t id="29">\33MBroadcast:\33X Ships Docked At...</t>
+		<t id="30">\33RUninstall...\33X</t>
+		<t id="31">\33MBroadcast:\33X Fleet...</t>
+		<t id="49">\33Y!!\33X Free trading requires no homebase and %s \33Y!!\33X\n</t>
+		<t id="50">\33Y!!\33X Homebased trading requires a station homebase and %s \33Y!!\33X</t>
+		<t id="51">This ship is already trading. It`s orders can be reviewed and updated below. Changes take effect after the trader`s current action.</t>
+		<t id="52">This ship is already trading.</t>
+		<t id="53">When the trader has a homebase assigned it will trade wares only for its homebase.</t>
+		<t id="54">When the trader has no homebase assigned it will act as a free trader and seek out profitable trades.</t>
+		<t id="55">The broadcast command applies OK Trade with the selected ware options to multiple ships.</t>
+		<t id="56">Wares with \33Bblue\33X names cannot fit in this trader`s cargobay.</t>
+		<t id="70">Mode</t>
+		<t id="71">Normal \(Standard Free Trading\)</t>
+		<t id="72">\33GEconomy\33X \(Prefer Stalled NPC Stations\)</t>
+		<t id="73">\33OPlayer\33X \(Prefer Player Stations\)</t>
+		<t id="80">Stock Limits...</t>
+		<t id="81">Stock Limits</t>
+		<t id="82">Stock limits apply to all traders at that homebase.</t>
+		<t id="83">OK traders avoid selling wares below the minimum stock percentage, and avoid buying wares above the maximum stock percentage. Note that this limit only applies to OK Traders and not NPC traders.</t>
+		<t id="84">OK traders observe limits configured in the dockware manager bonus plugin for how much of a ware should be bought by a station, in addition to OK`s own percentage based settings. If both dockware manager and OK trade limits apply to a ware, the minimum of the 2 settings will be used by OK to determine the max stock level.</t>
+		<t id="85">\33WMin Stock %\33X</t>
+		<t id="86">\33WMax Stock %\33X</t>
+		<t id="87">\33WDockware Manager Limit\33X</t>
+		<t id="88">\33WWare\33X</t>
+		<t id="120">\33BBuy\33X</t>
+		<t id="121">\33MSell\33X</t>
+		<t id="122">\33YNo Trade\33X</t>
+		<t id="200">\33COK\33X Global Settings</t>
+		<t id="210">Auto Rename</t>
+		<t id="211">Blacklist...</t>
+		<t id="212">Min Stock Level Trade %</t>
+		<t id="213">Trade Illegal Wares</t>
+		<t id="214">Alert sound when targetted</t>
+		<t id="238">Homebased Traders</t>
+		<t id="239">Free Traders</t>
+		<t id="240">Debugging</t>
+		<t id="241">Logging</t>
+		<t id="242">Logging Target: %s</t>
+		<t id="243">Logging Verbosity</t>
+		<t id="250">&lt;all&gt;</t>
+		<t id="260">Select a logging target</t>
+		<t id="270">Equipment\n</t>
+		<t id="271">Lasers</t>
+		<t id="272">Shields</t>
+		<t id="273">Missiles</t>
+		<t id="274">Drones</t>
+		<t id="275">Docking Computer</t>
+		<t id="276">Jumpdrive</t>
+		<t id="277">Triplex Scanner</t>
+		<t id="278">Rudder Optimization</t>
+		<t id="279">Cargo Life Support</t>
+		<t id="280">Duplex Scanner</t>
+		<t id="300">\33COK\33X Uninstall</t>
+		<t id="310">\33GAbort\33x</t>
+		<t id="311">\33RUninstall\33x</t>
+		<t id="320">To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="330">\33COK\33X Traders - Uninstalling... %s\%</t>
+		<t id="331">\33COK\33X Traders has been uninstalled. To complete the uninstall save the game and ensure the setup script is removed before reloading.</t>
+		<t id="400">\33COK\33X Blacklist</t>
+		<t id="410">Add Sector...</t>
+		<t id="411">Add \33MPirate\33X Sectors</t>
+		<t id="412">Add \33BNon-Jumpable\33X Sectors</t>
+		<t id="413">Add \33RWar\33X Sectors</t>
+		<t id="414">\33YClear\33X List</t>
+		<t id="415">Add Station...</t>
+		<t id="416">Add Race Sectors...</t>
+		<t id="420">\33WSector\33X</t>
+		<t id="421">\33WRace\33X</t>
+		<t id="430">Add to blacklist</t>
+		<t id="500">Reset Free Trader Balance</t>
+		<t id="501">Reset Global Free Trader Balance</t>
+		<t id="1000">OK Traders Version=%s.%s.%s, Internal=%s</t>
+		<t id="1001">\33COK\33X Traders v%s.%s.%s installed.</t>
+		<t id="1002">\33COK\33X Traders upgraded to v%s.%s.%s.</t>
+		<t id="1003">\33COK\33X Traders downgraded to v%s.%s.%s.</t>
+		<t id="1050">Off</t>
+		<t id="1051">On</t>
+		<t id="1052">Yes</t>
+		<t id="1053">No</t>
+		<t id="1054">&lt;none&gt;</t>
+		<t id="1056">Any</t>
+		<t id="1059">\33B%s\33X</t>
+		<t id="1060">Freighters</t>
+		<t id="1100">Free Trader</t>
+		<t id="1101">\33GEco\33X Trader</t>
+		<t id="1102">\33OPlayer\33X Trader %s</t>
+		<t id="1200">\33COK\33X: %s \(%s\) - incoming missile in sector %s</t>
+		<t id="1201">\33COK\33X: %s \(%s\) - under attack by %s in sector %s</t>
+		<t id="1202">\33COK\33X: %s \(%s\) - targetted by enemy %s in sector %s</t>
+		<t id="2000">OK Traders %s.%s.%s</t>
+	</page>
+</language>

--- a/tools/test_x3s.py
+++ b/tools/test_x3s.py
@@ -24,12 +24,12 @@ if __name__ == '__main__':
   # lint project scripts
   run([sys.executable, 'tools/x3s_lint.py', 'src/scripts'])
 
-  # lint known-good fixtures
-  good = sorted((ROOT / 'tools/fixtures/known_good').glob('**/src/scripts/*.x3s'))
-  if good:
-    run([sys.executable, 'tools/x3s_lint.py', *[str(p.relative_to(ROOT)) for p in good]])
+  # lint known-good fixtures recursively
+  good_paths = sorted(ROOT.glob('tools/fixtures/known_good/**/src/scripts/*.x3s'))
+  if good_paths:
+    run([sys.executable, 'tools/x3s_lint.py', *[str(p.relative_to(ROOT)) for p in good_paths]])
 
-  # ensure safety checks still trigger
+  # ensure safety checks still trigger (negative tests)
   fail_paths = sorted((ROOT / 'tools/fixtures/should_fail').glob('**/*.x3s'))
   if fail_paths:
     run_fail([sys.executable, 'tools/x3s_lint.py', *[str(p.relative_to(ROOT)) for p in fail_paths]])


### PR DESCRIPTION
## Summary
- expand `convert_mods.py` to convert mods in `tools/fixtures/mods` into per‑mod `.x3s` fixtures with headers, notes and README summaries
- document fixture layout and update test harness to lint all known-good scripts and negative examples
- add converted fixtures for FDN and OKTraders1_7_1

## Testing
- `python tools/convert_mods.py --out-dir /tmp/fixtures_test`
- `python tools/test_x3s.py` *(lots of warnings; linter exits 0)*
- `python tools/x3s_lint.py tools/fixtures/should_fail/missing_wait.x3s`

------
https://chatgpt.com/codex/tasks/task_e_68c60de8e1a083269d20c13cdcd1b773