### PR TITLE
Recognize custom info menu lines

### DIFF
--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -48,6 +48,9 @@
 - **send.message**: `send incoming message $Msg to player: display it=0`
 - **play.sample**: `play sample 972`
 
+### New Statements Recognized
+- **menu.open.info**: `open custom info menu: title=$txt description=null option array=$menu maxoptions=2`
+
 ## Fixtures
 
 Known-good mod fixtures live under `tools/fixtures/known_good/<mod_name>`. Each mod

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -253,6 +253,13 @@
       ]
     },
     {
+      "name": "menu.open.info",
+      "regex": "^\\s*=?\\s*open custom info menu: title=\\$[A-Za-z0-9_.]+ description=(\\$[A-Za-z0-9_.]+|null) option array=\\$[A-Za-z0-9_.]+(?: maxoptions=\\d+)?$",
+      "examples": [
+        "open custom info menu: title=$txt description=null option array=$menu maxoptions=2"
+      ]
+    },
+    {
       "name": "skip.if.eq",
       "regex": "^skip if \\$[A-Za-z0-9_.]+ == \\d+$",
       "examples": [


### PR DESCRIPTION
## Plan
- parse new fixture lines for custom info menus
- allow these lines in linter via regex and document them

## Changes
- allow `open custom info menu` via new `menu.open.info` regex
- document new statement in `docs/x3s-language.md`

## Test Results
- `python tools/x3s_lint.py src/scripts tools/fixtures/known_good/FDN/src/scripts tools/fixtures/known_good/OKTraders1_7_1/src/scripts`
- `python tools/test_x3s.py`

## Pattern List
- `menu.open.info`: `open custom info menu: title=$txt description=null option array=$menu maxoptions=2`

## Safety Checks
- while loops must contain a wait
- setup scripts must load their text page


------
https://chatgpt.com/codex/tasks/task_e_68c66c15e16883269869bc37addba90f