### PR TITLE
Add ADS mod fixtures and fix converter line handling

### DIFF
--- a/tools/fixtures/known_good/ADS/README.md
+++ b/tools/fixtures/known_good/ADS/README.md
@@ -1,0 +1,12 @@
+# ADS (fixtures)
+
+Generated from `mods/ADS` on 2025-09-14 07:36:36Z.
+
+## Summary
+- Scripts converted: 263
+- Scripts skipped:  1
+- Text pages copied: 10
+- Director copied:   no
+
+## Notes
+- Skipped non-XML file: x2script.xsl

--- a/tools/fixtures/known_good/ADS/src/scripts/!init.anarkis.modified.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/!init.anarkis.modified.x3s
@@ -1,0 +1,6 @@
+#name: !init.anarkis.modified
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/!init.anarkis.modified.xml
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/al.plugin.sk.ecs.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/al.plugin.sk.ecs.x3s
@@ -1,0 +1,9 @@
+#name: al.plugin.sk.ecs
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/al.plugin.sk.ecs.xml
+
+$page.id = 8511
+load text: id=$page.id
+al engine: register script=plugin.sk.ecs.al.register
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.al.init.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.al.init.x3s
@@ -1,0 +1,34 @@
+#name: anarkis.acc.al.init
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.al.init.xml
+
+* ===========================================
+* A.D.S. - Init Script, ECS Registration if available, show menu
+* ===========================================
+
+
+
+if get global variable: name='plugin.ecs.setup'
+= [THIS] -> call script anarkis.acc.ecs.register :
+end
+
+if  is datatyp[ $ecs.setup ] == DATATYP_ARRAY
+$ecs.setup[3] = [TRUE]
+else
+$ecs.setup =  array alloc: size=6
+$ecs.installed =  array alloc: size=0
+$ecs.configs =  array alloc: size=0
+$ecs.news =  array alloc: size=0
+$ecs.guilds =  array alloc: size=0
+$ecs.setup[0] = 250
+$ecs.setup[1] = $ecs.installed
+$ecs.setup[2] = $ecs.configs
+$ecs.setup[3] = [TRUE]
+$ecs.setup[4] = null
+$ecs.setup[5] = $ecs.news
+$ecs.setup[6] = $ecs.guilds
+end
+set global variable: name='plugin.ecs.setup' value=$ecs.setup
+= [THIS] -> call script plugin.sk.ecs.hotkey.install :
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.al.register.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.al.register.x3s
@@ -1,0 +1,48 @@
+#name: anarkis.acc.al.register
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.al.register.xml
+
+$text.id = '8510'
+
+$plugin.Vars = get global variable: name=$plugin.ID
+
+* setup new data structure and init it
+if not $plugin.Vars
+$plugin.Vars =  array alloc: size=2
+set global variable: name=$plugin.ID value=$plugin.Vars
+$plugin.Vars[0] = 0
+$plugin.Vars[1] = [TRUE]
+end
+
+* init and reinit are run every time the game loads
+if $plugin.Event == 'init' OR $plugin.Event == 'reinit'
+$desc = sprintf: pageid=$text.id textid=100, null, null, null, null, null
+al engine: set plugin $plugin.ID description to $desc
+$interval = 30 * 60
+al engine: set plugin $plugin.ID timer interval to $interval s
+skip if get global variable: name='plugin.ecs.setup'
+= [THIS] -> call script plugin.sk.ecs.al.init :
+
+else if $plugin.Event == 'isenabled'
+$desc = sprintf: pageid=$text.id textid=100, null, null, null, null, null
+al engine: set plugin $plugin.ID description to $desc
+$enabled = $plugin.Vars[1]
+return $enabled
+
+* Use this area to process special instructions when the plugin is toggled on
+else if $plugin.Event == 'start'
+$plugin.Vars[1] = [TRUE]
+= [THIS] -> call script plugin.sk.ecs.al.init :
+= [THIS] -> call script plugin.sk.ecs.manager :
+* Use this area to process special instructions when the plugin is toggled off
+else if $plugin.Event == 'stop'
+$plugin.Vars[1] = [FALSE]
+= [THIS] -> call script plugin.sk.ecs.al.stop :
+
+* The event script is called every interval
+else if $plugin.Event == 'timer'
+$enabled = $plugin.Vars[1]
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.al.stop.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.al.stop.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.acc.al.stop
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.al.stop.xml
+
+$ads.setup = get global variable: name='anarkis.ads.setup'
+$ads.setup[3] = [FALSE]
+set global variable: name='anarkis.ads.setup' value=$ads.setup
+
+START [THIS] -> call script plugin.sk.ecs.manager :
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.apply.active.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.apply.active.x3s
@@ -1,0 +1,19 @@
+#name: anarkis.acc.apply.active
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.apply.active.xml
+
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$home = $curr.ship -> get homebase
+if $home == [THIS] OR [OWNER] != Player
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=[TRUE]
+$name = $curr.ship -> get name
+$curr.ship -> set local variable: name='anarkis.acc.oldname' value=$name
+end
+
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.apply.relations.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.apply.relations.x3s
@@ -1,0 +1,34 @@
+#name: anarkis.acc.apply.relations
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.apply.relations.xml
+
+$setup = [THIS] -> get local variable: name='anarkis.acc.setup'
+$ignore.list = $setup[16]
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$enabled = $curr.ship -> get local variable: name='anarkis.acc.ship'
+if $only.active == [TRUE] AND $enabled != [TRUE]
+continue
+end
+$race.array = [THIS] -> call script anarkis.lib.get.race.array :
+$race.cnt =  size of array $race.array
+while $race.cnt
+dec $race.cnt =
+$race = $race.array[$race.cnt]
+$v1 = [THIS] -> get relation to race $race
+$curr.ship -> set relation against $race to $v1
+end
+$race.cnt =  size of array $ignore.list
+while $race.cnt
+dec $race.cnt =
+$race = $ignore.list[$race.cnt]
+$curr.ship -> set relation against $race to Friend
+end
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.apply.settings.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.apply.settings.x3s
@@ -1,0 +1,60 @@
+#name: anarkis.acc.apply.settings
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.apply.settings.xml
+
+$setup = [THIS] -> get local variable: name='anarkis.acc.setup'
+
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$enabled = $curr.ship -> get local variable: name='anarkis.acc.ship'
+
+if $only.active == [TRUE] AND $enabled != [TRUE]
+continue
+end
+
+$v1 = $setup[7]
+$curr.ship -> set autojump active: $v1
+$v1 = $setup[8]
+$curr.ship -> autojump minimum jumps= $v1
+$v1 = $setup[9]
+$curr.ship -> set jumpdrive fuel resupply: amount=$v1
+$v1 = $setup[10]
+$curr.ship -> set emergency jump active: $v1
+$v1 = $setup[11]
+$curr.ship -> autojump emergency jump shield threshold= $v1%
+$v1 = $setup[12]
+$curr.ship -> set fire missile probability to $v1
+
+$v1 = $setup[14]
+if $v1 == 245
+$turret.script = '!turret.protect.std'
+else if $v1 == 246
+$turret.script = '!turret.killenemies.std'
+else if $v1 == 247
+$turret.script = '!turret.missiledefense.std'
+else if $v1 == 248
+if $curr.ship -> get true amount of ware MARS - Motion Analysis Relay System in cargo bay
+$turret.script = 'plugin.gz.mars.turret'
+else
+$turret.script = '!turret.missiledefense.std'
+end
+else if $v1 == 249
+if $curr.ship -> get true amount of ware MARS - Motion Analysis Relay System in cargo bay
+$turret.script = 'plugin.gz.mars.turret.offense'
+else
+$turret.script = '!turret.killenemies.std'
+end
+end
+$turret.count = $curr.ship -> get number of turrets
+while $turret.count > 1
+dec $turret.count =
+$curr.ship -> start named script: task=$turret.count scriptname=$turret.script prio=0, $turret.count, null, null, null, null
+end
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.audio.alert.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.audio.alert.x3s
@@ -1,0 +1,14 @@
+#name: anarkis.acc.audio.alert
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.audio.alert.xml
+
+$sector = $ship -> get sector
+= speak text: page=13 id=1276 priority=0
+$d = $sector -> get object name array
+=  speak array: $d prio=0
+= speak text: page=13 id=1279 priority=0
+$d = $ship -> get object name array
+=  speak array: $d prio=0
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.alert.dock.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.alert.dock.x3s
@@ -1,0 +1,13 @@
+#name: anarkis.acc.cmd.alert.dock
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.cmd.alert.dock.xml
+
+[THIS] -> start task 896 with script anarkis.lib.dockall.adsonly and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+while [TRUE]
+= wait 1000 ms
+skip if [THIS] -> is script anarkis.lib.dockall.adsonly on stack of task=896
+break
+end
+= [THIS] -> call script anarkis.acc.repairshields :
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.alert.launch.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.alert.launch.x3s
@@ -1,0 +1,17 @@
+#name: anarkis.acc.cmd.alert.launch
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.cmd.alert.launch.xml
+
+$ship.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$ship.count =  size of array $ship.list
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+
+$r = $ship -> is script !ship.cmd.killenemies.std on stack of task=0
+skip if $r == [TRUE]
+$ship -> start task 0 with script !ship.cmd.killenemies.std and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+= wait 50 ms
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.attack.return.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.attack.return.x3s
@@ -1,0 +1,27 @@
+#name: anarkis.acc.cmd.attack.return
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.cmd.attack.return.xml
+
+[THIS] -> set command: COMMAND_ATTACK_RETURN  target=$victim target2=$dst par1=null par2=null
+
+* If the first target is a Big ship, it will try to attack other big ships
+if $victim -> is of class Big Ship
+$tg = Big Ship
+else
+$tg = null
+end
+
+$owner = $victim -> get owner race
+[THIS] -> set relation against $owner to Foe
+
+
+= [THIS] -> call script !fight.attack.object :  the victim=$victim  follow in new sector=null  Only attack shields=[FALSE]
+
+[THIS] -> set command target: $tg
+
+= [THIS] -> call script !fight.attack.enemiesrange.land :  object to land on=$dst  the range=null  refpos array   x y z=null  no idle, simply stand still=[TRUE]
+
+
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.buy.return.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.buy.return.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.acc.cmd.buy.return
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.cmd.buy.return.xml
+
+[THIS] -> set command: COMMAND_GET_WARE_BEST  target=$ware target2=$dest par1=$amount par2=$minprice
+= [THIS] -> call script !trade.getwareandreturnhome :  ware=$ware  destination station=$dest  amount=$amount  max.price=$minprice  stay if unable to buy=[FALSE]
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.buywares.pl.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.buywares.pl.x3s
@@ -1,0 +1,10 @@
+#name: anarkis.acc.cmd.buywares.pl
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.cmd.buywares.pl.xml
+
+[THIS] -> set command: ANARKIS_BUYWARES  target=null target2=null par1=null par2=null
+= [THIS] -> call script anarkis.acc.setup.buywares :  selected ship=[THIS]
+[THIS] -> set command: null  target=null target2=null par1=null par2=null
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.call.autocarrier.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.call.autocarrier.x3s
@@ -1,0 +1,14 @@
+#name: anarkis.acc.cmd.call.autocarrier
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.cmd.call.autocarrier.xml
+
+* ===========================================
+* Automated Carrier : Main Task
+* ===========================================
+
+= [THIS] -> call script anarkis.acc.task.autocarrier :
+
+
+return null
+

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.call.autostation.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.call.autostation.x3s
@@ -1,0 +1,13 @@
+#name: anarkis.acc.cmd.call.autostation
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.cmd.call.autostation.xml
+
+* ===========================================
+* Automated Carrier : Main Task
+* ===========================================
+= [THIS] -> call script anarkis.acc.task.autocarrier :
+
+
+return null
+

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.dock.all.pl.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.dock.all.pl.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.acc.cmd.dock.all.pl
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.cmd.dock.all.pl.xml
+
+[THIS] -> set command: ANARKIS_DOCKALL  target=null target2=null par1=null par2=null
+= [THIS] -> call script anarkis.acc.cmd.dock.all :
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.dock.all.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.dock.all.x3s
@@ -1,0 +1,13 @@
+#name: anarkis.acc.cmd.dock.all
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.cmd.dock.all.xml
+
+[THIS] -> start task 896 with script anarkis.lib.dockall.secure and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+while [TRUE]
+= wait 1000 ms
+skip if [THIS] -> is script anarkis.lib.dockall.secure on stack of task=896
+break
+end
+= [THIS] -> call script anarkis.acc.repairshields :
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.protect.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.protect.x3s
@@ -1,0 +1,34 @@
+#name: anarkis.acc.cmd.protect
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.cmd.protect.xml
+
+[THIS] -> set command: COMMAND_PROTECT  target=$protect target2=[FALSE] par1=null par2=null
+$flag = [Find.Nearest] | [Find.Enemy]
+
+skip if not [THIS] -> is docked
+= [THIS] -> call script !move.undock :
+
+while $protect -> exists
+= wait 100 ms
+$distance = get distance between [THIS] and $protect
+$protect.sector = $protect -> get sector
+if $protect.sector == [SECTOR]
+if $distance > 5000
+= [THIS] -> call script !move.movetoobject :  Target=$protect  Range=4500
+end
+else if [OWNER] != Player
+= [THIS] -> add 80 units of Energy Cells
+= [THIS] -> call script anarkis.lib.cmd.jumpnearobject :  destination=$protect
+else
+= [THIS] -> call script anarkis.lib.cmd.jumpnearobject :  destination=$protect
+end
+$enemy =  find ship: sector=[SECTOR] class or type=Moveable Ship race=null flags=$flag refobj=$protect maxdist=10000 maxnum=1 refpos=null
+if $enemy -> exists
+= [THIS] -> call script !fight.attack.object :  the victim=$enemy  follow in new sector=[FALSE]  Only attack shields=[FALSE]
+else
+= [THIS] -> call script !move.idle.timeout :  timeout in sec=10  wait while docked=[FALSE]
+end
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.sell.return.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.sell.return.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.acc.cmd.sell.return
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.cmd.sell.return.xml
+
+[THIS] -> set command: COMMAND_SELL_WARE_BEST  target=$ware target2=$dest par1=$amount par2=$minprice
+= [THIS] -> call script !trade.sellwareandreturnhome :  ware=$ware  destination station=$dest  amount=$amount  min price=$minprice
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.sellwares.pl.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.cmd.sellwares.pl.x3s
@@ -1,0 +1,10 @@
+#name: anarkis.acc.cmd.sellwares.pl
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.cmd.sellwares.pl.xml
+
+[THIS] -> set command: ANARKIS_SELLWARES  target=null target2=null par1=null par2=null
+= [THIS] -> call script anarkis.acc.setup.sellwares :  selected ship=[THIS]
+[THIS] -> set command: null  target=null target2=null par1=null par2=null
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.ecs.register.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.ecs.register.x3s
@@ -1,0 +1,19 @@
+#name: anarkis.acc.ecs.register
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.ecs.register.xml
+
+* Added to prevent ADS to start before ECS
+= [THIS] -> call script anarkis.lib.wait :  wait time (in sec)=30  global to check=null
+
+$setup =  array alloc: size=7
+$setup[0] = 'anarkis.acc.plugin'
+$setup[1] = 'anarkis.acc.hotkey.ecs'
+$setup[2] = null
+$setup[3] = Player
+$setup[4] = null
+$setup[5] = 15
+$setup[6] = 'Latest ADS Reports'
+skip if [THIS] -> call script plugin.sk.ecs.register :  Setup Array=$setup
+send incoming message 'ECS Not Detected - Comms with ships and stations will be disabled !' to player: display it=[TRUE]
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.ecs.remove.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.ecs.remove.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.acc.ecs.remove
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.ecs.remove.xml
+
+
+= [THIS] -> call script plugin.sk.ecs.unregister :  Plugin ID='anarkis.acc.plugin'
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.evaluate.enemy.npc.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.evaluate.enemy.npc.x3s
@@ -1,0 +1,32 @@
+#name: anarkis.acc.evaluate.enemy.npc
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.evaluate.enemy.npc.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$setup.array = $refobject -> get local variable: name='anarkis.acc.setup'
+
+$owner = $refobject -> get object class
+if $owner == Player
+$ignore.list = $gl.setup[7]
+else
+$ignore.list = $setup.array[16]
+end
+
+$class = $target -> get object class
+$owner = $target -> get owner race
+
+if  find $owner in array: $ignore.list
+return [FALSE]
+end
+
+if not $target -> is $refobject a enemy
+return [FALSE]
+end
+
+if $class == Fighter Drone OR $class == All Satellites OR $class == Freight Drone
+return [FALSE]
+end
+
+
+return [TRUE]

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.evaluate.enemy.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.evaluate.enemy.x3s
@@ -1,0 +1,30 @@
+#name: anarkis.acc.evaluate.enemy
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.evaluate.enemy.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$setup.array = $refobject -> get local variable: name='anarkis.acc.setup'
+
+$owner = $refobject -> get owner race
+if $owner == Player
+$ignore.list = $gl.setup[7]
+else
+$ignore.list = $setup.array[16]
+end
+$class = $target -> get object class
+$owner = $target -> get owner race
+
+if  find $owner in array: $ignore.list
+return [FALSE]
+end
+
+if not $target -> is $refobject a enemy
+return [FALSE]
+end
+
+if $class == Fighter Drone OR $class == All Satellites OR $class == Freight Drone
+return [FALSE]
+end
+
+return [TRUE]

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.evaluate.findstrong.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.evaluate.findstrong.x3s
@@ -1,0 +1,76 @@
+#name: anarkis.acc.evaluate.findstrong
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.evaluate.findstrong.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+
+$setup.array = $refobject -> get local variable: name='anarkis.acc.setup'
+$radar.range = $setup.array[1]
+
+$owner = $refobject -> get owner race
+if $owner == Player
+$ignore.list = $gl.setup[7]
+else
+$ignore.list = $setup.array[16]
+end
+
+$flags = [Find.Enemy] | [Find.Multiple]
+$ship.list =  find ship: sector=$sector class or type=Moveable Ship race=null flags=$flags refobj=$refobject maxdist=$radar.range maxnum=50 refpos=null
+$ship.count =  size of array $ship.list
+
+$selected = null
+$selected.class = -1
+
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$class = $ship -> get object class
+$owner = $ship -> get owner race
+if  find $owner in array: $ignore.list
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+if not $ship -> is $refobject a enemy
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+if $class == M2 AND $selected.class < 10
+$selected = $ship
+$selected.class = 10
+else if $class == M1 AND $selected.class < 9
+$selected = $ship
+$selected.class = 9
+else if $class == M7 AND $selected.class < 8
+$selected = $ship
+$selected.class = 8
+else if $class == M6 AND $selected.class < 7
+$selected = $ship
+$selected.class = 7
+else if $class == TL AND $selected.class < 6
+$selected = $ship
+$selected.class = 6
+else if $class == M8 AND $selected.class < 5
+$selected = $ship
+$selected.class = 5
+else if $class == M3 AND $selected.class < 4
+$selected = $ship
+$selected.class = 4
+else if $class == M4 AND $selected.class < 3
+$selected = $ship
+$selected.class = 3
+else if $class == M5 AND $selected.class < 2
+$selected = $ship
+$selected.class = 2
+else if $class == TM AND $selected.class < 1
+$selected = $ship
+$selected.class = 1
+else if ( $class == TP OR $class == TS ) AND $selected.class < 0
+$selected = $ship
+$selected.class = 0
+end
+end
+
+return $selected

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.evalute.danger.npc.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.evalute.danger.npc.x3s
@@ -1,0 +1,64 @@
+#name: anarkis.acc.evalute.danger.npc
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.evalute.danger.npc.xml
+
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+
+$setup.array = $refobject -> get local variable: name='anarkis.acc.setup'
+$radar.range = $setup.array[1]
+$owner = $refobject -> get owner race
+if $owner == Player
+$ignore.list = $gl.setup[7]
+else
+$ignore.list = $setup.array[16]
+end
+
+
+$flags = [Find.Multiple] | [Find.Enemy]
+$ship.list =  find ship: sector=$sector class or type=Moveable Ship race=null flags=$flags refobj=$refobject maxdist=$radar.range maxnum=50 refpos=null
+$ship.count =  size of array $ship.list
+
+$threat.level = 0
+
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$class = $ship -> get object class
+$owner = $ship -> get true owner
+
+
+if $ship -> is script !job.trade.freetrader on stack of task=0
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $ship -> is script !job.trade.docktrader on stack of task=0
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $ship -> is script !job.special.tpliners on stack of task=0
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $ship -> is script !job.special.taxi on stack of task=0
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+if  find $owner in array: $ignore.list
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> is $refobject a enemy
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $ship -> is civilian ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+$ship.threat = [THIS] -> call script anarkis.ads.lib.get.shipthreat :  ship/class=$ship
+$threat.level = $threat.level + $ship.threat
+end
+return $threat.level

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.evalute.danger.off.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.evalute.danger.off.x3s
@@ -1,0 +1,40 @@
+#name: anarkis.acc.evalute.danger.off
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.evalute.danger.off.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$setup.array = $refobject -> get local variable: name='anarkis.acc.setup'
+
+$radar.range = $setup.array[1]
+
+$owner = $refobject -> get owner race
+if $owner == Player
+$ignore.list = $gl.setup[7]
+else
+$ignore.list = $setup.array[16]
+end
+
+$flags = [Find.Enemy] | [Find.Multiple] | [Find.Nearest]
+$ship.list =  find ship: sector=$sector class or type=Moveable Ship race=null flags=$flags refobj=$refobject maxdist=$radar.range maxnum=50 refpos=null
+$ship.count =  size of array $ship.list
+
+$threat.level = 0
+
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$class = $ship -> get object class
+$owner = $ship -> get owner race
+if  find $owner in array: $ignore.list
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $ship -> is civilian ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+$ship.threat = [THIS] -> call script anarkis.ads.lib.get.shipthreat :  ship/class=$ship
+$threat.level = $threat.level + $ship.threat
+end
+return $threat.level

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.evalute.danger.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.evalute.danger.x3s
@@ -1,0 +1,43 @@
+#name: anarkis.acc.evalute.danger
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.evalute.danger.xml
+
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+
+$setup.array = $refobject -> get local variable: name='anarkis.acc.setup'
+$radar.range = $setup.array[1]
+$owner = $refobject -> get owner race
+if $owner == Player
+$ignore.list = $gl.setup[7]
+else
+$ignore.list = $setup.array[16]
+end
+$flags = [Find.Enemy] | [Find.Multiple] | [Find.Nearest]
+$ship.list =  find ship: sector=$sector class or type=Moveable Ship race=null flags=$flags refobj=$refobject maxdist=$radar.range maxnum=50 refpos=null
+$ship.count =  size of array $ship.list
+
+$threat.level = 0
+
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$class = $ship -> get object class
+$owner = $ship -> get owner race
+if  find $owner in array: $ignore.list
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> is $refobject a enemy
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $ship -> is civilian ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+$ship.threat = [THIS] -> call script anarkis.ads.lib.get.shipthreat :  ship/class=$ship
+$threat.level = $threat.level + $ship.threat
+end
+return $threat.level

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.get.acc.carriers.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.get.acc.carriers.x3s
@@ -1,0 +1,39 @@
+#name: anarkis.acc.get.acc.carriers
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.get.acc.carriers.xml
+
+
+$array =  get ship array: of race Player class/type=Moveable Ship
+$cnt =  size of array $array
+
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+
+$v1 = $select -> get object class
+
+if not ( $v1 == M1 OR $v1 == M7 OR $v1 == TL OR $v1 == TM )
+remove element from array $array at index $cnt
+continue
+end
+
+if not $select -> get true amount of ware Carrier Command Software  in cargo bay
+remove element from array $array at index $cnt
+continue
+end
+
+if $active.only == [TRUE]
+if not $select -> is script anarkis.acc.task.autocarrier on stack of task=10
+if not $select -> is script anarkis.acc.task.autocarrier on stack of task=11
+if not $select -> is script anarkis.acc.task.autocarrier.npc on stack of task=894
+remove element from array $array at index $cnt
+continue
+end
+end
+end
+end
+
+end
+
+return $array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.get.all.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.get.all.x3s
@@ -1,0 +1,35 @@
+#name: anarkis.acc.get.all
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.get.all.xml
+
+$array = [THIS] -> get owned ships: class/type=$ship.class
+$cnt =  size of array $array
+
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+if $select -> get local variable: name='anarkis.skipme'
+remove element from array $array at index $cnt
+continue
+end
+if $select -> get local variable: name='anarkis.acc.skipme'
+remove element from array $array at index $cnt
+continue
+end
+if $no.hull.dmg == [TRUE]
+$hull = $select -> get hull percent
+if $hull < 100
+remove element from array $array at index $cnt
+continue
+end
+end
+if $active.only == [TRUE]
+if not $select -> get local variable: name='anarkis.acc.ship'
+remove element from array $array at index $cnt
+continue
+end
+end
+end
+
+return $array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.get.dockedships.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.get.dockedships.x3s
@@ -1,0 +1,66 @@
+#name: anarkis.acc.get.dockedships
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.get.dockedships.xml
+
+$ship.array = [THIS] -> get ship array from sector/ship/station
+$ship.cnt =  size of array $ship.array
+while $ship.cnt
+dec $ship.cnt =
+$test.ship = $ship.array[$ship.cnt]
+* - Check All-in-One no go variable
+if $test.ship -> get local variable: name='anarkis.skipme'
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+* - Check specific ADS ignore variable
+if $test.ship -> get local variable: name='anarkis.acc.skipme'
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+* - Check Ownership
+$owner = $test.ship -> get true owner
+if $owner != [OWNER]
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+* - Check ACC ownership
+if not $test.ship -> get local variable: name='anarkis.acc.ship'
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+* - Check Class
+if not $test.ship -> is of class $ship.class
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+* - Check Homebase
+$homebase = $test.ship -> get homebase
+if [OWNER] == Player
+if not $homebase -> exists
+$test.ship -> set homebase to [THIS]
+else if $homebase != [THIS]
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+end
+
+* - Let's stop ships with returnhome
+if $test.ship -> is script !move.movetostation on stack of task=0
+$test.ship -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$test.ship -> set command: null
+$test.ship -> set destination to null
+* - Else, check if they are not waiting to go
+else if $test.ship -> is task 0 in use
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+* - Check the hull
+$hull = $test.ship -> get hull percent
+if $hull < 95 AND $no.hull.dmg == [TRUE]
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+end
+
+return $ship.array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.cmd.attack.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.cmd.attack.x3s
@@ -1,0 +1,17 @@
+#name: anarkis.acc.hotkey.cmd.attack
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.cmd.attack.xml
+
+$aim =  get player tracking aim
+skip if $aim -> exists
+return null
+
+if [THIS] -> call script anarkis.acc.is.compatible :  target=[PLAYERSHIP]
+$v1 = $aim -> get object class
+$count = [THIS] -> call script anarkis.lib.get.shipcount :  class=$v1
+START [PLAYERSHIP] -> call script anarkis.acc.wing.attack.pl :  target=$aim  wing size=$count
+= speak text: page=13 id=131 priority=0
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.cmd.clear.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.cmd.clear.x3s
@@ -1,0 +1,10 @@
+#name: anarkis.acc.hotkey.cmd.clear
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.cmd.clear.xml
+
+if [THIS] -> call script anarkis.acc.is.compatible :  target=[PLAYERSHIP]
+START speak text: page=13 id=131 priority=0
+START [PLAYERSHIP] -> call script anarkis.acc.wing.clearsector.pl :
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.cmd.dockall.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.cmd.dockall.x3s
@@ -1,0 +1,10 @@
+#name: anarkis.acc.hotkey.cmd.dockall
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.cmd.dockall.xml
+
+if [THIS] -> call script anarkis.acc.is.compatible :  target=[PLAYERSHIP]
+START speak text: page=13 id=131 priority=0
+START [PLAYERSHIP] -> call script anarkis.acc.cmd.dock.all.pl :
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.cmd.manage.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.cmd.manage.x3s
@@ -1,0 +1,7 @@
+#name: anarkis.acc.hotkey.cmd.manage
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.cmd.manage.xml
+
+= [THIS] -> call script anarkis.ads.comm.manage.call :
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.ecs.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.ecs.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.acc.hotkey.ecs
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.ecs.xml
+
+if [THIS] -> call script anarkis.acc.is.compatible :  target=$target
+$owner = $target -> get owner race
+if $owner == Player
+$target -> start task 892 with script anarkis.acc.setup and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.install.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.install.x3s
@@ -1,0 +1,25 @@
+#name: anarkis.acc.hotkey.install
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.install.xml
+
+$page.id = 8510
+load text: id=$page.id
+$installed = get global variable: name='anarkis.acc.hotkey'
+if not $installed
+$installed =  array alloc: size=0
+$st =  read text: page=$page.id id=600
+$hotkey.id =  register hotkey $st to call script anarkis.acc.hotkey.cmd.clear
+append $hotkey.id to array $installed
+$st =  read text: page=$page.id id=601
+$hotkey.id =  register hotkey $st to call script anarkis.acc.hotkey.cmd.dockall
+append $hotkey.id to array $installed
+$st =  read text: page=$page.id id=602
+$hotkey.id =  register hotkey $st to call script anarkis.acc.hotkey.cmd.attack
+append $hotkey.id to array $installed
+$st =  read text: page=$page.id id=603
+$hotkey.id =  register hotkey $st to call script anarkis.ads.comm.manage.call
+append $hotkey.id to array $installed
+set global variable: name='anarkis.acc.hotkey' value=$installed
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.setup.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.setup.x3s
@@ -1,0 +1,89 @@
+#name: anarkis.acc.hotkey.setup
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.setup.xml
+
+$page.id = 8510
+load text: id=$page.id
+
+* Retrieve setup, apply default if not found
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$cnt =  size of array $setup.array
+if not $cnt == 19
+$setup.array = [THIS] -> call script anarkis.acc.setup.default :
+= [THIS] -> call script anarkis.acc.apply.active :
+end
+skip if [THIS] -> is script anarkis.acc.task.repairs on stack of task=900
+[THIS] -> start task 900 with script anarkis.acc.task.repairs and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=240
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=211, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='setup.home'
+$st = sprintf: pageid=$page.id textid=242, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='repairbay'
+$st = sprintf: pageid=$page.id textid=241, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='autocarrier'
+$st = sprintf: pageid=$page.id textid=243, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='supplies'
+
+$st = sprintf: pageid=$page.id textid=210, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=212, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='report'
+
+$st =  read text: page=$page.id id=230
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=232, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='reset'
+
+$v1 = [THIS] -> get object class
+$st = sprintf: pageid=$page.id textid=250, [THIS], $v1, null, null, null
+add custom menu info line to array $menu: text=$st
+$st = sprintf: pageid=$page.id textid=251, [SECTOR], null, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 = [THIS] -> get number of landed ships
+$v2 = [THIS] -> get dock bay size
+$v3 = [THIS] -> get owned ships: class/type=Ship
+$v3 =  size of array $v3
+$st = sprintf: pageid=$page.id textid=252, $v1, $v2, $v3, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=200
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'autocarrier'
+= [THIS] -> call script anarkis.acc.setup.autocarrier :
+
+else if $menu.result == 'setup.home'
+= [THIS] -> call script anarkis.acc.setup.hangars :
+
+else if $menu.result == 'repairbay'
+= [THIS] -> call script anarkis.acc.setup.repair :
+
+else if $menu.result == 'supplies'
+= [THIS] -> call script anarkis.acc.setup.supplies :
+
+* dont loop here
+else if $menu.result == 'report'
+START $null -> call script anarkis.acc.setup.reports :  selected ship=[THIS]
+return null
+
+else if $menu.result == 'reset'
+$setup.array = [THIS] -> call script anarkis.acc.setup.default :
+
+
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.uninstall.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.hotkey.uninstall.x3s
@@ -1,0 +1,15 @@
+#name: anarkis.acc.hotkey.uninstall
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.uninstall.xml
+
+$page.id = 8510
+$installed = get global variable: name='anarkis.acc.hotkey'
+$cnt =  size of array $installed
+while $cnt
+dec $cnt =
+$hotkey.id = $installed[$cnt]
+unregister hotkey $hotkey.id
+end
+set global variable: name='anarkis.acc.hotkey' value=null
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.is.compatible.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.is.compatible.x3s
@@ -1,0 +1,21 @@
+#name: anarkis.acc.is.compatible
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.is.compatible.xml
+
+$v1 = $select -> get object class
+
+skip if not $select -> is of class Station
+return [TRUE]
+
+if not ( $v1 == M1 OR $v1 == M7 OR $v1 == TL OR $v1 == TM )
+return [FALSE]
+end
+
+skip if $select -> get true amount of ware Carrier Command Software  in cargo bay
+return [FALSE]
+
+skip if $select -> get dock bay size
+return [FALSE]
+
+return [TRUE]

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.applyallowned.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.applyallowned.x3s
@@ -1,0 +1,15 @@
+#name: anarkis.acc.lib.applyallowned
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.applyallowned.xml
+
+$dock.list = [THIS] -> get owned ships: class/type=Moveable Ship
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+skip if not $curr.ship -> get local variable: name='anarkis.skipme'
+continue
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=[TRUE]
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.arr.remove.ads.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.arr.remove.ads.x3s
@@ -1,0 +1,18 @@
+#name: anarkis.acc.lib.arr.remove.ads
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.arr.remove.ads.xml
+
+* ===========================================
+* Remove ADS ships from an array of ships
+* ===========================================
+$null = null
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+skip if not $select -> get local variable: name='anarkis.acc.ship'
+remove element from array $arr at index $cnt
+end
+
+return $arr

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.dockads.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.dockads.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.acc.lib.dockads
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.dockads.xml
+
+
+[THIS] -> start task 895 with script anarkis.lib.dockall.adsonly and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+= wait 1000 ms
+while [THIS] -> is script anarkis.lib.dockall.adsonly on stack of task=895
+= wait 1000 ms
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.get.adsonly.from.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.get.adsonly.from.x3s
@@ -1,0 +1,47 @@
+#name: anarkis.acc.lib.get.adsonly.from
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.get.adsonly.from.xml
+
+* ===========================================
+* Improved to handle NPC carriers too
+* ===========================================
+$null = null
+$isship = $target -> is of class Moveable Ship
+$owner = $target -> get owner race
+
+$arr = null
+if $isship == [TRUE] AND $owner != Player
+$ini = [THIS] -> call script anarkis.lib.custowned.getarray.f :  from=$target
+if $ini
+$cnt =  size of array $ini
+dec $cnt =
+$arr =  clone array $ini : index 0 ... $cnt
+end
+end
+
+skip if $arr
+$arr = $target -> get owned ships: class/type=Moveable Ship
+
+
+$cnt =  size of array $arr
+
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+if $select -> is of class Freighter
+remove element from array $arr at index $cnt
+continue
+end
+
+if $select -> get local variable: name='anarkis.acc.skipme'
+remove element from array $arr at index $cnt
+continue
+end
+if not $select -> get local variable: name='anarkis.acc.ship'
+remove element from array $arr at index $cnt
+continue
+end
+end
+
+return $arr

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.get.adsonly.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.get.adsonly.x3s
@@ -1,0 +1,44 @@
+#name: anarkis.acc.lib.get.adsonly
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.get.adsonly.xml
+
+* ===========================================
+* Improved to handle NPC carriers too
+* ===========================================
+$null = null
+$isship = [THIS] -> is of class Moveable Ship
+
+$arr = null
+if $isship == [TRUE] AND [OWNER] != Player
+$ini = [THIS] -> call script anarkis.lib.custowned.getarray :
+if $ini
+$cnt =  size of array $ini
+dec $cnt =
+$arr =  clone array $ini : index 0 ... $cnt
+end
+end
+
+skip if $arr
+$arr = [THIS] -> get owned ships: class/type=Moveable Ship
+
+$cnt =  size of array $arr
+
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+if $select -> is of class Freighter
+remove element from array $arr at index $cnt
+continue
+end
+if $select -> get local variable: name='anarkis.acc.skipme'
+remove element from array $arr at index $cnt
+continue
+end
+if not $select -> get local variable: name='anarkis.acc.ship'
+remove element from array $arr at index $cnt
+continue
+end
+end
+
+return $arr

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.get.enemies.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.get.enemies.x3s
@@ -1,0 +1,58 @@
+#name: anarkis.acc.lib.get.enemies
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.get.enemies.xml
+
+$class.list =  array alloc: size=0
+
+append M2 to array $class.list
+append M1 to array $class.list
+append M7 to array $class.list
+append TL to array $class.list
+append M6 to array $class.list
+append M8 to array $class.list
+append M3 to array $class.list
+append M4 to array $class.list
+append M5 to array $class.list
+append TM to array $class.list
+append TP to array $class.list
+append TS to array $class.list
+
+$class.count =  size of array $class.list
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$setup.array = $refobject -> get local variable: name='anarkis.acc.setup'
+$owner = $refobject -> get owner race
+if $owner == Player
+$ignore.list = $gl.setup[7]
+else
+$ignore.list = $setup.array[16]
+end
+$radar.range = $setup.array[1]
+$flags = [Find.Enemy] | [Find.Multiple]
+
+$final.list =  array alloc: size=0
+
+
+while $class.count
+dec $class.count =
+$select.class = $class.list[$class.count]
+$ship.list =  find ship: sector=$sector class or type=$select.class race=null flags=$flags refobj=$refobject maxdist=$radar.range maxnum=50 refpos=null
+$ship.count =  size of array $ship.list
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$owner = $ship -> get owner race
+$class = $ship -> get object class
+skip if not  find $owner in array: $ignore.list
+continue
+skip if $ship -> is $refobject a enemy
+continue
+skip if not $ship -> is civilian ship
+continue
+append $ship to array $final.list
+end
+end
+
+
+return $final.list

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.get.flyads.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.get.flyads.x3s
@@ -1,0 +1,19 @@
+#name: anarkis.acc.lib.get.flyads
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.get.flyads.xml
+
+$arr = [THIS] -> call script anarkis.acc.lib.get.adsonly :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$env = $select -> get environment
+skip if not $env == [THIS]
+remove element from array $arr at index $cnt
+end
+$cnt =  size of array $arr
+skip if $cnt
+return null
+
+return $arr

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.get.leader.big.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.get.leader.big.x3s
@@ -1,0 +1,22 @@
+#name: anarkis.acc.lib.get.leader.big
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.get.leader.big.xml
+
+$arr = [THIS] -> call script anarkis.acc.lib.get.leaderlist :
+$res = null
+$follow.count = 0
+
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$formation = $select -> get formation follower ships
+$formation =  size of array $formation
+if $formation >= $follow.count
+$res = $select
+$follow.count = $formation
+end
+end
+
+return $res

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.get.leaderlist.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.get.leaderlist.x3s
@@ -1,0 +1,26 @@
+#name: anarkis.acc.lib.get.leaderlist
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.get.leaderlist.xml
+
+$arr = [THIS] -> call script anarkis.acc.lib.get.adsonly :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$env = $select -> get environment
+if $env == [THIS]
+remove element from array $arr at index $cnt
+continue
+end
+if not $select -> has formation ships
+remove element from array $arr at index $cnt
+continue
+end
+end
+$cnt =  size of array $arr
+skip if $cnt
+return null
+
+
+return $arr

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.get.lonely.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.get.lonely.x3s
@@ -1,0 +1,23 @@
+#name: anarkis.acc.lib.get.lonely
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.get.lonely.xml
+
+$arr = [THIS] -> call script anarkis.acc.lib.get.adsonly :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$env = $select -> get environment
+skip if not $env == [THIS]
+remove element from array $arr at index $cnt
+skip if not $select -> has formation ships
+remove element from array $arr at index $cnt
+skip if not $select -> get formation leader
+remove element from array $arr at index $cnt
+end
+$cnt =  size of array $arr
+skip if $cnt
+return null
+
+return $arr

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.givetarget.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.givetarget.x3s
@@ -1,0 +1,33 @@
+#name: anarkis.acc.lib.givetarget
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.givetarget.xml
+
+$setup = [THIS] -> get local variable: name='anarkis.acc.setup'
+$radar.range = $setup[1]
+
+$leader.list = [THIS] -> call script anarkis.acc.lib.get.leaderlist :
+$leader.cnt =  size of array $leader.list
+while $leader.cnt
+dec $leader.cnt =
+$leader = $leader.list[$leader.cnt]
+* - Skip if a target is already assigned or on protect duty
+skip if not $leader -> is script !ship.cmd.protect.std on stack of task=0
+continue
+skip if not $leader -> is script anarkis.acc.cmd.protect on stack of task=0
+continue
+skip if not $leader -> get attack target
+continue
+* - Search for an enemy in the home radar range
+$flag = [Find.Random] | [Find.Enemy]
+$enemy =  find ship: sector=[SECTOR] class or type=Moveable Ship race=null flags=$flag refobj=[THIS] maxdist=$radar.range maxnum=1 refpos=null
+* - If not found, look around the leader
+skip if $enemy -> exists
+$enemy =  find ship: sector=[SECTOR] class or type=Moveable Ship race=null flags=$flag refobj=$leader maxdist=$radar.range maxnum=1 refpos=null
+if $enemy -> exists
+START $leader -> call script anarkis.acc.cmd.attack.return :  victim=$enemy  dst=[THIS]
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.isadsactive.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.isadsactive.x3s
@@ -1,0 +1,17 @@
+#name: anarkis.acc.lib.isadsactive
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.isadsactive.xml
+
+
+skip if not $target -> is script anarkis.acc.task.autocarrier on stack of task=10
+return [TRUE]
+skip if not $target -> is script anarkis.acc.task.autocarrier on stack of task=11
+return [TRUE]
+skip if not $target -> is script anarkis.acc.task.autocarrier.npc on stack of task=894
+return [TRUE]
+skip if not $target -> is script anarkis.acc.task.autocarrier on stack of task=894
+return [TRUE]
+
+return [FALSE]
+

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.name.load.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.name.load.x3s
@@ -1,0 +1,21 @@
+#name: anarkis.acc.lib.name.load
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.name.load.xml
+
+$arr = [THIS] -> call script anarkis.acc.lib.get.adsonly :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$name = $select -> get local variable: name='anarkis.acc.oldname'
+if $name
+$select -> set name to $name
+else
+$name = $select -> get ware type code of object
+$select -> set name to $name
+end
+$select -> set local variable: name='anarkis.acc.oldname' value=null
+end
+
+return $arr

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.name.save.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.lib.name.save.x3s
@@ -1,0 +1,15 @@
+#name: anarkis.acc.lib.name.save
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.name.save.xml
+
+$arr = [THIS] -> call script anarkis.acc.lib.get.adsonly :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$name = $select -> get name
+$select -> set local variable: name='anarkis.acc.oldname' value=$name
+end
+
+return $arr

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.repairshields.single.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.repairshields.single.x3s
@@ -1,0 +1,8 @@
+#name: anarkis.acc.repairshields.single
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.repairshields.single.xml
+
+$max = $ship -> get maximum shield strength
+$ship -> set current shield strength to $max
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.repairshields.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.repairshields.x3s
@@ -1,0 +1,21 @@
+#name: anarkis.acc.repairshields
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.repairshields.xml
+
+$array = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$max = $select -> get maximum shield strength
+$select -> set current shield strength to $max
+$select -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$select -> set command: COMMAND_NONE
+$select -> set destination to null
+$select -> set attack target to null
+$select -> set command target: null
+$select -> set command target2: null
+$select -> set ship command/signal SIGNAL_ATTACKED to global default behaviour
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.attackmode.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.attackmode.x3s
@@ -1,0 +1,28 @@
+#name: anarkis.acc.setup.attackmode
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.attackmode.xml
+
+$page.id = 8510
+
+$menu.result = -1
+while $menu.result == -1
+$menu =  create custom menu array
+
+$st = sprintf: pageid=$page.id textid=301, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=206, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=3
+$st = sprintf: pageid=$page.id textid=207, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=1
+$st = sprintf: pageid=$page.id textid=208, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=2
+
+$st = sprintf: pageid=$page.id textid=302, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 = sprintf: pageid=$page.id textid=301, null, null, null, null, null
+$menu.result =  open custom menu: title=$v1 description=null option array=$menu
+end
+
+return $menu.result

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.autocarrier.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.autocarrier.x3s
@@ -1,0 +1,233 @@
+#name: anarkis.acc.setup.autocarrier
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.autocarrier.xml
+
+$page.id = 8510
+
+* ====
+* Retrieve setup, apply default if not found
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$cnt =  size of array $setup.array
+if not $cnt == 19
+$setup.array = [THIS] -> call script anarkis.ads.setup.createdefault :  ref.object=[THIS]
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup.array
+end
+* ====
+
+* ====
+* Init selection arrays
+* - Alert Level
+$threat.level = $setup.array[0]
+$sel.threat =  array alloc: size=0
+append 1 to array $sel.threat
+append 3 to array $sel.threat
+append 5 to array $sel.threat
+append 8 to array $sel.threat
+append 10 to array $sel.threat
+append 15 to array $sel.threat
+append 20 to array $sel.threat
+append 25 to array $sel.threat
+append 30 to array $sel.threat
+append 35 to array $sel.threat
+append 40 to array $sel.threat
+$sel.threat.selection =  get index of $threat.level in array $sel.threat offset=-1 + 1
+$sel.threat.id = 'threat'
+* - Radar Range
+$radar.range = $setup.array[1]
+$sel.radar =  array alloc: size=0
+$v1 = 0
+while $v1 < 100000
+$v1 = $v1 + 5000
+append $v1 to array $sel.radar
+end
+$sel.radar.selection =  get index of $radar.range in array $sel.radar offset=-1 + 1
+$sel.radar.id = 'radar'
+* - Retreat Yes/No
+$retreat = $setup.array[3]
+$sel.yesno =  array alloc: size=0
+$v1 =  read text: page=$page.id id=820
+append $v1 to array $sel.yesno
+$v1 =  read text: page=$page.id id=821
+append $v1 to array $sel.yesno
+if $retreat == [TRUE]
+$sel.retreat.selection = 0
+else
+$sel.retreat.selection = 1
+end
+$sel.retreat.id = 'retreat'
+* - Attack Mode
+$sel.attack =  array alloc: size=0
+$v1 =  read text: page=$page.id id=206
+append $v1 to array $sel.attack
+$v1 =  read text: page=$page.id id=207
+append $v1 to array $sel.attack
+$v1 =  read text: page=$page.id id=208
+append $v1 to array $sel.attack
+$sel.attack.selection = $setup.array[6]
+skip if $sel.attack.selection != 3
+$sel.attack.selection = 0
+$sel.attack.id = 'attack'
+* - Defense ship count
+$defence = $setup.array[2]
+$sel.defense =  array alloc: size=0
+append 0 to array $sel.defense
+append 1 to array $sel.defense
+append 3 to array $sel.defense
+append 5 to array $sel.defense
+append 8 to array $sel.defense
+append 10 to array $sel.defense
+append 15 to array $sel.defense
+$sel.defense.selection =  get index of $defence in array $sel.defense offset=-1 + 1
+$sel.defense.id = 'defense'
+* - Delay before docking ships
+$delay = $setup.array[18]
+$sel.delay =  array alloc: size=0
+append 0 to array $sel.delay
+$v1 = 0
+while $v1 < 600
+$v1 = $v1 + 30
+append $v1 to array $sel.delay
+end
+$sel.delay.selection =  get index of $delay in array $sel.delay offset=-1 + 1
+$sel.delay.id = 'delay'
+* - Display Warning message Yes/No
+$warning = $setup.array[4]
+if $warning == [TRUE]
+$sel.warning.selection = 0
+else
+$sel.warning.selection = 1
+end
+$sel.warning.id = 'warning'
+* - Alert Type
+$sel.alert =  array alloc: size=0
+$v1 =  read text: page=$page.id id=233
+append $v1 to array $sel.alert
+$v1 =  read text: page=$page.id id=234
+append $v1 to array $sel.alert
+$v1 =  read text: page=$page.id id=235
+append $v1 to array $sel.alert
+$sel.alert.selection = $setup.array[5]
+skip if $sel.alert.selection != 3
+$sel.alert.selection = 0
+$sel.alert.id = 'warning.type'
+* End of init selection arrays
+* ====
+
+
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=220
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=221, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.threat, default=$sel.threat.selection, return id=$sel.threat.id
+
+$st = sprintf: pageid=$page.id textid=226, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.radar, default=$sel.radar.selection, return id=$sel.radar.id
+
+$st = sprintf: pageid=$page.id textid=223, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.yesno, default=$sel.retreat.selection, return id=$sel.retreat.id
+
+$st = sprintf: pageid=$page.id textid=224, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.attack, default=$sel.attack.selection, return id=$sel.attack.id
+
+$st = sprintf: pageid=$page.id textid=225, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.defense, default=$sel.defense.selection, return id=$sel.defense.id
+
+$st = sprintf: pageid=$page.id textid=238, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.delay, default=$sel.delay.selection, return id=$sel.delay.id
+
+$st =  read text: page=$page.id id=228
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=222, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.yesno, default=$sel.warning.selection, return id=$sel.warning.id
+
+$st = sprintf: pageid=$page.id textid=229, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.alert, default=$sel.alert.selection, return id=$sel.alert.id
+
+$st =  read text: page=$page.id id=403
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=1087
+add custom menu item to array $menu: text=$st returnvalue='save'
+
+$v1 = [THIS] -> get object class
+$st = sprintf: pageid=$page.id textid=250, [THIS], $v1, null, null, null
+add custom menu info line to array $menu: text=$st
+$st = sprintf: pageid=$page.id textid=251, [SECTOR], null, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 = [THIS] -> get number of landed ships
+$v2 = [THIS] -> get dock bay size
+$v3 = [THIS] -> get owned ships: class/type=Ship
+$v3 =  size of array $v3
+$st = sprintf: pageid=$page.id textid=252, $v1, $v2, $v3, null, null
+add custom menu info line to array $menu: text=$st
+$st = sprintf: pageid=$page.id textid=1088, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$st = sprintf: fmt='%s - Carrier Setup', [THIS], null, null, null, null
+$v1 =  read text: page=$page.id id=200
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if  is datatyp[ $menu.result ] == DATATYP_ARRAY
+$cnt =  size of array $menu.result
+while $cnt
+dec $cnt =
+$r.id = $menu.result[$cnt][0]
+$r.val = $menu.result[$cnt][1]
+* - - - Defense Ships
+if $r.id == $sel.defense.id
+$setup.array[2] = $sel.defense[$r.val]
+$sel.defense.selection = $r.val
+* - - - Radar Range
+else if $r.id == $sel.radar.id
+$setup.array[1] = $sel.radar[$r.val]
+$sel.radar.selection = $r.val
+* - - - Warning Type
+else if $r.id == $sel.alert.id
+$setup.array[5] = $r.val
+$sel.alert.selection = $r.val
+* - - - Attack Mode
+else if $r.id == $sel.attack.id
+skip if not $r.val == 0
+$r.val = 0
+$setup.array[6] = $r.val
+$sel.attack.selection = $r.val
+* - - - Retreat Mode
+else if $r.id == $sel.retreat.id
+if $r.val == 0
+$setup.array[3] = [TRUE]
+else
+$setup.array[3] = [FALSE]
+end
+$sel.retreat.selection = $r.val
+* - - - Delay before dock
+else if $r.id == $sel.delay.id
+$setup.array[18] = $sel.delay[$r.val]
+$sel.delay.selection = $r.val
+* - - - Warning Toggle
+else if $r.id == $sel.warning.id
+if $r.val == 0
+$setup.array[4] = [TRUE]
+else
+$setup.array[4] = [FALSE]
+end
+$sel.warning.selection = $r.val
+* - - - Threat Setting
+else if $r.id == $sel.threat.id
+$setup.array[0] = $sel.threat[$r.val]
+$sel.threat.selection = $r.val
+
+end
+end
+
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.buywares.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.buywares.x3s
@@ -1,0 +1,173 @@
+#name: anarkis.acc.setup.buywares
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.buywares.xml
+
+skip if $selected -> exists
+return null
+
+$page.id = 8510
+$null = null
+$setup.array = $selected -> get local variable: name='anarkis.acc.setup'
+$ware.list =  array alloc: size=0
+$quant.list =  array alloc: size=0
+$jump.range = 2
+$sector = $selected -> get sector
+
+while $menu.result != -1
+$menu =  create custom menu array
+$st =  read text: page=$page.id id=641
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=646
+add custom menu item to array $menu: text=$st returnvalue='add.ware'
+$cnt =  size of array $ware.list
+while $cnt
+dec $cnt =
+$v1 = $ware.list[$cnt]
+$v2 = $quant.list[$cnt]
+$st = sprintf: pageid=$page.id textid=660, $v1, $v2, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=$v1
+end
+$st =  read text: page=$page.id id=647
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=643
+add custom menu item to array $menu: text=$st returnvalue='rem.all'
+$st = sprintf: pageid=$page.id textid=648, $jump.range, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='jump.range'
+$st =  read text: page=$page.id id=659
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=645
+add custom menu item to array $menu: text=$st returnvalue='proceed'
+
+$st = sprintf: pageid=$page.id textid=658, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=657
+$st = sprintf: pageid=$page.id textid=488, $selected, null, null, null, null
+$menu.result =  open custom menu: title=$v1 description=$st option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'rem.all'
+$ware.list =  array alloc: size=0
+$quant.list =  array alloc: size=0
+
+else if $menu.result == 'jump.range'
+$st =  read text: page=$page.id id=651
+$jump.range = $selected -> get user input: type=Var/Number, title=$st
+
+else if $menu.result == 'add.ware'
+$st =  read text: page=$page.id id=652
+$v1 = $selected -> get user input: type=Var/Ware, title=$st
+if $v1
+if not  find $v1 in array: $ware.list
+$st =  read text: page=$page.id id=662
+$v2 = $selected -> get user input: type=Var/Number, title=$st
+if $v2
+append $v1 to array $ware.list
+append $v2 to array $quant.list
+end
+end
+end
+
+
+else if  is datatyp[ $menu.result ] == DATATYP_WARE
+$v1 =  get index of $menu.result in array $ware.list offset=-1 + 1
+remove element from array $ware.list at index $v1
+remove element from array $quant.list at index $v1
+
+else if $menu.result == 'proceed'
+$ok = [TRUE]
+
+while $ok == [TRUE]
+$ok = [FALSE]
+gosub cleanlist
+$proc.count =  size of array $ware.list
+while $proc.count
+dec $proc.count =
+$select.ware = $ware.list[$proc.count]
+$ware.amount = $quant.list[$proc.count]
+gosub getbestship
+if $select.ship -> exists
+$ok = [TRUE]
+$dest.station = $select.ship -> call script !lib.get.bestbuy :  Ware=$select.ware  Max Price=null  Max Jumps=$jump.range  Check for Property=[FALSE]  Find around sector=$selected
+$proc.warecount = $select.ship -> get max amount of ware $select.ware that can be stored in cargo bay
+if $proc.warecount >= $ware.amount
+$proc.warecount = $ware.amount
+$quant.list[$proc.count] = 0
+else
+$ware.amount = $ware.amount - $proc.warecount
+$quant.list[$proc.count] = $ware.amount
+end
+START $select.ship -> call script anarkis.acc.cmd.buy.return :  ware=$select.ware  station=$dest.station  quantity=$proc.warecount  min price=null
+$st = sprintf: pageid=$page.id textid=661, $select.ship, $proc.warecount, $select.ware, $dest.station, null
+display subtitle text: text=$st duration=2000 ms
+= wait 2000 ms
+end
+end
+end
+$menu.result = -1
+end
+end
+
+return null
+
+
+cleanlist:
+$cnt =  size of array $ware.list
+while $cnt
+dec $cnt =
+$select.ware = $ware.list[$cnt]
+$ware.amount = $quant.list[$cnt]
+gosub getbestship
+if $ware.amount == 0
+remove element from array $ware.list at index $cnt
+remove element from array $quant.list at index $cnt
+continue
+end
+if not $select.ship -> exists
+remove element from array $ware.list at index $cnt
+remove element from array $quant.list at index $cnt
+$st = sprintf: pageid=$page.id textid=655, $select.ware, null, null, null, null
+display subtitle text: text=$st duration=2000 ms
+= wait 2000 ms
+continue
+end
+if not [THIS] -> call script !lib.get.bestbuy :  Ware=$select.ware  Max Price=null  Max Jumps=$jump.range  Check for Property=[FALSE]  Find around sector=$selected
+remove element from array $ware.list at index $cnt
+$st = sprintf: pageid=$page.id textid=656, $select.ware, null, null, null, null
+display subtitle text: text=$st duration=2000 ms
+= wait 2000 ms
+continue
+end
+end
+
+endsub
+
+getbestship:
+$select.ship = null
+$v2 = 0
+$id = null
+$ship.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$ship.count =  size of array $ship.list
+while $ship.count
+dec $ship.count =
+$v1 = $ship.list[$ship.count]
+skip if not $v1 -> is task 0 in use
+continue
+$amt = $v1 -> get max amount of ware $select.ware that can be stored in cargo bay
+if $amt > $v2
+$v2 = $amt
+$id = $ship.count
+skip if not $amt >= $ware.amount
+break
+end
+end
+if $id != null
+$select.ship = $ship.list[$id]
+end
+endsub
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.copy.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.copy.x3s
@@ -1,0 +1,44 @@
+#name: anarkis.acc.setup.copy
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.copy.xml
+
+$null = null
+$setup = $base -> get local variable: name='anarkis.acc.setup'
+$v1 =  size of array $setup
+skip if $v1 == 19
+return [FALSE]
+
+$dest.setup = $dest -> get local variable: name='anarkis.acc.setup'
+$v1 =  size of array $dest.setup
+skip if $v1 == 19
+$dest.setup = $null -> call script anarkis.acc.setup.default.to :  dest=$dest
+
+* base setup (0-15)
+$v1 = 16
+while $v1
+dec $v1 =
+$dest.setup[$v1] = $setup[$v1]
+end
+$dest.setup[18] = $setup[18]
+
+* Ignore List (16)
+$arr = $setup[16]
+$v1 =  size of array $arr
+$arr.d =  array alloc: size=$v1
+while $v1
+dec $v1 =
+$arr.d[$v1] = $arr[$v1]
+end
+$dest.setup[16] = $arr.d
+
+* Mechanists (17) - ignore mech.count
+$arr = $setup[17]
+$arr.d = $dest.setup[17]
+$arr.d[1] = $arr[1]
+$arr.d[2] = $arr[2]
+$dest.setup[17] = $arr.d
+
+$dest -> set local variable: name='anarkis.acc.setup' value=$dest.setup
+
+return $dest.setup

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.default.st.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.default.st.x3s
@@ -1,0 +1,60 @@
+#name: anarkis.acc.setup.default.st
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.default.st.xml
+
+$setup =  array alloc: size=0
+
+* 0 threat level
+append 5 to array $setup
+* 1 Radar Range
+append 100000 to array $setup
+* 2 Defense Ship count
+append 5 to array $setup
+* 3 Damaged ships retreat
+append [TRUE] to array $setup
+* 4 Display warning
+append [TRUE] to array $setup
+* 5 warning type (0 subtitle, 1 audio, 2 text)
+append 2 to array $setup
+* 6 attack mode (3 auto, 1 nearest first, 2 strongest first)
+append 3 to array $setup
+* 7 docked ship autojump on / off
+append [TRUE] to array $setup
+* 8 docked ship autojump distance
+append 1 to array $setup
+* 9 docked ship fuel resupply (jumps)
+append 10 to array $setup
+* 10 docked ship emergency jump/escape
+append [TRUE] to array $setup
+* 11 docked ship shield threshold (in percent)
+append 10 to array $setup
+* 12 docked ship missile usage
+append 15 to array $setup
+* 13 use logfile
+append [FALSE] to array $setup
+* 14 turret settings
+append 246 to array $setup
+* 15 enable auto rename
+append [TRUE] to array $setup
+
+* 16 Ignore List (array)
+$ignore =  array alloc: size=0
+append $ignore to array $setup
+
+* 17 Mechanics
+$mechanists =  array alloc: size=0
+* - 0 Count
+append 4 to array $mechanists
+* - 1 Allow ship repairs
+append [FALSE] to array $mechanists
+* - 2 Allow carrier repairs
+append [FALSE] to array $mechanists
+append $mechanists to array $setup
+
+* 18 Delay before the autocarrier docks its ships
+append 600 to array $setup
+
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup
+
+return $setup

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.default.to.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.default.to.x3s
@@ -1,0 +1,60 @@
+#name: anarkis.acc.setup.default.to
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.default.to.xml
+
+$setup =  array alloc: size=0
+
+* 0 threat level
+append 15 to array $setup
+* 1 Radar Range
+append 20000 to array $setup
+* 2 Defense Ship count
+append 5 to array $setup
+* 3 Damaged ships retreat
+append [TRUE] to array $setup
+* 4 Display warning
+append [TRUE] to array $setup
+* 5 warning type (0 subtitle, 1 audio, 2 text)
+append 2 to array $setup
+* 6 attack mode (3 auto, 1 nearest first, 2 strongest first)
+append 3 to array $setup
+* 7 docked ship autojump on / off
+append [TRUE] to array $setup
+* 8 docked ship autojump distance
+append 1 to array $setup
+* 9 docked ship fuel resupply (jumps)
+append 10 to array $setup
+* 10 docked ship emergency jump/escape
+append [TRUE] to array $setup
+* 11 docked ship shield threshold (in percent)
+append 10 to array $setup
+* 12 docked ship missile usage
+append 15 to array $setup
+* 13 use logfile
+append [FALSE] to array $setup
+* 14 turret settings
+append 246 to array $setup
+* 15 enable autorename
+append [TRUE] to array $setup
+
+* 16 Ignore List (array)
+$ignore =  array alloc: size=0
+append $ignore to array $setup
+
+* 17 Mechanics
+$mechanists =  array alloc: size=0
+* - 0 Count
+append 0 to array $mechanists
+* - 1 Allow ship repairs
+append [FALSE] to array $mechanists
+* - 2 Allow carrier repairs
+append [FALSE] to array $mechanists
+append $mechanists to array $setup
+
+* 18 delay before dock
+append 300 to array $setup
+
+$dest -> set local variable: name='anarkis.acc.setup' value=$setup
+
+return $setup

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.default.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.default.x3s
@@ -1,0 +1,60 @@
+#name: anarkis.acc.setup.default
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.default.xml
+
+$setup =  array alloc: size=0
+
+* 0 threat level
+append 15 to array $setup
+* 1 Radar Range
+append 20000 to array $setup
+* 2 Defense Ship count
+append 5 to array $setup
+* 3 Damaged ships retreat
+append [TRUE] to array $setup
+* 4 Display warning
+append [TRUE] to array $setup
+* 5 warning type (0 subtitle, 1 audio, 2 text)
+append 2 to array $setup
+* 6 attack mode (3 auto, 1 nearest first, 2 strongest first)
+append 3 to array $setup
+* 7 docked ship autojump on / off
+append [TRUE] to array $setup
+* 8 docked ship autojump distance
+append 1 to array $setup
+* 9 docked ship fuel resupply (jumps)
+append 10 to array $setup
+* 10 docked ship emergency jump/escape
+append [TRUE] to array $setup
+* 11 docked ship shield threshold (in percent)
+append 10 to array $setup
+* 12 docked ship missile usage
+append 15 to array $setup
+* 13 use logfile
+append [FALSE] to array $setup
+* 14 turret settings
+append 246 to array $setup
+* 15 enable auto rename
+append [TRUE] to array $setup
+
+* 16 Ignore List (array)
+$ignore =  array alloc: size=0
+append $ignore to array $setup
+
+* 17 Mechanics
+$mechanists =  array alloc: size=0
+* - 0 Count
+append 0 to array $mechanists
+* - 1 Allow ship repairs
+append [FALSE] to array $mechanists
+* - 2 Allow carrier repairs
+append [FALSE] to array $mechanists
+append $mechanists to array $setup
+
+* 18 Delay before the autocarrier docks its ships
+append 300 to array $setup
+
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup
+
+return $setup

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.hangars.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.hangars.x3s
@@ -1,0 +1,143 @@
+#name: anarkis.acc.setup.hangars
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.hangars.xml
+
+$page.id = 8510
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=423
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=424
+add custom menu item to array $menu: text=$st returnvalue='set.home.all'
+$st =  read text: page=$page.id id=434
+add custom menu item to array $menu: text=$st returnvalue='set.name'
+$st =  read text: page=$page.id id=217
+add custom menu item to array $menu: text=$st returnvalue='setup'
+
+$st = sprintf: pageid=$page.id textid=425, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=426
+add custom menu item to array $menu: text=$st returnvalue='add.all'
+$st =  read text: page=$page.id id=427
+add custom menu item to array $menu: text=$st returnvalue='add.m3m4'
+$st =  read text: page=$page.id id=428
+add custom menu item to array $menu: text=$st returnvalue='add.m3'
+$st =  read text: page=$page.id id=429
+add custom menu item to array $menu: text=$st returnvalue='rem.all'
+
+$st = sprintf: pageid=$page.id textid=422, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$class = $curr.ship -> get object class
+$enabled = $curr.ship -> get local variable: name='anarkis.acc.ship'
+if $enabled == [TRUE]
+$v1 =  read text: page=$page.id id=431
+else
+$v1 =  read text: page=$page.id id=432
+end
+$st = sprintf: pageid=$page.id textid=430, $class, $curr.ship, $v1, null, null
+add custom menu item to array $menu: text=$st returnvalue=$curr.ship
+end
+
+$st = sprintf: pageid=$page.id textid=421, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 =  read text: page=$page.id id=420
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'add.all'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=[TRUE]
+$name = $curr.ship -> get name
+$curr.ship -> set local variable: name='anarkis.acc.oldname' value=$name
+if [OWNER] == Player
+$curr.ship -> set homebase to [THIS]
+end
+end
+
+else if $menu.result == 'rem.all'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=null
+end
+
+else if $menu.result == 'add.m3m4'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$v1 = $curr.ship -> get object class
+if $v1 == M3 OR $v1 == M4
+$name = $curr.ship -> get name
+$curr.ship -> set local variable: name='anarkis.acc.oldname' value=$name
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=[TRUE]
+$curr.ship -> set homebase to [THIS]
+end
+end
+
+else if $menu.result == 'add.m3'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$v1 = $curr.ship -> get object class
+if $v1 == M3
+$name = $curr.ship -> get name
+$curr.ship -> set local variable: name='anarkis.acc.oldname' value=$name
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=[TRUE]
+$curr.ship -> set homebase to [THIS]
+end
+end
+
+else if $menu.result == 'setup'
+= [THIS] -> call script anarkis.acc.setup.ships :
+
+else if $menu.result == 'set.home.all'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$curr.ship -> set homebase to [THIS]
+end
+
+else if $menu.result == 'set.name'
+= [THIS] -> call script anarkis.acc.setup.rename :
+
+else if $menu.result -> exists
+$enabled = $menu.result -> get local variable: name='anarkis.acc.ship'
+$enabled = ! $enabled
+$menu.result -> set local variable: name='anarkis.acc.ship' value=$enabled
+*$menu.result -> set local variable: name='anarkis.acc.skipme' value=$enabled
+if $enabled == [TRUE]
+$name = $menu.result -> get name
+$menu.result -> set local variable: name='anarkis.acc.oldname' value=$name
+$menu.result -> set homebase to [THIS]
+end
+end
+
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.ignorerace.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.ignorerace.x3s
@@ -1,0 +1,67 @@
+#name: anarkis.acc.setup.ignorerace
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.ignorerace.xml
+
+$page.id = 8510
+
+* Retrieve setup, apply default if not found
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+
+
+while $menu.result != -1
+
+$race.array = $setup.array[16]
+$race.count =  size of array $race.array
+
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=461
+add custom menu heading to array $menu: title=$st
+
+$st =  read text: page=$page.id id=463
+add custom menu item to array $menu: text=$st returnvalue='add'
+if $race.count
+$st =  read text: page=$page.id id=462
+add custom menu item to array $menu: text=$st returnvalue='clear'
+end
+
+if $race.count
+$st =  read text: page=$page.id id=460
+add custom menu heading to array $menu: title=$st
+$cnt = $race.count
+while $cnt
+dec $cnt =
+$v1 = $race.array[$cnt]
+$st = sprintf: pageid=$page.id textid=464, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=$v1
+end
+end
+
+$v1 =  read text: page=$page.id id=460
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'clear'
+resize array $race.array to 0
+
+else if $menu.result == 'add'
+$st =  read text: page=$page.id id=465
+$v1 = [THIS] -> get user input: type=Var/Race, title=$st
+skip if  is datatyp[ $v1 ] == DATATYP_RACE
+continue
+skip if  find $v1 in array: $race.array
+append $v1 to array $race.array
+
+else if $menu.result != -1
+$index =  get index of $menu.result in array $race.array offset=-1 + 1
+remove element from array $race.array at index $index
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.rename.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.rename.x3s
@@ -1,0 +1,76 @@
+#name: anarkis.acc.setup.rename
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.rename.xml
+
+$page.id = 8510
+$rename.mode = 481
+
+while $menu.result != -1
+
+$menu =  create custom menu array
+
+$v1 =  read text: page=$page.id id=$rename.mode
+$st = sprintf: pageid=$page.id textid=488, $v1, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$st =  read text: page=$page.id id=481
+add custom menu item to array $menu: text=$st returnvalue=481
+$st =  read text: page=$page.id id=482
+add custom menu item to array $menu: text=$st returnvalue=482
+$st =  read text: page=$page.id id=483
+add custom menu item to array $menu: text=$st returnvalue=483
+
+$st =  read text: page=$page.id id=485
+add custom menu heading to array $menu: title=$st
+
+$st =  read text: page=$page.id id=486
+add custom menu item to array $menu: text=$st returnvalue='ren.docked'
+$st =  read text: page=$page.id id=487
+add custom menu item to array $menu: text=$st returnvalue='ren.active'
+
+$st =  read text: page=$page.id id=484
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=480
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result > 480
+$rename.mode = $menu.result
+
+else if $menu.result == 'ren.docked' OR $menu.result == 'ren.active'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+$nb = 0
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$enabled = $curr.ship -> get local variable: name='anarkis.acc.ship'
+if $menu.result == 'ren.active' AND $enabled != [TRUE]
+continue
+end
+inc $nb =
+$v1 = $curr.ship -> get ware type code of object
+$v2 = $curr.ship -> get object class
+$v3 = $curr.ship -> get maker race
+$v4 = [THIS] -> get name
+if $rename.mode == 481
+$newname = sprintf: fmt='%s %s - %s', $v1, $v2, $nb, null, null
+else if $rename.mode == 482
+$newname = sprintf: fmt='%s - %s - %s', $v4, $v1, $nb, null, null
+else if $rename.mode == 483
+$newname = sprintf: fmt='%s %s - %s', $v3, $v2, $nb, null, null
+end
+$curr.ship -> set local variable: name='anarkis.acc.oldname' value=$newname
+$curr.ship -> set name to $newname
+end
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.repair.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.repair.x3s
@@ -1,0 +1,111 @@
+#name: anarkis.acc.setup.repair
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.repair.xml
+
+$page.id = 8510
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$mecha.setup = $setup.array[17]
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=403
+add custom menu heading to array $menu: title=$st
+
+$repair.docked = $mecha.setup[1]
+if $repair.docked == [TRUE]
+$v1 = 203
+else
+$v1 = 204
+end
+$st =  read text: page=$page.id id=$v1
+$st = sprintf: pageid=$page.id textid=404, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='ship.toggle'
+
+$repair.carrier = $mecha.setup[2]
+if $repair.carrier == [TRUE]
+$v1 = 203
+else
+$v1 = 204
+end
+$st =  read text: page=$page.id id=$v1
+$st = sprintf: pageid=$page.id textid=405, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='carrier.toggle'
+
+$mecha.count = $mecha.setup[0]
+$st = sprintf: pageid=$page.id textid=406, $mecha.count, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$st =  read text: page=$page.id id=407
+add custom menu item to array $menu: text=$st returnvalue='add'
+if $mecha.count
+$st =  read text: page=$page.id id=408
+add custom menu item to array $menu: text=$st returnvalue='rem'
+end
+
+$st = sprintf: pageid=$page.id textid=409, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$class = $curr.ship -> get object class
+$hull = $curr.ship -> get hull percent
+if $hull < 100
+$st = sprintf: pageid=$page.id textid=410, $class, $curr.ship, $hull, null, null
+add custom menu item to array $menu: text=$st returnvalue=$curr.ship
+end
+end
+
+$v1 = $mecha.count * 1000
+$v2 = $mecha.count * 5000
+$st = sprintf: pageid=$page.id textid=401, $v1, $v2, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 =  read text: page=$page.id id=400
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'rem'
+dec $mecha.count =
+$mecha.setup[0] = $mecha.count
+
+else if $menu.result == 'add'
+$v1 = get player money
+if $v1 < 50000
+$v2 =  read text: page=$page.id id=407
+= [THIS] -> call script anarkis.lib.display.message :  title=$v2  page number=$page.id  page.id=412  text arg1=null  text arg2=null  text arg3=null
+continue
+end
+$v2 = [Find.Friend] | [Find.Neutral]
+$v1 =  find station: sector=[SECTOR] class or type=Trading Dock race=null flags=$v2 refobj=[THIS] maxdist=null maxnum=1 refpos=null
+if not $v1 -> exists
+$v2 =  read text: page=$page.id id=407
+= [THIS] -> call script anarkis.lib.display.message :  title=$v2  page number=$page.id  page.id=413  text arg1=null  text arg2=null  text arg3=null
+continue
+end
+$v1 =  read text: page=$page.id id=411
+$v1 = [THIS] -> get user input: type=Var/Boolean, title=$v1
+if $v1 == 1
+add money to player: -50000
+inc $mecha.count =
+$mecha.setup[0] = $mecha.count
+end
+
+else if $menu.result == 'ship.toggle'
+$repair.docked = ! $repair.docked
+$mecha.setup[1] = $repair.docked
+
+else if $menu.result == 'carrier.toggle'
+$repair.carrier = ! $repair.carrier
+$mecha.setup[2] = $repair.carrier
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.reports.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.reports.x3s
@@ -1,0 +1,86 @@
+#name: anarkis.acc.setup.reports
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.reports.xml
+
+$page.id = 8510
+$null = null
+$setup.array = $selected -> get local variable: name='anarkis.acc.setup'
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+if $selected -> exists
+$st =  read text: page=$page.id id=806
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=807
+add custom menu item to array $menu: text=$st returnvalue='setup'
+$st =  read text: page=$page.id id=808
+add custom menu item to array $menu: text=$st returnvalue='all'
+end
+
+$st =  read text: page=$page.id id=803
+add custom menu heading to array $menu: title=$st
+$array = $null -> call script anarkis.acc.get.acc.carriers :  active only?=[FALSE]
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$v1 = $array[$cnt]
+$v2 = $v1 -> get object class
+$v3 = $v1 -> get sector
+$st = sprintf: pageid=$page.id textid=804, $v1, $v2, $v3, null, null
+add custom menu item to array $menu: text=$st returnvalue=$v1
+end
+
+
+if $selected -> exists
+$v1 = $selected -> get object class
+$st = sprintf: pageid=$page.id textid=801, $selected, $v1, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v3 = $selected -> get sector
+$v2 = $v3 -> get owner race
+$st = sprintf: pageid=$page.id textid=805, $v3, $v2, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 = $selected -> get command
+$v2 =  read text: page=$page.id id=820
+if not $selected -> is script anarkis.acc.task.autocarrier on stack of task=10
+if not $selected -> is script anarkis.acc.task.autocarrier on stack of task=11
+$v2 =  read text: page=$page.id id=821
+end
+end
+$st = sprintf: pageid=$page.id textid=802, $v1, $v2, null, null, null
+add custom menu info line to array $menu: text=$st
+end
+$v1 =  read text: page=$page.id id=800
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result -> is of class Moveable Ship
+$selected = $menu.result
+
+else if $menu.result == 'all'
+$array = $null -> call script anarkis.acc.get.acc.carriers :  active only?=[FALSE]
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$v1 = $array[$cnt]
+if $v1 != $selected
+= $null -> call script anarkis.acc.setup.copy :  base=$selected  dest=$v1
+end
+end
+
+else if $menu.result == 'setup'
+$selected -> start task 892 with script anarkis.acc.setup and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+return null
+end
+
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.sellwares.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.sellwares.x3s
@@ -1,0 +1,189 @@
+#name: anarkis.acc.setup.sellwares
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.sellwares.xml
+
+skip if $selected -> exists
+return null
+
+$page.id = 8510
+$null = null
+$setup.array = $selected -> get local variable: name='anarkis.acc.setup'
+$ware.list =  array alloc: size=0
+$jump.range = 2
+$sector = $selected -> get sector
+
+while $menu.result != -1
+$menu =  create custom menu array
+$st =  read text: page=$page.id id=641
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=646
+add custom menu item to array $menu: text=$st returnvalue='add.ware'
+$cnt =  size of array $ware.list
+while $cnt
+dec $cnt =
+$v1 = $ware.list[$cnt]
+$v2 = $selected -> get amount of ware $v1 in cargo bay
+$st = sprintf: pageid=$page.id textid=650, $v1, $v2, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=$v1
+end
+$st =  read text: page=$page.id id=642
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=643
+add custom menu item to array $menu: text=$st returnvalue='rem.all'
+$st =  read text: page=$page.id id=644
+add custom menu item to array $menu: text=$st returnvalue='add.all'
+$st =  read text: page=$page.id id=663
+add custom menu item to array $menu: text=$st returnvalue='add.missile'
+$st =  read text: page=$page.id id=647
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=648, $jump.range, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='jump.range'
+$st =  read text: page=$page.id id=645
+add custom menu item to array $menu: text=$st returnvalue='proceed'
+
+$st = sprintf: pageid=$page.id textid=649, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=640
+$st = sprintf: pageid=$page.id textid=488, $selected, null, null, null, null
+$menu.result =  open custom menu: title=$v1 description=$st option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'rem.all'
+$ware.list =  array alloc: size=0
+
+else if $menu.result == 'jump.range'
+$st =  read text: page=$page.id id=651
+$jump.range = $selected -> get user input: type=Var/Number, title=$st
+
+else if $menu.result == 'add.ware'
+$st =  read text: page=$page.id id=652
+$v1 = $selected -> get user input: type=Var/Ware of Ship, title=$st
+$v1 = $v1[0]
+if $v1
+skip if  find $v1 in array: $ware.list
+append $v1 to array $ware.list
+end
+
+else if $menu.result == 'add.missile'
+$wares = $selected -> get tradeable ware array from ship
+$cnt =  size of array $wares
+while $cnt
+dec $cnt =
+$v1 = $wares[$cnt]
+$v2 =  get maintype of ware $v1
+if $v2 == 10
+skip if  find $v1 in array: $ware.list
+append $v1 to array $ware.list
+end
+end
+
+else if $menu.result == 'add.all'
+$wares = $selected -> get tradeable ware array from ship
+$cnt =  size of array $wares
+while $cnt
+dec $cnt =
+$v1 = $wares[$cnt]
+$v2 =  get maintype of ware $v1
+if $v2 != 10 AND $v2 != 8 AND $v2 != 9
+skip if  find $v1 in array: $ware.list
+append $v1 to array $ware.list
+end
+end
+
+else if  is datatyp[ $menu.result ] == DATATYP_WARE
+$v1 =  get index of $menu.result in array $ware.list offset=-1 + 1
+remove element from array $ware.list at index $v1
+
+else if $menu.result == 'proceed'
+$ok = [TRUE]
+
+while $ok == [TRUE]
+$ok = [FALSE]
+gosub cleanlist
+$proc.count =  size of array $ware.list
+while $proc.count
+dec $proc.count =
+$select.ware = $ware.list[$proc.count]
+gosub getbestship
+if $select.ship -> exists
+$ok = [TRUE]
+$dest.station = $select.ship -> call script !lib.get.bestsell :  Ware=$select.ware  Min Price=null  Max Jumps=$jump.range  Check for Property=[FALSE]  Find around sector=$selected
+$proc.warecount = $select.ship -> get max amount of ware $select.ware that can be stored in cargo bay
+START $select.ship -> call script anarkis.acc.cmd.sell.return :  ware=$select.ware  station=$dest.station  quantity=$proc.warecount  min price=null
+$st = sprintf: pageid=$page.id textid=653, $select.ship, $select.ware, $dest.station, null, null
+display subtitle text: text=$st duration=2000 ms
+= wait 2000 ms
+end
+end
+end
+$menu.result = -1
+end
+end
+
+return null
+
+
+cleanlist:
+$cnt =  size of array $ware.list
+while $cnt
+dec $cnt =
+$select.ware = $ware.list[$cnt]
+if not $selected -> get amount of ware $select.ware in cargo bay
+remove element from array $ware.list at index $cnt
+continue
+end
+gosub getbestship
+if not $select.ship -> exists
+remove element from array $ware.list at index $cnt
+$st = sprintf: pageid=$page.id textid=655, $select.ware, null, null, null, null
+display subtitle text: text=$st duration=2000 ms
+= wait 2000 ms
+continue
+end
+if not $select.ship -> call script !lib.get.bestsell :  Ware=$select.ware  Min Price=null  Max Jumps=$jump.range  Check for Property=[FALSE]  Find around sector=$selected
+remove element from array $ware.list at index $cnt
+$st = sprintf: pageid=$page.id textid=654, $select.ware, null, null, null, null
+display subtitle text: text=$st duration=2000 ms
+= wait 2000 ms
+continue
+end
+end
+
+endsub
+
+getstation:
+$dest.station = $selected -> find station: resource $select.ware with best price: min.price=null, amount=$ware.amount, max.jumps=$jump.range, startsector=$sector, trader=$select.ship, exclude array=null
+endsub
+
+
+getbestship:
+$select.ship = null
+$v2 = 0
+$id = null
+$ware.amount = $selected -> get amount of ware $select.ware in cargo bay
+$ship.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$ship.count =  size of array $ship.list
+while $ship.count
+dec $ship.count =
+$v1 = $ship.list[$ship.count]
+skip if not $v1 -> is task 0 in use
+continue
+$amt = $v1 -> get max amount of ware $select.ware that can be stored in cargo bay
+if $amt > $v2
+$v2 = $amt
+$id = $ship.count
+skip if not $amt >= $ware.amount
+break
+end
+end
+if $id != null
+$select.ship = $ship.list[$id]
+end
+endsub
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.ships.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.ships.x3s
@@ -1,0 +1,169 @@
+#name: anarkis.acc.setup.ships
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.ships.xml
+
+$page.id = 8510
+* Retrieve setup, apply default if not found
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$cnt =  size of array $setup.array
+skip if $cnt == 19
+$setup.array = [THIS] -> call script anarkis.acc.setup.default :
+
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st = sprintf: pageid=$page.id textid=210, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$setup.missile = $setup.array[12]
+if not $setup.missile
+$v1 =  read text: page=$page.id id=205
+else
+$v1 = $setup.missile + '%'
+end
+$st = sprintf: pageid=$page.id textid=213, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='setup.missile'
+
+$setup.emergency = $setup.array[10]
+$v1 =  read text: page=$page.id id=205
+if $setup.emergency == [TRUE]
+$v1 =  read text: page=$page.id id=201
+else if $setup.emergency == [FALSE]
+$v1 =  read text: page=$page.id id=202
+end
+
+$setup.shieldlimit = $setup.array[11]
+if not $setup.shieldlimit
+$v2 =  read text: page=$page.id id=205
+else
+$v2 = $setup.shieldlimit + '%'
+end
+$st = sprintf: pageid=$page.id textid=214, $v1, $v2, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='setup.emergency'
+
+$autojump.enabled = $setup.array[7]
+$autojump.range = $setup.array[8]
+$v1 =  read text: page=$page.id id=205
+if $autojump.enabled == [TRUE]
+$v1 =  read text: page=$page.id id=201
+else if $autojump.enabled == [FALSE]
+$v1 =  read text: page=$page.id id=202
+end
+if not $autojump.range
+$v2 =  read text: page=$page.id id=205
+else
+$v2 = $autojump.range
+end
+$st = sprintf: pageid=$page.id textid=215, $v1, $v2, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='setup.autojump'
+
+$fuel.resupply = $setup.array[9]
+if not $fuel.resupply
+$v1 =  read text: page=$page.id id=205
+else
+$v1 = $fuel.resupply
+end
+$st = sprintf: pageid=$page.id textid=216, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='fuel.resupply'
+
+$turret.setup = $setup.array[14]
+$v1 =  read text: page=$page.id id=$turret.setup
+$st = sprintf: pageid=$page.id textid=244, $v1, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=245, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=245
+$st = sprintf: pageid=$page.id textid=246, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=246
+$st = sprintf: pageid=$page.id textid=247, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=247
+$mars.check = get global variable: name='GZ.MARS.CONFIG'
+if  is datatyp[ $mars.check ] == DATATYP_ARRAY
+$st = sprintf: pageid=$page.id textid=248, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=248
+$st = sprintf: pageid=$page.id textid=249, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=249
+
+end
+
+$st =  read text: page=$page.id id=230
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=231, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='set.all'
+$st = sprintf: pageid=$page.id textid=237, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='set.active'
+
+
+$v1 = [THIS] -> get object class
+$st = sprintf: pageid=$page.id textid=250, [THIS], $v1, null, null, null
+add custom menu info line to array $menu: text=$st
+$st = sprintf: pageid=$page.id textid=251, [SECTOR], null, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 = [THIS] -> get number of landed ships
+$v2 = [THIS] -> get dock bay size
+$v3 = [THIS] -> get owned ships: class/type=Ship
+$v3 =  size of array $v3
+$st = sprintf: pageid=$page.id textid=252, $v1, $v2, $v3, null, null
+add custom menu info line to array $menu: text=$st
+
+$st = sprintf: fmt='%s - Carrier Setup', [THIS], null, null, null, null
+$v1 =  read text: page=$page.id id=200
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'fuel.resupply'
+$st =  read text: page=$page.id id=308
+$fuel.resupply = [THIS] -> get user input: type=Var/Number, title=$st
+$setup.array[9] = $fuel.resupply
+
+else if $menu.result == 'setup.autojump'
+$st =  read text: page=$page.id id=309
+$autojump.enabled = [THIS] -> get user input: type=Var/Boolean, title=$st
+if $autojump.enabled == 1
+$autojump.enabled = [TRUE]
+$st =  read text: page=$page.id id=310
+$autojump.range = [THIS] -> get user input: type=Var/Number, title=$st
+$setup.array[8] = $autojump.range
+else
+$autojump.enabled = [FALSE]
+end
+$setup.array[7] = $autojump.enabled
+
+else if $menu.result == 'setup.emergency'
+$st =  read text: page=$page.id id=311
+$setup.emergency = [THIS] -> get user input: type=Var/Boolean, title=$st
+if $setup.emergency == 1
+$setup.emergency = [TRUE]
+$st =  read text: page=$page.id id=312
+$setup.shieldlimit = [THIS] -> get user input: type=Var/Number, title=$st
+$setup.array[11] = $setup.shieldlimit
+else
+$setup.emergency = [FALSE]
+end
+$setup.array[10] = $setup.emergency
+
+else if $menu.result == 'setup.missile'
+$st =  read text: page=$page.id id=313
+$setup.missile = [THIS] -> get user input: type=Var/Number, title=$st
+$setup.array[12] = $setup.missile
+
+else if $menu.result == 'set.active'
+= [THIS] -> call script anarkis.acc.apply.settings :  active ships only?=[TRUE]
+
+else if $menu.result == 'set.all'
+= [THIS] -> call script anarkis.acc.apply.settings :  active ships only?=[FALSE]
+
+else if $menu.result >= 245
+$setup.array[14] = $menu.result
+
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.supplies.c2s.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.supplies.c2s.x3s
@@ -1,0 +1,172 @@
+#name: anarkis.acc.setup.supplies.c2s
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.supplies.c2s.xml
+
+$page.id = 8510
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$supply.setup = $setup.array[15]
+
+$trans.ship = 529
+$trans.mode = 525
+
+$ware.list =  array alloc: size=0
+$ware.limit =  array alloc: size=0
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=521
+add custom menu heading to array $menu: title=$st
+
+$st =  read text: page=$page.id id=522
+add custom menu item to array $menu: text=$st returnvalue='add'
+
+$v1 =  size of array $ware.list
+while $v1
+dec $v1 =
+$v2 = $ware.list[$v1]
+$v3 = $ware.limit[$v1]
+$st = sprintf: pageid=$page.id textid=523, $v2, $v3, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=$v2
+end
+
+$st =  read text: page=$page.id id=$trans.mode
+$st = sprintf: pageid=$page.id textid=524, $st, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=525
+add custom menu item to array $menu: text=$st returnvalue=525
+$st =  read text: page=$page.id id=526
+add custom menu item to array $menu: text=$st returnvalue=526
+
+$st =  read text: page=$page.id id=$trans.ship
+$st = sprintf: pageid=$page.id textid=527, $st, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=528
+add custom menu item to array $menu: text=$st returnvalue=528
+$st =  read text: page=$page.id id=529
+add custom menu item to array $menu: text=$st returnvalue=529
+
+$st =  read text: page=$page.id id=530
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=531
+add custom menu item to array $menu: text=$st returnvalue='proceed'
+
+$v1 =  read text: page=$page.id id=520
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result < 527
+$trans.mode = $menu.result
+
+else if $menu.result < 530
+$trans.ship = $menu.result
+
+else if  is datatyp[ $menu.result ] == DATATYP_WARE
+$v1 =  get index of $menu.result in array $ware.list offset=-1 + 1
+remove element from array $ware.list at index $v1
+remove element from array $ware.limit at index $v1
+
+else if $menu.result == 'add'
+$st =  read text: page=$page.id id=532
+if [THIS] -> is of class Station
+$v1 = [THIS] -> get user input: type=Var/Station and Ware, title=$st
+else
+$v1 = [THIS] -> get user input: type=Var/Ware of Ship, title=$st
+end
+$v1 = $v1[0]
+skip if not  find $v1 in array: $ware.list
+continue
+skip if not $v1 == null
+continue
+$st =  read text: page=$page.id id=533
+$v2 = [THIS] -> get user input: type=Var/Number, title=$st
+skip if $v2 > 0
+continue
+append $v1 to array $ware.list
+append $v2 to array $ware.limit
+
+else if $menu.result == 'proceed'
+* - - Proceed
+
+$report.menu =  create custom menu array
+$st =  read text: page=$page.id id=541
+add custom menu heading to array $report.menu: title=$st
+
+if $trans.ship == 528
+$array = [THIS] -> get ship array from sector/ship/station
+else
+$array = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[FALSE]
+end
+$total.ship =  size of array $array
+$cnt =  size of array $array
+* - - Mode : 525 - Same Quant
+if $trans.mode == 525
+$ware.count =  size of array $ware.list
+while $ware.count
+dec $ware.count =
+$ware = $ware.list[$ware.count]
+$ware.quant = $ware.limit[$ware.count]
+$curr.amt = [THIS] -> get amount of ware $ware in cargo bay
+$add.amt = $curr.amt / $total.ship
+skip if $add.amt
+inc $add.amt =
+skip if $add.amt <= $ware.quant
+$add.amt = $ware.quant
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$ship = $array[$cnt]
+$left = $ship -> add $add.amt units of $ware
+$st = sprintf: pageid=$page.id textid=542, $left, $ware, $ship, null, null
+add custom menu item to array $report.menu: text=$st returnvalue=0
+
+$rem = 0 - $add.amt
+= [THIS] -> add $rem units of $ware
+skip if [THIS] -> get amount of ware $ware in cargo bay
+break
+end
+end
+* - - Mode : 526 - At least
+else if $trans.mode == 526
+$ware.count =  size of array $ware.list
+while $ware.count
+dec $ware.count =
+$ware = $ware.list[$ware.count]
+$ware.quant = $ware.limit[$ware.count]
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$ship = $array[$cnt]
+$curr.amt = [THIS] -> get amount of ware $ware in cargo bay
+skip if $curr.amt >= $ware.quant
+$ware.quant = $curr.amt
+$left = $ship -> add $ware.quant units of $ware
+
+$st = sprintf: pageid=$page.id textid=542, $left, $ware, $ship, null, null
+add custom menu item to array $report.menu: text=$st returnvalue=0
+
+$rem = 0 - $ware.quant
+= [THIS] -> add $rem units of $ware
+
+
+
+skip if [THIS] -> get amount of ware $ware in cargo bay
+break
+end
+end
+end
+* - - And exit
+$v1 =  read text: page=$page.id id=540
+$v2 =  read text: page=$page.id id=260
+$x =  open custom menu: title=$v1 description=$v2 option array=$report.menu
+return null
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.supplies.s2c.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.supplies.s2c.x3s
@@ -1,0 +1,111 @@
+#name: anarkis.acc.setup.supplies.s2c
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.supplies.s2c.xml
+
+$page.id = 8510
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$supply.setup = $setup.array[15]
+
+$trans.type = 451
+$trans.ship = 456
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=$trans.type
+$st = sprintf: pageid=$page.id textid=450, $st, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$st =  read text: page=$page.id id=451
+add custom menu item to array $menu: text=$st returnvalue=451
+$st =  read text: page=$page.id id=452
+add custom menu item to array $menu: text=$st returnvalue=452
+$st =  read text: page=$page.id id=453
+add custom menu item to array $menu: text=$st returnvalue=453
+$st =  read text: page=$page.id id=454
+add custom menu item to array $menu: text=$st returnvalue=454
+
+$st =  read text: page=$page.id id=$trans.ship
+$st = sprintf: pageid=$page.id textid=455, $st, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$st =  read text: page=$page.id id=456
+add custom menu item to array $menu: text=$st returnvalue=456
+$st =  read text: page=$page.id id=457
+add custom menu item to array $menu: text=$st returnvalue=457
+
+$st =  read text: page=$page.id id=458
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=459
+add custom menu item to array $menu: text=$st returnvalue='proceed'
+
+$st =  read text: page=$page.id id=449
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=440
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result < 456
+$trans.type = $menu.result
+
+else if $menu.result < 460
+$trans.ship = $menu.result
+
+else if $menu.result == 'proceed'
+if $trans.ship == 457
+$array = [THIS] -> get ship array from sector/ship/station
+else
+$array = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[FALSE]
+end
+$cnt =  size of array $array
+$report.menu =  create custom menu array
+$st =  read text: page=$page.id id=541
+add custom menu heading to array $report.menu: title=$st
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$wares = $select -> get tradeable ware array from ship
+$v1 =  size of array $wares
+while $v1
+dec $v1 =
+$cur.ware = $wares[$v1]
+$v2 =  get maintype of ware $cur.ware
+if $trans.type == 451 AND ( $v2 != 8 AND $v2 != 16 AND $v2 != 10 AND $v2 != 11 )
+$amt = $select -> get amount of ware $cur.ware in cargo bay
+$left = $select -> unload $amt units of $cur.ware
+$st = sprintf: pageid=$page.id textid=543, $left, $cur.ware, $select, null, null
+add custom menu item to array $report.menu: text=$st returnvalue=0
+else if $trans.type == 452 AND ( $v2 != 8 AND $v2 != 10 AND $v2 != 16 )
+$amt = $select -> get amount of ware $cur.ware in cargo bay
+$left = $select -> unload $amt units of $cur.ware
+$st = sprintf: pageid=$page.id textid=543, $left, $cur.ware, $select, null, null
+add custom menu item to array $report.menu: text=$st returnvalue=0
+else if $trans.type == 453 AND ( $v2 == 10 )
+$amt = $select -> get amount of ware $cur.ware in cargo bay
+$left = $select -> unload $amt units of $cur.ware
+$st = sprintf: pageid=$page.id textid=543, $left, $cur.ware, $select, null, null
+add custom menu item to array $report.menu: text=$st returnvalue=0
+else if $trans.type == 454
+$amt = $select -> get amount of ware $cur.ware in cargo bay
+$left = $select -> unload $amt units of $cur.ware
+$st = sprintf: pageid=$page.id textid=543, $left, $cur.ware, $select, null, null
+add custom menu item to array $report.menu: text=$st returnvalue=0
+end
+end
+end
+$v1 =  read text: page=$page.id id=540
+$v2 =  read text: page=$page.id id=260
+$x =  open custom menu: title=$v1 description=$v2 option array=$report.menu
+
+return null
+
+end
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.supplies.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.supplies.x3s
@@ -1,0 +1,61 @@
+#name: anarkis.acc.setup.supplies
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.supplies.xml
+
+$page.id = 8510
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$supply.setup = $setup.array[15]
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=442
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=443
+add custom menu item to array $menu: text=$st returnvalue='c2s'
+$st =  read text: page=$page.id id=444
+add custom menu item to array $menu: text=$st returnvalue='s2c'
+
+$st =  read text: page=$page.id id=445
+add custom menu heading to array $menu: title=$st
+
+$replace.ship = $supply.setup[0]
+if $replace.ship == [TRUE]
+$v1 = 203
+else
+$v1 = 204
+end
+$st =  read text: page=$page.id id=$v1
+$st = sprintf: pageid=$page.id textid=446, $st, null, null, null, null
+*add custom menu item to array $menu: text=$st returnvalue='replace.ship'
+
+$keep.supply = $supply.setup[1]
+if $keep.supply == [TRUE]
+$v1 = 203
+else
+$v1 = 204
+end
+$st =  read text: page=$page.id id=$v1
+$st = sprintf: pageid=$page.id textid=447, $st, null, null, null, null
+*add custom menu item to array $menu: text=$st returnvalue='keep.supply'
+
+$st =  read text: page=$page.id id=441
+add custom menu info line to array $menu: text=$st
+$v1 =  read text: page=$page.id id=440
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 's2c'
+= [THIS] -> call script anarkis.acc.setup.supplies.s2c :
+else if $menu.result == 'c2s'
+= [THIS] -> call script anarkis.acc.setup.supplies.c2s :
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.threatsetup.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.threatsetup.x3s
@@ -1,0 +1,34 @@
+#name: anarkis.acc.setup.threatsetup
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.threatsetup.xml
+
+$page.id = 8510
+
+$menu.result = -1
+while $menu.result == -1
+$menu =  create custom menu array
+
+$st = sprintf: pageid=$page.id textid=307, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+add custom menu item to array $menu: text='1' returnvalue=1
+add custom menu item to array $menu: text='3' returnvalue=3
+add custom menu item to array $menu: text='5' returnvalue=5
+add custom menu item to array $menu: text='10' returnvalue=10
+add custom menu item to array $menu: text='15' returnvalue=15
+add custom menu item to array $menu: text='20' returnvalue=20
+add custom menu item to array $menu: text='25' returnvalue=25
+add custom menu item to array $menu: text='30' returnvalue=30
+add custom menu item to array $menu: text='35' returnvalue=35
+add custom menu item to array $menu: text='40' returnvalue=40
+
+$st = sprintf: pageid=$page.id textid=305, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+$st = sprintf: pageid=$page.id textid=306, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 = sprintf: pageid=$page.id textid=301, null, null, null, null, null
+$menu.result =  open custom menu: title=$v1 description=null option array=$menu
+end
+
+return $menu.result

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.setup.x3s
@@ -1,0 +1,113 @@
+#name: anarkis.acc.setup
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+
+
+* Retrieve setup, apply default if not found
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$cnt =  size of array $setup.array
+if not $cnt == 19
+$setup.array = [THIS] -> call script anarkis.ads.setup.createdefault :  ref.object=[THIS]
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup.array
+end
+
+*= [THIS] -> call script anarkis.acc.apply.active :
+
+skip if [THIS] -> is script anarkis.acc.task.repairs on stack of task=900
+[THIS] -> start task 900 with script anarkis.acc.task.repairs and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=240
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=211, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='setup.home'
+$st = sprintf: pageid=$page.id textid=242, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='repairbay'
+
+if [THIS] -> is of class Station
+$st = sprintf: pageid=$page.id textid=1086, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='barracks'
+else if [THIS] -> is of class M1
+$st = sprintf: pageid=$page.id textid=1086, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='barracks'
+end
+
+$st = sprintf: pageid=$page.id textid=241, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='autocarrier'
+
+
+$st = sprintf: pageid=$page.id textid=440, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=443, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='c2s'
+$st = sprintf: pageid=$page.id textid=444, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='s2c'
+
+$st = sprintf: pageid=$page.id textid=210, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=232, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='reset'
+
+$v1 = [THIS] -> get object class
+$v2 = [THIS] -> get name
+$st = sprintf: pageid=$page.id textid=250, $v2, $v1, null, null, null
+add custom menu info line to array $menu: text=$st
+$st = [THIS] -> call script anarkis.lib.sector.format :  sector=[SECTOR]
+$st = sprintf: pageid=$page.id textid=251, $st, null, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 = [THIS] -> get number of landed ships
+$v2 = [THIS] -> get dock bay size
+$v3 = [THIS] -> get owned ships: class/type=Ship
+$v3 =  size of array $v3
+$st = sprintf: pageid=$page.id textid=252, $v1, $v2, $v3, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=200
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'autocarrier'
+= [THIS] -> call script anarkis.acc.setup.autocarrier :
+
+else if $menu.result == 'c2s'
+= [THIS] -> call script anarkis.acc.setup.supplies.c2s :
+
+else if $menu.result == 's2c'
+= [THIS] -> call script anarkis.acc.setup.supplies.s2c :
+
+else if $menu.result == 'setup.home'
+= [THIS] -> call script anarkis.acc.setup.hangars :
+
+else if $menu.result == 'repairbay'
+= [THIS] -> call script anarkis.acc.setup.repair :
+
+else if $menu.result == 'supplies'
+= [THIS] -> call script anarkis.acc.setup.supplies :
+else if $menu.result == 'barracks'
+= [THIS] -> call script anarkis.ads.comm.barracks :  ship or station=[THIS]
+
+* dont loop here
+
+else if $menu.result == 'reset'
+$setup.array = [THIS] -> call script anarkis.acc.setup.default :
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup.array
+
+
+end
+
+end
+
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup.array
+return $setup.array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.signal.killed.npc.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.signal.killed.npc.x3s
@@ -1,0 +1,11 @@
+#name: anarkis.acc.signal.killed.npc
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.signal.killed.npc.xml
+
+* Prevent ship respawn
+
+[THIS] -> set owner race to Neutral Race
+[THIS] -> set homebase to null
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.task.autocarrier.npc.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.task.autocarrier.npc.x3s
@@ -1,0 +1,363 @@
+#name: anarkis.acc.task.autocarrier.npc
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.task.autocarrier.npc.xml
+
+* ===========================================
+* Automated Carrier : Main Task
+* Can be run on NPC carriers without the ship respawning
+* ===========================================
+
+$null = null
+$fightinprogress = [FALSE]
+$page.id = 8510
+
+if [OWNER] == Player
+return null
+end
+
+$save.owner = [OWNER]
+
+while [OWNER] == $save.owner
+
+* - Reload setup
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$var1 =  size of array $setup.array
+if not $var1 == 19
+$setup.array = [THIS] -> call script anarkis.ads.setup.createdefault :  ref.object=[THIS]
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup.array
+= [THIS] -> call script anarkis.acc.apply.active :
+end
+
+* - Start Repair task if needed
+*skip if [THIS] -> is script anarkis.acc.task.repairs on stack of task=900
+*[THIS] -> start task 900 with script anarkis.acc.task.repairs and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+
+$display.warning = $setup.array[4]
+$alert.level = $setup.array[0]
+$defence.ships = $setup.array[2]
+$attack.mode = $setup.array[6]
+$autorename = $setup.array[15]
+$dock.delay = $setup.array[18]
+
+*$curr.threat = $null -> call script anarkis.acc.evalute.danger :  sector=[SECTOR]  checker=[THIS]
+$curr.threat = $null -> call script anarkis.acc.evalute.danger.npc :  sector=[SECTOR]  checker=[THIS]
+$shield = [THIS] -> get shield percent
+$attacker = [THIS] -> get attacker
+if $curr.threat > 3
+$strongest = $null -> call script anarkis.acc.evaluate.findstrong :  sector=[SECTOR]  checker=[THIS]
+end
+
+* - The carrier is attacked by an incoming
+if $attacker != null AND $shield <= 80 AND $fightinprogress == [FALSE]
+gosub alert
+gosub counterattack
+
+* - The threat level is reached
+else if $curr.threat >= $alert.level AND $fightinprogress == [FALSE]
+gosub alert
+gosub rename
+* - - Nearest First (usual command will work)
+if $attack.mode == 1
+gosub clearsector
+* - - Strongest First
+else if $attack.mode == 2
+gosub strongestfirst
+* - - Let ACC decide
+else
+gosub decide
+end
+
+* - Battle in progress, handle wings and deploy docked fighters
+else if $curr.threat > 0 AND $fightinprogress == [TRUE]
+gosub handlewings
+
+* - Threat eliminated, lets dock if no new enemies
+else if $curr.threat == 0 AND $fightinprogress == [TRUE]
+$pl.time = playing time
+$end.time = $pl.time + $dock.delay
+skip if not $dock.delay
+gosub protect.carrier
+while $pl.time < $end.time AND $curr.threat == 0
+= wait randomly from 1000 to 2000 ms
+$curr.threat = $null -> call script anarkis.acc.evalute.danger.npc :  sector=[SECTOR]  checker=[THIS]
+*$curr.threat = $null -> call script anarkis.acc.evalute.danger :  sector=[SECTOR]  checker=[THIS]
+$pl.time = playing time
+end
+if $curr.threat == 0
+$fightinprogress = [FALSE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=null
+= [THIS] -> call script anarkis.acc.cmd.alert.dock :
+gosub stoprename
+else
+gosub stop.protect
+end
+
+* - Not supposed to happen, but it happens :/ so we dock
+else if [THIS] -> call script anarkis.acc.lib.get.flyads :
+$fightinprogress = [FALSE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=null
+= [THIS] -> call script anarkis.acc.cmd.alert.dock :
+gosub stoprename
+end
+
+= wait 8000 ms
+end
+return null
+
+
+* ====================================
+* AutoRename v2
+* ====================================
+rename:
+if $autorename == [TRUE]
+if not [THIS] -> is script anarkis.acc.task.autoname.plus on stack of task=893
+= [THIS] -> call script anarkis.acc.lib.name.save :
+[THIS] -> start task 893 with script anarkis.acc.task.autoname.plus and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+end
+endsub
+* ====================================
+stoprename:
+if [THIS] -> is script anarkis.acc.task.autoname.plus on stack of task=893
+[THIS] -> start task 893 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+= [THIS] -> call script anarkis.acc.lib.name.load :
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Wings ordered to resume battle
+* ====================================
+stop.protect:
+$arr = [THIS] -> call script anarkis.acc.lib.get.leaderlist :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$leader = $arr[$cnt]
+START $leader -> call script !ship.cmd.killenemies.std :
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Wings ordered to protect carrier
+* ====================================
+protect.carrier:
+$arr = [THIS] -> call script anarkis.acc.lib.get.leaderlist :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$leader = $arr[$cnt]
+START $leader -> call script anarkis.acc.cmd.protect :  protect target=[THIS]
+end
+$arr = [THIS] -> call script anarkis.acc.lib.get.lonely :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$leader = $arr[$cnt]
+START $leader -> call script !ship.cmd.returnhome.std :
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Handle wings during battle
+* ====================================
+handlewings:
+if $attack.mode != 1
+$my.attacker = [THIS] -> get attacker
+$leader = [THIS] -> call script anarkis.acc.lib.get.leader.big :
+if $my.attacker -> is of class Big Ship
+if $leader
+$var1 = $leader -> get attack target
+skip if $var1 == $my.attacker
+START $leader -> call script anarkis.acc.cmd.attack.return :  victim=$my.attacker  dst=[THIS]
+end
+else
+$strongest = $null -> call script anarkis.acc.evaluate.findstrong :  sector=[SECTOR]  checker=[THIS]
+if $strongest AND $leader
+$var1 = $leader -> get attack target
+skip if $var1 == $strongest
+START $leader -> call script anarkis.acc.cmd.attack.return :  victim=$strongest  dst=[THIS]
+end
+end
+end
+= wait 100 ms
+= [THIS] -> call script anarkis.acc.lib.givetarget :
+= wait 100 ms
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+* ====================================
+* Display warning if needed
+* ====================================
+alert:
+skip if $display.warning == [TRUE]
+endsub
+$enemy.class = $strongest -> get object class
+$var1 = [THIS] -> call script anarkis.acc.get.all :  ship class=Moveable Ship  no damaged ships?=[TRUE]  active only?=[TRUE]
+$var1 =  size of array $var1
+if ( $var1 < $curr.threat AND $curr.threat > 40 ) OR ( $enemy.class == M2 ) OR ( $shield < 30 AND $attacker )
+
+$display.mode = $setup.array[5]
+if $display.mode == 1
+else if $display.mode == 1
+play sample [IncomingTransmission.SOS]
+$st = sprintf: pageid=$page.id textid=506, [THIS], [SECTOR], null, null, null
+display subtitle text: text=$st duration=15000 ms
+else if $display.mode == 2
+START $null -> call script anarkis.acc.audio.alert :  ship=[THIS]
+else if $display.mode == 3
+$st = sprintf: pageid=$page.id textid=500, [THIS], [SECTOR], null, null, null
+send incoming message $st to player: display it=[TRUE]
+end
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Will choose to attack the stronger if M6 or + found else will go for usual
+* ====================================
+decide:
+$enemy.class = $strongest -> get object class
+if $enemy.class == M1 OR $enemy.class == M2 OR $enemy.class == M7 OR $enemy.class == M6
+goto label advanced.mode
+*goto label strongestfirst
+else
+goto label clearsector
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Most efficient way
+* ====================================
+* - Each wing will be sent with a size according to the threat
+* ====================================
+advanced.mode:
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+$fightinprogress = [TRUE]
+$enemy.list = [THIS] -> call script anarkis.acc.lib.get.enemies :  sector=[SECTOR]  checker=[THIS]
+$enemy.count =  size of array $enemy.list
+$wing.id = 0
+while $enemy.count
+dec $enemy.count =
+$enemy.ship = $enemy.list[$enemy.count]
+$enemy.class = $enemy.ship -> get object class
+$min.fighter = [THIS] -> call script anarkis.lib.get.shipcount :  class=$enemy.class
+$dock.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$dock.count =  size of array $dock.list
+if $dock.count >= $min.fighter
+inc $wing.id =
+$wing.name = sprintf: fmt='A%s', $wing.id, null, null, null, null
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$enemy.ship  wing size=$min.fighter  wing ID=$wing.name
+end
+end
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+strongestfirst:
+* ====================================
+* Will attack the strongest enemy in range first
+* ====================================
+* - A defensive wing will be deployed
+* - An offensive wing against the strongest enemy will be deployed
+* - Other ships if any are ordered to clear sector
+* ====================================
+* No strong, fall back to clear sector
+skip if $strongest -> exists
+goto label clearsector
+$fightinprogress = [TRUE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+= [THIS] -> call script anarkis.acc.apply.relations :  active ships only?=[TRUE]
+* Repair Shields
+= [THIS] -> call script anarkis.acc.repairshields :
+* A defensive wing will be deployed
+if $defence.ships > 0
+= [THIS] -> call script anarkis.acc.wing.defence :  target=[THIS]  wing size=$defence.ships
+= wait 2000 ms
+end
+* An offensive wing against the strongest enemy will be deployed
+$enemy.class = $strongest -> get object class
+$min.fighter = [THIS] -> call script anarkis.lib.get.shipcount :  class=$enemy.class
+$dock.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$dock.count =  size of array $dock.list
+if $dock.count > $min.fighter
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$strongest  wing size=$min.fighter  wing ID='A'
+else
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$strongest  wing size=$dock.count  wing ID='A'
+end
+* Other ships if any are ordered to clear sector
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+clearsector:
+* ====================================
+* Used in non critical situation
+* ====================================
+* - A defensive wing will be deployed
+* - Other ships if any are ordered to clear sector
+* ====================================
+$fightinprogress = [TRUE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+= [THIS] -> call script anarkis.acc.apply.relations :  active ships only?=[TRUE]
+= [THIS] -> call script anarkis.acc.repairshields :
+if $defence.ships > 0
+= [THIS] -> call script anarkis.acc.wing.defence :  target=[THIS]  wing size=$defence.ships
+= wait 2000 ms
+end
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+counterattack:
+* ====================================
+* Used when the carrier is attacked by an incoming
+* ====================================
+* - A defensive wing will be deployed
+* - An offensive wing against the attacker will be deployed too
+* - Other ships if any are ordered to clear sector
+* ====================================
+skip if $attacker -> exists
+endsub
+$fightinprogress = [TRUE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+= [THIS] -> call script anarkis.acc.repairshields :
+= [THIS] -> call script anarkis.acc.apply.relations :  active ships only?=[TRUE]
+* A defensive wing will be deployed
+if $defence.ships > 0
+= [THIS] -> call script anarkis.acc.wing.defence :  target=[THIS]  wing size=$defence.ships
+= wait 2000 ms
+end
+* An offensive wing against the attacker will be deployed too
+$enemy.class = $attacker -> get object class
+$min.fighter = $null -> call script anarkis.lib.get.shipcount :  class=$enemy.class
+$dock.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$dock.count =  size of array $dock.list
+if $dock.count > $min.fighter
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$attacker  wing size=$min.fighter  wing ID='A'
+else
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$attacker  wing size=$dock.count  wing ID='A'
+end
+* Other ships if any are ordered to clear sector
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+
+return null
+

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.task.autocarrier.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.task.autocarrier.x3s
@@ -1,0 +1,371 @@
+#name: anarkis.acc.task.autocarrier
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.task.autocarrier.xml
+
+* ===========================================
+* Automated Carrier : Main Task
+* ===========================================
+
+$null = null
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+$fightinprogress = [FALSE]
+
+*if [THIS] == [PLAYERSHIP]
+*$st = sprintf: pageid=$page.id textid=105, [THIS], null, null, null, null
+*send incoming message $st to player: display it=[TRUE]
+*end
+
+while [TRUE]
+*while [THIS] != [PLAYERSHIP]
+
+* - Reload setup
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$var1 =  size of array $setup.array
+if not $var1 == 19
+$setup.array = [THIS] -> call script anarkis.ads.setup.createdefault :  ref.object=[THIS]
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup.array
+= [THIS] -> call script anarkis.acc.apply.active :
+end
+
+* - Start Repair task if needed
+skip if [THIS] -> is script anarkis.acc.task.repairs on stack of task=900
+[THIS] -> start task 900 with script anarkis.acc.task.repairs and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+
+$display.warning = $setup.array[4]
+$alert.level = $setup.array[0]
+$defence.ships = $setup.array[2]
+$attack.mode = $setup.array[6]
+$autorename = $gl.setup[3]
+$dock.delay = $setup.array[18]
+
+$curr.threat = $null -> call script anarkis.acc.evalute.danger :  sector=[SECTOR]  checker=[THIS]
+$shield = [THIS] -> get shield percent
+$attacker = [THIS] -> get attacker
+if $curr.threat > 3
+$strongest = $null -> call script anarkis.acc.evaluate.findstrong :  sector=[SECTOR]  checker=[THIS]
+end
+
+* - The carrier is attacked by an incoming
+if $attacker != null AND $shield <= 80 AND $fightinprogress == [FALSE]
+gosub alert
+gosub counterattack
+
+* - The threat level is reached
+else if $curr.threat >= $alert.level AND $fightinprogress == [FALSE]
+
+* - - ECS - -
+if [OWNER] == Player
+$my.name = [THIS] -> get name
+$st = sprintf: pageid=$page.id textid=1031, $my.name, [SECTOR], null, null, null
+$v1 = [THIS] -> get object class
+$var1 = sprintf: pageid=$page.id textid=1032, $my.name, $v1, [SECTOR], $curr.threat, null
+= [THIS] -> call script plugin.sk.ecs.news.add :  Plugin ID='anarkis.acc.plugin'  News Title=$st  News Content=$var1  from=[THIS]
+end
+* - - ECS End - -
+
+gosub alert
+gosub rename
+* - - Nearest First (usual command will work)
+if $attack.mode == 1
+gosub clearsector
+* - - Strongest First
+else if $attack.mode == 2
+gosub strongestfirst
+* - - Let ACC decide
+else
+gosub decide
+end
+
+* - Battle in progress, handle wings and deploy docked fighters
+else if $curr.threat > 0 AND $fightinprogress == [TRUE]
+gosub handlewings
+
+* - Threat eliminated, lets dock if no new enemies
+else if $curr.threat == 0 AND $fightinprogress == [TRUE]
+$pl.time = playing time
+$end.time = $pl.time + $dock.delay
+skip if not $dock.delay
+gosub protect.carrier
+while $pl.time < $end.time AND $curr.threat == 0
+= wait randomly from 1000 to 2000 ms
+$curr.threat = $null -> call script anarkis.acc.evalute.danger :  sector=[SECTOR]  checker=[THIS]
+$pl.time = playing time
+end
+if $curr.threat == 0
+$fightinprogress = [FALSE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=null
+= [THIS] -> call script anarkis.acc.cmd.alert.dock :
+gosub stoprename
+else
+gosub stop.protect
+end
+
+* - Not supposed to happen, but it happens :/ so we dock
+else if [THIS] -> call script anarkis.acc.lib.get.flyads :
+$fightinprogress = [FALSE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=null
+= [THIS] -> call script anarkis.acc.cmd.alert.dock :
+gosub stoprename
+end
+
+= wait 8000 ms
+end
+return null
+
+
+* ====================================
+* AutoRename v2
+* ====================================
+rename:
+if $autorename == [TRUE]
+if not [THIS] -> is script anarkis.acc.task.autoname.plus on stack of task=893
+= [THIS] -> call script anarkis.acc.lib.name.save :
+[THIS] -> start task 893 with script anarkis.acc.task.autoname.plus and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+end
+endsub
+* ====================================
+stoprename:
+if [THIS] -> is script anarkis.acc.task.autoname.plus on stack of task=893
+[THIS] -> start task 893 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+= [THIS] -> call script anarkis.acc.lib.name.load :
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Wings ordered to resume battle
+* ====================================
+stop.protect:
+$arr = [THIS] -> call script anarkis.acc.lib.get.leaderlist :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$leader = $arr[$cnt]
+START $leader -> call script !ship.cmd.killenemies.std :
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Wings ordered to protect carrier
+* ====================================
+protect.carrier:
+$arr = [THIS] -> call script anarkis.acc.lib.get.leaderlist :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$leader = $arr[$cnt]
+START $leader -> call script anarkis.acc.cmd.protect :  protect target=[THIS]
+end
+$arr = [THIS] -> call script anarkis.acc.lib.get.lonely :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$leader = $arr[$cnt]
+START $leader -> call script !ship.cmd.returnhome.std :
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Handle wings during battle
+* ====================================
+handlewings:
+if $attack.mode != 1
+$my.attacker = [THIS] -> get attacker
+$leader = [THIS] -> call script anarkis.acc.lib.get.leader.big :
+if $my.attacker -> is of class Big Ship
+if $leader
+$var1 = $leader -> get attack target
+skip if $var1 == $my.attacker
+START $leader -> call script anarkis.acc.cmd.attack.return :  victim=$my.attacker  dst=[THIS]
+end
+else
+$strongest = $null -> call script anarkis.acc.evaluate.findstrong :  sector=[SECTOR]  checker=[THIS]
+if $strongest AND $leader
+$var1 = $leader -> get attack target
+skip if $var1 == $strongest
+START $leader -> call script anarkis.acc.cmd.attack.return :  victim=$strongest  dst=[THIS]
+end
+end
+end
+= wait 100 ms
+= [THIS] -> call script anarkis.acc.lib.givetarget :
+= wait 100 ms
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+* ====================================
+* Display warning if needed
+* ====================================
+alert:
+skip if $display.warning == [TRUE]
+endsub
+$enemy.class = $strongest -> get object class
+$var1 = [THIS] -> call script anarkis.acc.get.all :  ship class=Moveable Ship  no damaged ships?=[TRUE]  active only?=[TRUE]
+$var1 =  size of array $var1
+if ( $var1 < $curr.threat AND $curr.threat > 40 ) OR ( $enemy.class == M2 ) OR ( $shield < 30 AND $attacker )
+$display.mode = $setup.array[5]
+if $display.mode == 1
+else if $display.mode == 1
+play sample [IncomingTransmission.SOS]
+$st = sprintf: pageid=$page.id textid=506, [THIS], [SECTOR], null, null, null
+display subtitle text: text=$st duration=15000 ms
+else if $display.mode == 2
+START $null -> call script anarkis.acc.audio.alert :  ship=[THIS]
+else if $display.mode == 3
+$st = sprintf: pageid=$page.id textid=500, [THIS], [SECTOR], null, null, null
+send incoming message $st to player: display it=[TRUE]
+end
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Will choose to attack the stronger if M6 or + found else will go for usual
+* ====================================
+decide:
+$enemy.class = $strongest -> get object class
+if $enemy.class == M1 OR $enemy.class == M2 OR $enemy.class == M7 OR $enemy.class == M6
+goto label advanced.mode
+*goto label strongestfirst
+else
+goto label clearsector
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Most efficient way
+* ====================================
+* - Each wing will be sent with a size according to the threat
+* ====================================
+advanced.mode:
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+$fightinprogress = [TRUE]
+$enemy.list = [THIS] -> call script anarkis.acc.lib.get.enemies :  sector=[SECTOR]  checker=[THIS]
+$enemy.count =  size of array $enemy.list
+$wing.id = 0
+while $enemy.count
+dec $enemy.count =
+$enemy.ship = $enemy.list[$enemy.count]
+$enemy.class = $enemy.ship -> get object class
+$min.fighter = [THIS] -> call script anarkis.lib.get.shipcount :  class=$enemy.class
+$dock.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$dock.count =  size of array $dock.list
+if $dock.count >= $min.fighter
+inc $wing.id =
+$wing.name = sprintf: fmt='A%s', $wing.id, null, null, null, null
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$enemy.ship  wing size=$min.fighter  wing ID=$wing.name
+end
+end
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+strongestfirst:
+* ====================================
+* Will attack the strongest enemy in range first
+* ====================================
+* - A defensive wing will be deployed
+* - An offensive wing against the strongest enemy will be deployed
+* - Other ships if any are ordered to clear sector
+* ====================================
+* No strong, fall back to clear sector
+skip if $strongest -> exists
+goto label clearsector
+$fightinprogress = [TRUE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+= [THIS] -> call script anarkis.acc.apply.relations :  active ships only?=[TRUE]
+* Repair Shields
+= [THIS] -> call script anarkis.acc.repairshields :
+* A defensive wing will be deployed
+if $defence.ships > 0
+= [THIS] -> call script anarkis.acc.wing.defence :  target=[THIS]  wing size=$defence.ships
+= wait 2000 ms
+end
+* An offensive wing against the strongest enemy will be deployed
+$enemy.class = $strongest -> get object class
+$min.fighter = [THIS] -> call script anarkis.lib.get.shipcount :  class=$enemy.class
+$dock.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$dock.count =  size of array $dock.list
+if $dock.count > $min.fighter
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$strongest  wing size=$min.fighter  wing ID='A'
+else
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$strongest  wing size=$dock.count  wing ID='A'
+end
+* Other ships if any are ordered to clear sector
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+clearsector:
+* ====================================
+* Used in non critical situation
+* ====================================
+* - A defensive wing will be deployed
+* - Other ships if any are ordered to clear sector
+* ====================================
+$fightinprogress = [TRUE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+= [THIS] -> call script anarkis.acc.apply.relations :  active ships only?=[TRUE]
+= [THIS] -> call script anarkis.acc.repairshields :
+if $defence.ships > 0
+= [THIS] -> call script anarkis.acc.wing.defence :  target=[THIS]  wing size=$defence.ships
+= wait 2000 ms
+end
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+counterattack:
+* ====================================
+* Used when the carrier is attacked by an incoming
+* ====================================
+* - A defensive wing will be deployed
+* - An offensive wing against the attacker will be deployed too
+* - Other ships if any are ordered to clear sector
+* ====================================
+skip if $attacker -> exists
+endsub
+$fightinprogress = [TRUE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+= [THIS] -> call script anarkis.acc.repairshields :
+= [THIS] -> call script anarkis.acc.apply.relations :  active ships only?=[TRUE]
+* A defensive wing will be deployed
+if $defence.ships > 0
+= [THIS] -> call script anarkis.acc.wing.defence :  target=[THIS]  wing size=$defence.ships
+= wait 2000 ms
+end
+* An offensive wing against the attacker will be deployed too
+$enemy.class = $attacker -> get object class
+$min.fighter = $null -> call script anarkis.lib.get.shipcount :  class=$enemy.class
+$dock.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$dock.count =  size of array $dock.list
+if $dock.count > $min.fighter
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$attacker  wing size=$min.fighter  wing ID='A'
+else
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$attacker  wing size=$dock.count  wing ID='A'
+end
+* Other ships if any are ordered to clear sector
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+
+return null
+

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.task.autoname.plus.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.task.autoname.plus.x3s
@@ -1,0 +1,97 @@
+#name: anarkis.acc.task.autoname.plus
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.task.autoname.plus.xml
+
+$page.id = 8510
+
+while [TRUE]
+$task = [THIS] -> is script anarkis.acc.task.autocarrier on stack of task=10
+skip if $task
+$task = [THIS] -> is script anarkis.acc.task.autocarrier on stack of task=11
+skip if $task
+$task = [THIS] -> is script anarkis.acc.task.autocarrier on stack of task=894
+
+if not $task
+= [THIS] -> call script anarkis.acc.lib.name.load :
+return null
+end
+
+$leader.list = [THIS] -> call script anarkis.acc.lib.get.leaderlist :
+$leader.count =  size of array $leader.list
+$wing.id = 0
+while $leader.count
+dec $leader.count =
+inc $wing.id =
+$leader = $leader.list[$leader.count]
+$wing = [THIS] -> call script anarkis.lib.wing.getall :  ship=$leader
+$wing.size =  size of array $wing
+while $wing.size
+dec $wing.size =
+$curr.ship = $wing[$wing.size]
+$ship.type = $curr.ship -> get ware type code of object
+* - - - Leader
+if $curr.ship -> has formation ships
+if $curr.ship -> is script !ship.cmd.protect.std on stack of task=0
+$main.id = 715
+$target = $curr.ship -> get command target
+else if $curr.ship -> is script anarkis.acc.cmd.protect on stack of task=0
+$main.id = 715
+$target = $curr.ship -> get command target
+else
+$main.id = 714
+$target = $curr.ship -> get attack target
+end
+if $target -> exists
+$target = $target -> get ware type code of object
+$target = sprintf: pageid=$page.id textid=$main.id, $target, null, null, null, null
+else
+$target =  read text: page=$page.id id=713
+end
+$formation =  read text: page=$page.id id=710
+$new.name = sprintf: pageid=$page.id textid=700, $wing.id, $formation, $target, null, null
+* - - - Follower
+else if $curr.ship -> is script !ship.cmd.attacksame.std on stack of task=0
+$target = $curr.ship -> get formation leader
+$target = $curr.ship -> get attack target
+if $target -> exists
+$target = $target -> get ware type code of object
+$target = sprintf: pageid=$page.id textid=714, $target, null, null, null, null
+else
+$target =  read text: page=$page.id id=712
+end
+$formation =  read text: page=$page.id id=711
+$new.name = sprintf: pageid=$page.id textid=700, $wing.id, $formation, $target, null, null
+* - - - Flee
+else if $curr.ship -> is script !move.movetostation on stack of task=0
+$main.id = 702
+$new.name = sprintf: pageid=$page.id textid=$main.id, $ship.type, null, null, null, null
+* - - - Others
+else
+$main.id = 703
+$new.name = sprintf: pageid=$page.id textid=$main.id, $ship.type, null, null, null, null
+end
+$curr.ship -> set name to $new.name
+end
+end
+= wait 1000 ms
+* - Ships without wing
+$leader.list = [THIS] -> call script anarkis.acc.lib.get.lonely :
+$leader.count =  size of array $leader.list
+while $leader.count
+dec $leader.count =
+$curr.ship = $leader.list[$leader.count]
+$ship.type = $curr.ship -> get ware type code of object
+if $curr.ship -> is script !move.movetostation on stack of task=0
+$main.id = 702
+$new.name = sprintf: pageid=$page.id textid=$main.id, $ship.type, null, null, null, null
+else
+$main.id = 703
+$new.name = sprintf: pageid=$page.id textid=$main.id, $ship.type, null, null, null, null
+end
+$curr.ship -> set name to $new.name
+end
+= wait 1000 ms
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.task.autoname.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.task.autoname.x3s
@@ -1,0 +1,31 @@
+#name: anarkis.acc.task.autoname
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.task.autoname.xml
+
+$page.id = 8510
+
+while [THIS] -> is task 0 in use
+
+if [ENVIRONMENT] == [HOMEBASE]
+$saved.name = [THIS] -> get local variable: name='anarkis.acc.oldname'
+[THIS] -> set name to $saved.name
+end
+
+= wait 1000 ms
+if not [HOMEBASE] -> exists
+$saved.name = [THIS] -> get local variable: name='anarkis.acc.oldname'
+if $saved.name
+[THIS] -> set name to $saved.name
+else
+$saved.name = [THIS] -> get ware type code of object
+[THIS] -> set name to $saved.name
+end
+[THIS] -> set local variable: name='anarkis.acc.oldname' value=null
+[THIS] -> set local variable: name='anarkis.acc.wing' value=null
+return null
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.task.hullcheck.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.task.hullcheck.x3s
@@ -1,0 +1,56 @@
+#name: anarkis.acc.task.hullcheck
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.task.hullcheck.xml
+
+while [ENVIRONMENT] == [HOMEBASE]
+= wait 4000 ms
+end
+
+$newleader = [THIS] -> get formation leader
+
+while [ENVIRONMENT] != [HOMEBASE]
+= wait 1000 ms
+
+skip if [HOMEBASE] -> exists
+return null
+*skip if [HOMEBASE] -> get local variable: name='anarkis.acc.battle'
+*return null
+
+$shield = [THIS] -> get shield percent
+$hull = [THIS] -> get hull percent
+
+if [THIS] -> is script !ship.cmd.retreat.std on stack of task=0
+$leader.ok = $newleader -> exists
+$lead.env = $newleader -> get environment
+if $shield > 80 AND $hull >= 100 AND $newleader != [THIS] AND $leader.ok == [TRUE] AND $lead.env != [HOMEBASE]
+[THIS] -> start task 0 with script !ship.cmd.attacksame.std and prio 0: arg1=$newleader arg2=[TRUE] arg3=null arg4=null arg5=null
+else
+if [THIS] -> get true amount of ware Transporter Device in cargo bay
+$v1 = get distance between [THIS] and [HOMEBASE]
+if $v1 < 5000
+[THIS] -> put into environment [HOMEBASE] ->
+[THIS] -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+[THIS] -> set command: COMMAND_NONE
+[THIS] -> set destination to null
+[THIS] -> set command target: null
+[THIS] -> set command target2: null
+end
+end
+end
+continue
+end
+
+if $hull < 100 OR $shield < 20
+if [THIS] -> has formation ships
+$newleader = [THIS] -> call script anarkis.lib.wing.changeleader :
+else
+$newleader = null
+end
+[THIS] -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=[HOMEBASE] arg2=null arg3=null arg4=null arg5=null
+end
+
+end
+
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.task.repairs.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.task.repairs.x3s
@@ -1,0 +1,99 @@
+#name: anarkis.acc.task.repairs
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.task.repairs.xml
+
+
+$owner = [OWNER]
+$timer.training = 0
+while [OWNER] == $owner
+
+= [THIS] -> call script anarkis.lib.wait :  wait time (in sec)=60  global to check=null
+inc $timer.training =
+if $timer.training >= 60
+$timer.training = 0
+$cost = [THIS] -> call script anarkis.ads.crew.getcost :  ref object=[THIS]
+$pl.money = get player money
+if $pl.money >= $cost
+$cost = 0 - $cost
+add money to player: $cost
+= [THIS] -> call script anarkis.ads.crew.train :  ref object=[THIS]
+else
+= [THIS] -> call script anarkis.ads.crew.sleep :  ref object=[THIS]
+end
+end
+
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$repair.setup = $setup.array[17]
+
+$mecha.count = $repair.setup[0]
+skip if $mecha.count > 0
+continue
+
+$allow.docked = $repair.setup[1]
+$allow.carrier = $repair.setup[2]
+
+$repair.ratio = [THIS] -> call script anarkis.ads.crew.getrepair :  ref object=[THIS]
+$repair.ratio = $mecha.count * 25 + $repair.ratio
+$onduty = [FALSE]
+
+if $allow.carrier == [TRUE]
+$c.hull = [THIS] -> get hull
+$m.hull = [THIS] -> get max hull
+$need = $m.hull - $c.hull
+if $need
+$onduty = [TRUE]
+$c.hull = $c.hull + $repair.ratio
+[THIS] -> set hull to $c.hull
+$repair.ratio = 0
+end
+end
+
+if $allow.docked == [TRUE]
+$ship.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $ship.list
+while $cnt AND $repair.ratio
+dec $cnt =
+$select = $ship.list[$cnt]
+$c.hull = $select -> get hull
+$m.hull = $select -> get max hull
+$need = $m.hull - $c.hull
+if $need > 0
+$onduty = [TRUE]
+if $need >= $repair.ratio
+$c.hull = $c.hull + $repair.ratio
+$repair.ratio = 0
+else
+$repair.ratio = $repair.ratio - $need
+$c.hull = $c.hull + $need
+end
+*$msg = sprintf: fmt='Repair : %s (%s)', $select, $need, null, null, null
+*display subtitle text: text=$msg duration=2000 ms
+if $c.hull > $m.hull
+$select -> set hull to $m.hull
+else
+$select -> set hull to $c.hull
+end
+end
+end
+end
+
+if [OWNER] == Player
+if $onduty == [TRUE]
+$cost = $mecha.count * 5000 / 60
+else
+$cost = $mecha.count * 1000 / 60
+end
+$money = get player money
+if $cost > $money
+$repair.setup[0] = 0
+else
+$cost = 0 - $cost
+add money to player: $cost
+end
+end
+
+end
+
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.uninstall.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.uninstall.x3s
@@ -1,0 +1,59 @@
+#name: anarkis.acc.uninstall
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.uninstall.xml
+
+$page.id = 8510
+set global variable: name='anarkis.ads.grid.mode' value=null
+$array = [THIS] -> call script anarkis.acc.get.acc.carriers :  active only?=[FALSE]
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$curr.ship = $array[$cnt]
+$repairs = null
+if $curr.ship -> is script anarkis.acc.task.repairs on stack of task=900
+$curr.ship -> start task 900 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+$task.id = null
+if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=10
+$task.id = 10
+else if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=11
+$task.id = 11
+else if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=894
+$task.id = 894
+else if $curr.ship -> is script anarkis.acc.task.autocarrier.npc on stack of task=894
+$task.id = 894
+end
+if $task.id
+$curr.ship -> start task $task.id with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+end
+$array =  get station array: of race Player class/type=Dock
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$curr.ship = $array[$cnt]
+$curr.ship -> start task 900 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$task.id = null
+if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=10
+$task.id = 10
+else if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=11
+$task.id = 11
+else if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=894
+$task.id = 894
+else if $curr.ship -> is script anarkis.acc.task.autocarrier.npc on stack of task=894
+$task.id = 894
+end
+if $task.id
+$curr.ship -> start task $task.id with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+end
+
+
+= [THIS] -> call script anarkis.acc.ecs.remove :
+= [THIS] -> call script anarkis.acc.hotkey.uninstall :
+set global variable: name='anarkis.acc.plugin' value=null
+
+$msg =  read text: page=$page.id id=106
+send incoming message $msg to player: display it=[TRUE]
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.upgrade.disable.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.upgrade.disable.x3s
@@ -1,0 +1,36 @@
+#name: anarkis.acc.upgrade.disable
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.upgrade.disable.xml
+
+$array = [THIS] -> call script anarkis.acc.get.acc.carriers :  active only?=[FALSE]
+$cnt =  size of array $array
+
+while $cnt
+
+dec $cnt =
+$curr.ship = $array[$cnt]
+
+$repairs = null
+if $curr.ship -> is script anarkis.acc.task.repairs on stack of task=900
+$repairs = [TRUE]
+$curr.ship -> start task 900 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+
+$task.id = null
+if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=10
+$task.id = 10
+else if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=11
+$task.id = 11
+end
+if $task.id
+$curr.ship -> start task $task.id with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+
+$curr.ship -> set local variable: name='anarkis.acc.task' value=$task.id
+$curr.ship -> set local variable: name='anarkis.acc.repair' value=$repairs
+
+end
+
+set global variable: name='anarkis.ads.grid.mode' value=null
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.upgrade.enable.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.upgrade.enable.x3s
@@ -1,0 +1,29 @@
+#name: anarkis.acc.upgrade.enable
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.upgrade.enable.xml
+
+
+$array = [THIS] -> call script anarkis.acc.get.acc.carriers :  active only?=[FALSE]
+$cnt =  size of array $array
+
+while $cnt
+
+dec $cnt =
+$curr.ship = $array[$cnt]
+
+$repairs = $curr.ship -> get local variable: name='anarkis.acc.repair'
+if $repairs
+$curr.ship -> start task 900 with script anarkis.acc.task.repairs and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$curr.ship -> set local variable: name='anarkis.acc.repair' value=null
+end
+
+$task.id = $curr.ship -> get local variable: name='anarkis.acc.task'
+if $task.id
+$curr.ship -> start task $task.id with script anarkis.acc.task.autocarrier and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$curr.ship -> set local variable: name='anarkis.acc.task' value=null
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.wing.attack.pl.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.wing.attack.pl.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.acc.wing.attack.pl
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.wing.attack.pl.xml
+
+* ===========================================
+* Wing : Send a wing to attack a given target
+* ===========================================
+[THIS] -> set command: ANARKIS_ATTACKWING  target=$target target2=$wing.size par1=null par2=null
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$target  wing size=$wing.size  wing ID='A'
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.wing.attack.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.wing.attack.x3s
@@ -1,0 +1,77 @@
+#name: anarkis.acc.wing.attack
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.wing.attack.xml
+
+* ===========================================
+* Wing : Send a wing to attack a given target
+* ===========================================
+
+skip if $target -> exists
+return null
+if  is datatyp[ $wing.size ] == DATATYP_ARRAY
+$v1 =  size of array $wing.size
+dec $v1 =
+$wing.array =  clone array $wing.size : index 0 ... $v1
+$wing.size =  size of array $wing.array
+
+else
+$wing.array = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$cnt =  size of array $wing.array
+while $cnt
+dec $cnt =
+$v1 = $wing.array[$cnt]
+skip if not $v1 -> is of class Freighter
+remove element from array $wing.array at index $cnt
+end
+$cnt =  size of array $wing.array
+
+if $cnt > $wing.size
+resize array $wing.array to $wing.size
+end
+$wing.size =  size of array $wing.array
+end
+
+$setup = [THIS] -> get local variable: name='anarkis.acc.setup'
+$callback = $setup[3]
+$autorename = $setup[15]
+
+$leader = $wing.array[0]
+skip if $leader -> exists
+return null
+= [THIS] -> call script anarkis.acc.repairshields.single :  ship=$leader
+
+if $target -> is of class Big Ship
+$leader -> set command target: Big Ship
+else
+$leader -> set command target: null
+end
+START $leader -> call script anarkis.acc.cmd.attack.return :  victim=$target  dst=[THIS]
+$leader -> set local variable: name='anarkis.acc.wing' value=$name
+if $callback == [TRUE]
+$leader -> start task 900 with script anarkis.acc.task.hullcheck and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+*if $autorename == [TRUE]
+*$leader -> start task 893 with script anarkis.acc.task.autoname and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+*end
+remove element from array $wing.array at index 0
+
+
+= wait randomly from 500 to 1000 ms
+
+$cnt =  size of array $wing.array
+while $cnt
+dec $cnt =
+$wingmate = $wing.array[$cnt]
+$wingmate -> set local variable: name='anarkis.acc.wing' value=$name
+= [THIS] -> call script anarkis.acc.repairshields.single :  ship=$wingmate
+START $wingmate -> call script !ship.cmd.attacksame.std :  the target=$leader  stop if leader is docked=[TRUE]
+if $callback == [TRUE]
+$wingmate -> start task 900 with script anarkis.acc.task.hullcheck and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+*if $autorename == [TRUE]
+*$wingmate -> start task 893 with script anarkis.acc.task.autoname and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+*end
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.wing.clearsector.pl.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.wing.clearsector.pl.x3s
@@ -1,0 +1,13 @@
+#name: anarkis.acc.wing.clearsector.pl
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.wing.clearsector.pl.xml
+
+* ===========================================
+* Wing : Send all ships in wings
+* ===========================================
+* Ships will be dispatched in 5 ship wings
+[THIS] -> set command: ANARKIS_CLEANSECTOR  target=null target2=null par1=null par2=null
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.wing.clearsector.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.wing.clearsector.x3s
@@ -1,0 +1,63 @@
+#name: anarkis.acc.wing.clearsector
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.wing.clearsector.xml
+
+* ===========================================
+* Wing : Send all ships in wings
+* ===========================================
+* Ships will be dispatched in 5 ship wings
+
+$wing.array = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$cnt =  size of array $wing.array
+while $cnt
+dec $cnt =
+$leader = $wing.array[$cnt]
+skip if not $leader -> is of class Freighter
+remove element from array $wing.array at index $cnt
+end
+$cnt =  size of array $wing.array
+
+= [THIS] -> call script anarkis.acc.apply.relations :  active ships only?=[TRUE]
+$maincount =  size of array $wing.array
+$setup = [THIS] -> get local variable: name='anarkis.acc.setup'
+$callback = $setup[3]
+$autorename = $setup[15]
+$wing.id = 0
+
+while $maincount
+$leader = $wing.array[0]
+skip if $leader -> exists
+return null
+= [THIS] -> call script anarkis.acc.repairshields.single :  ship=$leader
+inc $wing.id =
+START $leader -> call script !ship.cmd.killenemies.std :
+$leader -> set local variable: name='anarkis.acc.wing' value=$wing.id
+if $callback == [TRUE]
+$leader -> start task 900 with script anarkis.acc.task.hullcheck and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+*if $autorename == [TRUE]
+*$leader -> start task 893 with script anarkis.acc.task.autoname and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+*end
+remove element from array $wing.array at index 0
+$cnt = 4
+$size =  size of array $wing.array
+while $cnt > 0 AND $size > 0
+dec $cnt =
+$wingmate = $wing.array[0]
+= [THIS] -> call script anarkis.acc.repairshields.single :  ship=$wingmate
+START $wingmate -> call script !ship.cmd.attacksame.std :  the target=$leader  stop if leader is docked=[FALSE]
+$wingmate -> set local variable: name='anarkis.acc.wing' value=$wing.id
+if $callback == [TRUE]
+$wingmate -> start task 900 with script anarkis.acc.task.hullcheck and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+*if $autorename == [TRUE]
+*$wingmate -> start task 893 with script anarkis.acc.task.autoname and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+*end
+remove element from array $wing.array at index 0
+$size =  size of array $wing.array
+end
+$maincount =  size of array $wing.array
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.wing.defence.pl.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.wing.defence.pl.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.acc.wing.defence.pl
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.wing.defence.pl.xml
+
+* ===========================================
+* Wing : Send a wing to protect a target
+* ===========================================
+[THIS] -> set command: ANARKIS_DEFENSIVEWING  target=$target target2=$wing.size par1=null par2=null
+= [THIS] -> call script anarkis.acc.wing.defence :  target=$target  wing size=$wing.size
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.wing.defence.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.acc.wing.defence.x3s
@@ -1,0 +1,76 @@
+#name: anarkis.acc.wing.defence
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.wing.defence.xml
+
+* ===========================================
+* Wing : Send a wing to protect a target
+* ===========================================
+
+skip if $target -> exists
+return null
+
+if  is datatyp[ $wing.size ] == DATATYP_ARRAY
+$cnt =  size of array $wing.size
+dec $cnt =
+$wing.array =  clone array $wing.size : index 0 ... $cnt
+$wing.size =  size of array $wing.array
+else
+$wing.array = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$cnt =  size of array $wing.array
+while $cnt
+dec $cnt =
+$v1 = $wing.array[$cnt]
+skip if not $v1 -> is of class Freighter
+remove element from array $wing.array at index $cnt
+end
+$cnt =  size of array $wing.array
+
+if $cnt > $wing.size
+resize array $wing.array to $wing.size
+end
+$wing.size =  size of array $wing.array
+end
+
+$leader = $wing.array[0]
+skip if $leader -> exists
+return null
+
+$setup = [THIS] -> get local variable: name='anarkis.acc.setup'
+$callback = $setup[3]
+$autorename = $setup[15]
+
+= [THIS] -> call script anarkis.acc.repairshields.single :  ship=$leader
+if $target -> is of class Moveable Ship
+START $leader -> call script anarkis.acc.cmd.protect :  protect target=$target
+*START $leader -> call script !ship.cmd.attacksame.std :  the target=$target  stop if leader is docked=[TRUE]
+else
+START $leader -> call script anarkis.acc.cmd.protect :  protect target=$target
+*START $leader -> call script !ship.cmd.protect.std :  target=$target  stop if leader docked=[TRUE]
+end
+$leader -> set local variable: name='anarkis.acc.wing' value='D'
+remove element from array $wing.array at index 0
+*if $autorename == [TRUE]
+*$leader -> start task 893 with script anarkis.acc.task.autoname and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+*end
+if $callback == [TRUE]
+$leader -> start task 900 with script anarkis.acc.task.hullcheck and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+= wait randomly from 1000 to 5000 ms
+
+$cnt =  size of array $wing.array
+while $cnt
+dec $cnt =
+$wingmate = $wing.array[$cnt]
+= [THIS] -> call script anarkis.acc.repairshields.single :  ship=$wingmate
+START $wingmate -> call script !ship.cmd.attacksame.std :  the target=$leader  stop if leader is docked=[TRUE]
+$wingmate -> set local variable: name='anarkis.acc.wing' value='D'
+*if $autorename == [TRUE]
+*$wingmate -> start task 893 with script anarkis.acc.task.autoname and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+*end
+if $callback == [TRUE]
+$wingmate -> start task 900 with script anarkis.acc.task.hullcheck and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.al.init.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.al.init.x3s
@@ -1,0 +1,34 @@
+#name: anarkis.ads.al.init
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.al.init.xml
+
+* ===========================================
+* A.D.S. - Init Script, ECS Registration if available, show menu
+* ===========================================
+
+
+
+if get global variable: name='plugin.ecs.setup'
+= [THIS] -> call script anarkis.acc.ecs.register :
+end
+
+if  is datatyp[ $ecs.setup ] == DATATYP_ARRAY
+$ecs.setup[3] = [TRUE]
+else
+$ecs.setup =  array alloc: size=6
+$ecs.installed =  array alloc: size=0
+$ecs.configs =  array alloc: size=0
+$ecs.news =  array alloc: size=0
+$ecs.guilds =  array alloc: size=0
+$ecs.setup[0] = 250
+$ecs.setup[1] = $ecs.installed
+$ecs.setup[2] = $ecs.configs
+$ecs.setup[3] = [TRUE]
+$ecs.setup[4] = null
+$ecs.setup[5] = $ecs.news
+$ecs.setup[6] = $ecs.guilds
+end
+set global variable: name='plugin.ecs.setup' value=$ecs.setup
+= [THIS] -> call script plugin.sk.ecs.hotkey.install :
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.al.register.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.al.register.x3s
@@ -1,0 +1,48 @@
+#name: anarkis.ads.al.register
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.al.register.xml
+
+$text.id = '8510'
+
+$plugin.Vars = get global variable: name=$plugin.ID
+
+* setup new data structure and init it
+if not $plugin.Vars
+$plugin.Vars =  array alloc: size=2
+set global variable: name=$plugin.ID value=$plugin.Vars
+$plugin.Vars[0] = 0
+$plugin.Vars[1] = [TRUE]
+end
+
+* init and reinit are run every time the game loads
+if $plugin.Event == 'init' OR $plugin.Event == 'reinit'
+$desc = sprintf: pageid=$text.id textid=100, null, null, null, null, null
+al engine: set plugin $plugin.ID description to $desc
+$interval = 30 * 60
+al engine: set plugin $plugin.ID timer interval to $interval s
+skip if get global variable: name='plugin.ecs.setup'
+= [THIS] -> call script plugin.sk.ecs.al.init :
+
+else if $plugin.Event == 'isenabled'
+$desc = sprintf: pageid=$text.id textid=100, null, null, null, null, null
+al engine: set plugin $plugin.ID description to $desc
+$enabled = $plugin.Vars[1]
+return $enabled
+
+* Use this area to process special instructions when the plugin is toggled on
+else if $plugin.Event == 'start'
+$plugin.Vars[1] = [TRUE]
+= [THIS] -> call script plugin.sk.ecs.al.init :
+= [THIS] -> call script plugin.sk.ecs.manager :
+* Use this area to process special instructions when the plugin is toggled off
+else if $plugin.Event == 'stop'
+$plugin.Vars[1] = [FALSE]
+= [THIS] -> call script plugin.sk.ecs.al.stop :
+
+* The event script is called every interval
+else if $plugin.Event == 'timer'
+$enabled = $plugin.Vars[1]
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.al.stop.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.al.stop.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.ads.al.stop
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.al.stop.xml
+
+$ads.setup = get global variable: name='anarkis.ads.setup'
+$ads.setup[3] = [FALSE]
+set global variable: name='anarkis.ads.setup' value=$ads.setup
+
+START [THIS] -> call script plugin.sk.ecs.manager :
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.cmd.protectgrid.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.cmd.protectgrid.x3s
@@ -1,0 +1,106 @@
+#name: anarkis.ads.cmd.protectgrid
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.cmd.protectgrid.xml
+
+* ===========================================
+* CMD : Defense Grid - Interrupt Cmd : Protect Sector
+* ===========================================
+* - Should work for both AI and player owned ships
+* - Jump beacon support
+* ===========================================
+
+skip if $tg.sector -> exists
+return null
+
+$previous.sector = [SECTOR]
+[THIS] -> set local variable: name='anarkis.ads.grid.busy' value=[TRUE]
+= [THIS] -> call script anarkis.lib.shipstate.save :  ship=[THIS]
+
+$string = sprintf: fmt='(ADS) %s Jump to protect %s', [THIS], $tg.sector, null, null, null
+= [THIS] -> call script anarkis.debug.output :  msg=$string
+
+* =====
+* Energy Handling
+$energy.needed = [THIS] -> needed jump drive energy for jump to sector $tg.sector
+$v1 = [THIS] -> get amount of ware Energy Cells in cargo bay
+$energy.needed = $energy.needed - $v1
+$free.space = [THIS] -> get free amount of ware Energy Cells in cargo bay
+if $free.space < $energy.needed
+$string = sprintf: fmt='(ADS) Grid - %s can't jump to %s : Not enough cargo space for fuel', [THIS], $tg.sector, null, null, null
+= [THIS] -> call script anarkis.debug.output :  msg=$string
+[THIS] -> set local variable: name='anarkis.ads.grid.busy' value=null
+return [FALSE]
+end
+* Player has to pay, not the AI. Pay the double price. for going and wayback.
+* All expenses are here to prevent ships from behind stuck where they shouldn't be
+if [OWNER] == Player
+$pl.money = get player money
+$price = get average price of ware Energy Cells
+$price = $price * 4 * $energy.needed
+* - Check for funds
+if $price > $pl.money
+$string = sprintf: fmt='(ADS) Grid - %s can't jump to %s : Not enough money', [THIS], $tg.sector, null, null, null
+= [THIS] -> call script anarkis.debug.output :  msg=$string
+[THIS] -> set local variable: name='anarkis.ads.grid.busy' value=null
+return [FALSE]
+end
+$price = 0 - $price
+add money to player: $price
+end
+= [THIS] -> add $energy.needed units of Energy Cells
+* =====
+
+$string = sprintf: fmt='(ADS) %s jump to protect %s', [THIS], $tg.sector, null, null, null
+= [THIS] -> call script anarkis.debug.output :  msg=$string
+
+
+$attacker.owner = $attacker -> get true owner
+skip if $attacker.owner
+$attacker.owner = $attacker -> get owner race
+
+$previous.relation = [THIS] -> get relation to race $attacker.owner
+[THIS] -> set relation against $attacker.owner to Foe
+
+* =====
+* Do the jump
+if [SECTOR] != $tg.sector
+$beacon =  find ship: sector=$tg.sector class or type=Jump Beacon race=[OWNER] flags=[Find.Random] refobj=null maxdist=null maxnum=1 refpos=null
+if $beacon
+= [THIS] -> call script anarkis.lib.cmd.jumptobeacon :  jump.beacon=$beacon
+else
+$gate =  find gate: flags=[Find.Nearest], refobj=$attacker, max dist=null, refpos=null
+*$gate =  get next gate on route from $tg.sector to [SECTOR]
+= [THIS] -> call script !ship.cmd.jump.std :  target gate or sector=$gate  followers should jump too=[TRUE]
+end
+end
+* =====
+
+
+* =====
+* Battling Part - room for improvement
+if $attacker -> exists
+= [THIS] -> call script !ship.cmd.attack.std :  the victim=$attacker  do not follow in new sector=[TRUE]
+end
+$my.pos = [THIS] -> get position as array
+= [THIS] -> call script anarkis.lib.cmd.killandland.timeout :  object to land on=null  the range=100000  refpos array   x y z=$my.pos  no idle, simply stand still=null  timeout=360
+
+while [THIS] -> get local variable: name='anarkis.acc.battle'
+= [THIS] -> call script !move.idle.timeout :  timeout in sec=30  wait while docked=[FALSE]
+end
+* =====
+
+* =====
+* Restore previous settings and go back to original sector
+[THIS] -> set relation against $attacker.owner to $previous.relation
+$energy.needed = [THIS] -> needed jump drive energy for jump to sector $previous.sector
+= [THIS] -> add $energy.needed units of Energy Cells
+
+skip if [SECTOR] == $previous.sector
+= [THIS] -> call script !move.jumptosector :  sector=$previous.sector  should followers jump too=[TRUE]
+
+[THIS] -> set local variable: name='anarkis.ads.grid.busy' value=null
+= [THIS] -> call script anarkis.lib.shipstate.restore :  ship=[THIS]
+* =====
+
+return [TRUE]

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.comm.barracks.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.comm.barracks.x3s
@@ -1,0 +1,96 @@
+#name: anarkis.ads.comm.barracks
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.comm.barracks.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+
+$sel.role =  array alloc: size=0
+$st = sprintf: pageid=$page.id textid=1076, null, null, null, null, null
+append $st to array $sel.role
+$st = sprintf: pageid=$page.id textid=1077, null, null, null, null, null
+append $st to array $sel.role
+$st = sprintf: pageid=$page.id textid=1078, null, null, null, null, null
+append $st to array $sel.role
+$sel.role.id = 'role'
+$sel.role.select = 0
+
+while $menu.result != -1
+= wait 10 ms
+$menu =  create custom menu array
+$st = sprintf: pageid=$page.id textid=1004, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=1106, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='save'
+$st = sprintf: pageid=$page.id textid=1107, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$array = $ship -> get marines array
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$v1 = $select -> get name
+$v2 = $select -> get marine overall skill
+$v3 = $select -> get marine buy price
+$v1 = [THIS] -> call script anarkis.lib.shortstring :  string=$v1  max=20
+$v3 =  convert number $v3 to string
+$st = sprintf: pageid=$page.id textid=1080, $v1, $v2, $v3, null, null
+$sel.role.select = $select -> get local variable: name='anarkis.ads.marine'
+add value selection to menu: $menu, text=$st, value array=$sel.role, default=$sel.role.select, return id=$select
+$v1 = $select -> get marine fighting skill
+$v2 = $select -> get marine mechanical skill
+$v3 = $select -> get marine hacking skill
+$v4 = $select -> get marine engineering skill
+$st = sprintf: pageid=$page.id textid=1079, $v1, $v2, $v3, $v4, null
+add custom menu item to array $menu: text=$st returnvalue=0
+end
+
+$array = $ship -> get marines array
+$v2 = $ship -> free space for marines
+$cnt =  size of array $array
+$v2 = $v2 + $cnt
+$v1 = sprintf: pageid=$page.id textid=1109, $cnt, $v2, null, null, null
+add custom menu info line to array $menu: text=$v1
+$v1 = 0
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+skip if not $select -> get local variable: name='anarkis.ads.marine'
+inc $v1 =
+end
+$st = sprintf: pageid=$page.id textid=1108, $v1, null, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 = [THIS] -> call script anarkis.ads.crew.getcost :  ref object=$ship
+$v1 =  convert number $v1 to string
+$v1 = sprintf: pageid=$page.id textid=1105, $v1, null, null, null, null
+add custom menu info line to array $menu: text=$v1
+
+$v1 = sprintf: pageid=$page.id textid=1088, $v1, null, null, null, null
+add custom menu info line to array $menu: text=$v1
+
+$v1 =  read text: page=$page.id id=1075
+
+$v2 = sprintf: pageid=$page.id textid=455, $ship, null, null, null, null
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+if  is datatyp[ $menu.result ] == DATATYP_ARRAY
+$cnt =  size of array $menu.result
+while $cnt
+dec $cnt =
+$r.id = $menu.result[$cnt][0]
+$r.val = $menu.result[$cnt][1]
+if $r.id -> exists
+$r.id -> set local variable: name='anarkis.ads.marine' value=$r.val
+end
+end
+end
+if $menu.result -> exists
+
+$menu.result -> set local variable: name='anarkis.ads.marine' value=[TRUE]
+end
+
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.comm.hangars.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.comm.hangars.x3s
@@ -1,0 +1,147 @@
+#name: anarkis.ads.comm.hangars
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.comm.hangars.xml
+
+$page.id = 8510
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+load text: id=$page.id
+
+
+
+while $menu.result != -1
+
+
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=1101
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=424
+add custom menu item to array $menu: text=$st returnvalue='set.home.all'
+$st =  read text: page=$page.id id=434
+add custom menu item to array $menu: text=$st returnvalue='set.name'
+$st =  read text: page=$page.id id=217
+add custom menu item to array $menu: text=$st returnvalue='setup'
+
+$st = sprintf: pageid=$page.id textid=425, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=426
+add custom menu item to array $menu: text=$st returnvalue='add.all'
+$st =  read text: page=$page.id id=427
+add custom menu item to array $menu: text=$st returnvalue='add.m3m4'
+$st =  read text: page=$page.id id=428
+add custom menu item to array $menu: text=$st returnvalue='add.m3'
+$st =  read text: page=$page.id id=429
+add custom menu item to array $menu: text=$st returnvalue='rem.all'
+
+$st = sprintf: pageid=$page.id textid=422, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$class = $curr.ship -> get object class
+$enabled = $curr.ship -> get local variable: name='anarkis.acc.ship'
+if $enabled == [TRUE]
+$v1 =  read text: page=$page.id id=431
+else
+$v1 =  read text: page=$page.id id=432
+end
+$st = sprintf: pageid=$page.id textid=430, $class, $curr.ship, $v1, null, null
+add custom menu item to array $menu: text=$st returnvalue=$curr.ship
+end
+
+$st = sprintf: pageid=$page.id textid=421, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 =  read text: page=$page.id id=420
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'add.all'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=[TRUE]
+$name = $curr.ship -> get name
+$curr.ship -> set local variable: name='anarkis.acc.oldname' value=$name
+if [OWNER] == Player
+$curr.ship -> set homebase to [THIS]
+end
+end
+
+else if $menu.result == 'rem.all'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=null
+end
+
+else if $menu.result == 'add.m3m4'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$v1 = $curr.ship -> get object class
+if $v1 == M3 OR $v1 == M4
+$name = $curr.ship -> get name
+$curr.ship -> set local variable: name='anarkis.acc.oldname' value=$name
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=[TRUE]
+$curr.ship -> set homebase to [THIS]
+end
+end
+
+else if $menu.result == 'add.m3'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$v1 = $curr.ship -> get object class
+if $v1 == M3
+$name = $curr.ship -> get name
+$curr.ship -> set local variable: name='anarkis.acc.oldname' value=$name
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=[TRUE]
+$curr.ship -> set homebase to [THIS]
+end
+end
+
+else if $menu.result == 'setup'
+= [THIS] -> call script anarkis.acc.setup.ships :
+
+else if $menu.result == 'set.home.all'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$curr.ship -> set homebase to [THIS]
+end
+
+else if $menu.result == 'set.name'
+= [THIS] -> call script anarkis.acc.setup.rename :
+
+else if $menu.result -> exists
+$enabled = $menu.result -> get local variable: name='anarkis.acc.ship'
+$enabled = ! $enabled
+$menu.result -> set local variable: name='anarkis.acc.ship' value=$enabled
+if $enabled == [TRUE]
+$name = $menu.result -> get name
+$menu.result -> set local variable: name='anarkis.acc.oldname' value=$name
+$menu.result -> set homebase to [THIS]
+end
+end
+
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.comm.manage.call.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.comm.manage.call.x3s
@@ -1,0 +1,280 @@
+#name: anarkis.ads.comm.manage.call
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.comm.manage.call.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+$cmd.id = 2010
+
+*load text: id=$page.id
+
+$m.filter = Carrier
+$m.selected = null
+$m.menumode = 'list'
+$m.showcmd = [FALSE]
+$m.showgridship = [FALSE]
+$m.viewowned = [FALSE]
+
+$is.open = get global variable: name='anarkis.ads.manager.open'
+skip if not $is.open
+return null
+set global variable: name='anarkis.ads.manager.open' value=[TRUE]
+
+
+$aim =  get player tracking aim
+if $aim -> exists
+$owner = $aim -> get owner race
+$isbig = $aim -> is of class Big Ship
+$isstation = $aim -> is of class Station
+$compat = [THIS] -> call script anarkis.acc.is.compatible :  target=$aim
+if $owner == Player
+
+if $isbig == [TRUE] OR $isstation == [TRUE] OR $compat == [TRUE]
+$m.selected = $aim
+end
+if $compat == [TRUE]
+$m.filter = Carrier
+else if $isbig == [TRUE]
+$m.menumode = 'defense.grid'
+end
+if $isstation == [TRUE]
+$m.filter = Station
+end
+
+end
+end
+
+
+$menu =  create custom menu array
+$select =  array alloc: size=0
+append $m.filter to array $select
+append $m.selected to array $select
+append $m.menumode to array $select
+append $m.showcmd to array $select
+append $m.showgridship to array $select
+append $m.viewowned to array $select
+set global variable: name='anarkis.ads.menu' value=$select
+
+START $null -> call script anarkis.ads.comm.manage.menu :  menu=$menu
+
+while $menu.result != -1
+
+if $m.selected -> exists
+$v1 = $m.selected -> get name
+$v1 = [THIS] -> call script anarkis.lib.shortstring :  string=$v1  max=25
+$v2 = $m.selected -> get sector
+$v2 = sprintf: pageid=$page.id textid=1012, $v2, $v1, null, null, null
+else
+$v2 =  read text: page=$page.id id=100
+end
+$v1 =  read text: page=$page.id id=1040
+= wait 100 ms
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+if  is datatyp[ $menu.result ] == DATATYP_OBJCLASS
+$m.filter = $menu.result
+$select[0] = $menu.result
+$select[1] = null
+$select[2] = 'list'
+$m.menumode = 'list'
+$m.selected = null
+else if  is datatyp[ $menu.result ] == DATATYP_STRING
+
+* - - Setup Carrier
+if $menu.result == 'setup.object'
+$m.selected -> start task 892 with script anarkis.acc.setup and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+while $m.selected -> is task 892 in use
+= wait 200 ms
+end
+
+else if $menu.result == 'gen.set'
+= [THIS] -> call script anarkis.ads.setup.global :
+
+* - - Defense Grid Mode
+else if $menu.result == 'defense.grid'
+$select[0] = null
+$select[1] = null
+$select[2] = 'grid.sector'
+$m.menumode = 'grid.sector'
+$m.selected = null
+
+* - - Defense Grid Toggle
+else if $menu.result == 'toggle.grid'
+$m.selected = $select[1]
+if $m.selected -> get local variable: name='anarkis.ads.grid'
+$m.selected -> set local variable: name='anarkis.ads.grid' value=null
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+else
+$m.selected -> set local variable: name='anarkis.ads.grid' value=[TRUE]
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+end
+
+* - - Defense Grid Ship Manager
+else if $menu.result == 'grid.ship' OR $menu.result == 'grid.sector'
+$select[1] = null
+$m.showgridship = $select[4]
+$m.showgridship = ! $m.showgridship
+$select[4] = $m.showgridship
+$m.selected = null
+
+else if $menu.result == 'grid.toggle'
+if get global variable: name='anarkis.ads.grid.mode'
+set global variable: name='anarkis.ads.grid.mode' value=null
+= wait 1000 ms
+else
+set global variable: name='anarkis.ads.grid.mode' value=[TRUE]
+START $null -> call script anarkis.ads.task.maingrid :  race=Player
+end
+
+* - - Toggle ADS
+else if $menu.result == 'toggle.ads'
+if [THIS] -> call script anarkis.acc.lib.isadsactive :  target=$m.selected
+= [THIS] -> call script anarkis.ads.toggle.task :  target=$m.selected  activate=[FALSE]
+else
+= [THIS] -> call script anarkis.ads.toggle.task :  target=$m.selected  activate=[TRUE]
+end
+
+* - - Jump to Playership
+else if $menu.result == 'jumptome'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script anarkis.lib.cmd.jumpnearobject :  destination=[PLAYERSHIP]
+
+* - - Jump to Sector
+else if $menu.result == 'jumpto'
+$v1 =  read text: page=$page.id id=1026
+$v1 = $m.selected -> get user input: type=Var/Jumpdrive Gate, title=$v1
+if $v1 -> exists
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script !ship.cmd.jump.std :  target gate or sector=$v1  followers should jump too=[TRUE]
+end
+
+* - - Attack
+else if $menu.result == 'attack'
+$v1 =  read text: page=$page.id id=1027
+$v1 = $m.selected -> get user input: type=Var/Ship/Station, title=$v1
+if $v1 -> exists
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script anarkis.lib.cmd.attack :  the victim=$v1
+end
+
+* - - Dock Command
+else if $menu.result == 'dockto'
+$v1 =  read text: page=$page.id id=1026
+$v1 = $m.selected -> get user input: type=Var/Station/Carrier to dock at, title=$v1
+if $v1 -> exists
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script !ship.cmd.movestation.std :  object to land on=$v1
+end
+
+* - - Attack All
+else if $menu.result == 'attackall'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script !ship.cmd.killenemies.std :
+
+* - - Protect
+else if $menu.result == 'protect'
+$v1 = $m.selected -> get user input: type=Var/Ship/Station, title=$v1
+if $v1 -> exists
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script anarkis.acc.cmd.protect :  protect target=$v1
+end
+
+* - - Standby
+else if $menu.result == 'standby'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script !ship.cmd.stay.std :
+
+* - - Patrol
+else if $menu.result == 'patrol'
+$v1 = $m.selected -> call script !ship.cmd.patrol.multi.pl :
+$v3 = $m.selected -> get local variable: name='patrol.route'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script !ship.cmd.patrol.multi.std :  Patrol Route Array=$v3
+
+* - - Dock All
+else if $menu.result == 'dockall'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script anarkis.acc.cmd.dock.all.pl :
+
+* - - Clear Sector
+else if $menu.result == 'clearsector'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script anarkis.acc.wing.clearsector.pl :
+
+* - - Attack Wing
+else if $menu.result == 'wingattack'
+$v1 =  read text: page=$page.id id=1027
+$v1 = $m.selected -> get user input: type=Var/Ship/Station, title=$v1
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+= $m.selected -> call script anarkis.ads.wing.attack.pl :  target=$v1
+
+* - - Defend Wing
+else if $menu.result == 'wingdefend'
+$v1 =  read text: page=$page.id id=1027
+$v1 = $m.selected -> get user input: type=Var/Ship/Station, title=$v1
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+= $m.selected -> call script anarkis.ads.wing.defense.pl :  target=$v1
+
+* - - Buy Wares
+else if $menu.result == 'buywares'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+= $m.selected -> call script anarkis.acc.cmd.buywares.pl :
+
+* - - Sell Wares
+else if $menu.result == 'sellwares'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+= $m.selected -> call script anarkis.acc.cmd.sellwares.pl :
+
+* - - Show ECS News
+else if $menu.result == 'alert'
+= [THIS] -> call script plugin.sk.ecs.news.display :  Plugin ID='anarkis.acc.plugin'
+
+* - - Toggle CMD Panel
+else if $menu.result == 'cmdoff'
+$select[3] = [FALSE]
+
+else if $menu.result == 'cmdon'
+$select[3] = [TRUE]
+
+* - - Toggle View Ship List
+else if $menu.result == 'viewships'
+$v1 = $select[5]
+$v1 = ! $v1
+$select[5] = $v1
+
+* - - Run un-installer
+else if $menu.result == 'uninstall'
+= [THIS] -> call script anarkis.acc.uninstall :
+$m.menumode = 'quit'
+$select[2] = 'quit'
+set global variable: name='anarkis.ads.manager.open' value=null
+
+return null
+
+* - - Show on cursor
+else if $menu.result == 'cursor'
+set player tracking aim to $m.selected ->
+$select[2] = 'quit'
+set global variable: name='anarkis.ads.manager.open' value=null
+return null
+end
+
+else if $menu.result == -1
+if $m.selected != null
+$select[1] = null
+$select[5] = [FALSE]
+$m.selected = null
+$menu.result = 0
+end
+else if $menu.result -> exists
+$select[1] = $menu.result
+$m.selected = $menu.result
+end
+
+end
+$select[2] = 'quit'
+set global variable: name='anarkis.ads.manager.open' value=null
+
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.comm.manage.menu.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.comm.manage.menu.x3s
@@ -1,0 +1,407 @@
+#name: anarkis.ads.comm.manage.menu
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.comm.manage.menu.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+
+$cmd.id = 2010
+$m.menumode = 'none'
+
+* While order /= quit
+while $m.menumode != 'quit'
+$select = get global variable: name='anarkis.ads.menu'
+
+$m.filter = $select[0]
+$m.selected = $select[1]
+$m.menumode = $select[2]
+$m.showcmd = $select[3]
+$m.viewgridship = $select[4]
+$m.viewowned = $select[5]
+
+*$debug = sprintf: fmt='%s - %s - %s - %s - %s', $m.filter, $m.selected, $m.menumode, $m.showcmd, $m.viewgridship
+*= [THIS] -> call script anarkis.debug.output :  msg=$debug
+
+resize array $menu to 0
+
+* - If something is selected
+if $m.selected -> exists
+* - - If viewship over something select
+* - - Well, let's show owned ships then
+if $m.viewowned == [TRUE]
+$list = $m.selected -> get owned ships: class/type=Ship
+$cnt =  size of array $list
+$st = sprintf: pageid=$page.id textid=1042, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$ok = [FALSE]
+while $cnt
+dec $cnt =
+$v1 = $list[$cnt]
+skip if not $v1 -> is docked
+continue
+$v2 = $v1 -> get ware type code of object
+$v3 = $v1 -> get command
+$v3 = [THIS] -> call script anarkis.lib.shortcmd :  command=$v3
+$v4 = $v1 -> get hull percent
+$v5 = $v1 -> get shield percent
+$ok = [TRUE]
+if $m.selected -> get attacker
+$st = sprintf: pageid=$page.id textid=1123, $v2, $v3, $v4, $v5, null
+else
+$st = sprintf: pageid=$page.id textid=1041, $v2, $v3, $v4, $v5, null
+end
+add custom menu item to array $menu: text=$st returnvalue=$v1
+end
+if not $ok
+$cnt =  size of array $menu
+dec $cnt =
+resize array $menu to $cnt
+end
+$ok = [FALSE]
+$cnt =  size of array $list
+$st = sprintf: pageid=$page.id textid=1043, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+while $cnt
+dec $cnt =
+$v1 = $list[$cnt]
+skip if $v1 -> is docked
+continue
+$v2 = $v1 -> get ware type code of object
+$v3 = $v1 -> get command
+$v3 = [THIS] -> call script anarkis.lib.shortcmd :  command=$v3
+$v4 = $v1 -> get hull percent
+$v5 = $v1 -> get shield percent
+$ok = [TRUE]
+$st = sprintf: pageid=$page.id textid=1041, $v2, $v3, $v4, $v5, null
+add custom menu item to array $menu: text=$st returnvalue=$v1
+end
+if not $ok
+$cnt =  size of array $menu
+dec $cnt =
+resize array $menu to $cnt
+end
+end
+* - - End Display : Owned Ships
+
+$st = sprintf: pageid=$page.id textid=1001, $m.selected, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$v1 = [PLAYERSHIP] -> get sector
+$v2 = $m.selected -> get sector
+if $v1 == $v2
+$st = sprintf: pageid=$page.id textid=1030, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='cursor'
+end
+
+* - - If the fucking selection is a ship display the comand panel
+if $m.selected -> is of class Moveable Ship
+if $m.showcmd == [FALSE]
+$st = sprintf: pageid=$page.id textid=1034, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='cmdon'
+else
+$st = sprintf: pageid=$page.id textid=1038, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='cmdoff'
+if $v1 != $v2
+$st = sprintf: pageid=$page.id textid=1023, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='jumptome'
+end
+$st = sprintf: pageid=$page.id textid=1024, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='jumpto'
+$st = sprintf: pageid=$page.id textid=1033, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='dockto'
+$st = sprintf: pageid=$page.id textid=1025, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='attack'
+$st = sprintf: pageid=$page.id textid=1036, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='protect'
+$st = sprintf: pageid=$page.id textid=1029, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='attackall'
+$st = sprintf: pageid=$page.id textid=1028, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='patrol'
+$st = sprintf: pageid=$page.id textid=1037, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='standby'
+$isadscompat = [THIS] -> call script anarkis.acc.is.compatible :  target=$m.selected
+$isadsactive = [THIS] -> call script anarkis.acc.lib.isadsactive :  target=$m.selected
+if $isadscompat == [TRUE] AND $isadsactive == [FALSE]
+$st = sprintf: pageid=$cmd.id textid=834, null, null, null, null, null
+$st = sprintf: pageid=$page.id textid=1039, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='wingattack'
+$st = sprintf: pageid=$cmd.id textid=833, null, null, null, null, null
+$st = sprintf: pageid=$page.id textid=1039, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='wingdefend'
+$st = sprintf: pageid=$cmd.id textid=835, null, null, null, null, null
+$st = sprintf: pageid=$page.id textid=1039, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='clearsector'
+$st = sprintf: pageid=$cmd.id textid=836, null, null, null, null, null
+$st = sprintf: pageid=$page.id textid=1039, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='dockall'
+$st = sprintf: pageid=$cmd.id textid=832, null, null, null, null, null
+$st = sprintf: pageid=$page.id textid=1039, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='buywares'
+$st = sprintf: pageid=$cmd.id textid=831, null, null, null, null, null
+$st = sprintf: pageid=$page.id textid=1039, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='sellwares'
+end
+end
+end
+* - - End
+
+* - - ACC Commands for Stations
+if $m.selected -> is of class Station
+$isadscompat = [THIS] -> call script anarkis.acc.is.compatible :  target=$m.selected
+$isadsactive = [THIS] -> call script anarkis.acc.lib.isadsactive :  target=$m.selected
+if $isadscompat == [TRUE] AND $isadsactive == [FALSE]
+$st = sprintf: pageid=$cmd.id textid=834, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='wingattack'
+
+$st = sprintf: pageid=$cmd.id textid=833, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='wingdefend'
+
+$st = sprintf: pageid=$cmd.id textid=835, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='clearsector'
+
+$st = sprintf: pageid=$cmd.id textid=836, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='dockall'
+$st = sprintf: pageid=$cmd.id textid=832, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='buywares'
+$st = sprintf: pageid=$cmd.id textid=831, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='sellwares'
+
+end
+end
+
+if [THIS] -> call script anarkis.acc.lib.isadsactive :  target=$m.selected
+$v1 = sprintf: pageid=$page.id textid=201, null, null, null, null, null
+else
+$v1 = sprintf: pageid=$page.id textid=202, null, null, null, null, null
+end
+* - - End
+
+* - - If the selected object has docking bays, show menu
+if $m.selected -> get dock bay size
+$st = sprintf: pageid=$page.id textid=1035, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='viewships'
+end
+* - - End
+
+* - - If the selected object is ADS compatible show setup and automode
+if [THIS] -> call script anarkis.acc.is.compatible :  target=$m.selected
+$st = sprintf: pageid=$page.id textid=1018, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='toggle.ads'
+$v2 = $m.selected -> get object class
+$st = sprintf: pageid=$page.id textid=1019, $v2, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='setup.object'
+end
+* - - End
+
+* - - Show the Grid Mode toggle for big ships
+if $m.selected -> is of class Big Ship
+if $m.selected -> get local variable: name='anarkis.ads.grid'
+$st =  read text: page=$page.id id=820
+else
+$st =  read text: page=$page.id id=821
+end
+$st = sprintf: pageid=$page.id textid=1059, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='toggle.grid'
+end
+* - - End
+end
+* - Ship Menu Done
+
+* - Show the main menu
+if $m.selected == null AND $m.menumode != 'grid.sector'
+if $m.filter == null
+$v1 =  read text: page=$page.id id=1044
+else
+$v1 = $m.filter
+end
+$st = sprintf: pageid=$page.id textid=1001, $v1, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=1003
+add custom menu item to array $menu: text=$st returnvalue=Carrier
+$st =  read text: page=$page.id id=1002
+add custom menu item to array $menu: text=$st returnvalue=Station
+$st =  read text: page=$page.id id=1044
+add custom menu item to array $menu: text=$st returnvalue='defense.grid'
+end
+* - End
+
+* - Defense Grid : Main Menu
+if $m.menumode == 'grid.sector'
+$st =  read text: page=$page.id id=1049
+add custom menu heading to array $menu: title=$st
+
+if $m.viewgridship == [TRUE]
+$st =  read text: page=$page.id id=820
+else
+$st =  read text: page=$page.id id=204
+end
+$st = sprintf: pageid=$page.id textid=1047, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='grid.ship'
+end
+
+* - Defense Grid : Ship List
+if $m.viewgridship == [TRUE]
+$st =  read text: page=$page.id id=1118
+add custom menu heading to array $menu: title=$st
+$v1 =  get ship array: of race Player class/type=Big Ship
+$v2 =  size of array $v1
+while $v2
+dec $v2 =
+$v3 = $v1[$v2]
+if $v3 -> get local variable: name='anarkis.ads.grid'
+$st = [THIS] -> call script anarkis.ads.lib.shiptostring :  target=$v3
+add custom menu item to array $menu: text=$st returnvalue=$v3
+end
+end
+$st =  read text: page=$page.id id=1119
+add custom menu heading to array $menu: title=$st
+$v1 =  get ship array: of race Player class/type=Big Ship
+$v2 =  size of array $v1
+while $v2
+dec $v2 =
+$v3 = $v1[$v2]
+if not $v3 -> get local variable: name='anarkis.ads.grid'
+$st = [THIS] -> call script anarkis.ads.lib.shiptostring :  target=$v3
+add custom menu item to array $menu: text=$st returnvalue=$v3
+end
+end
+
+end
+
+* - Defense Grid : Sector List
+if $m.menumode == 'grid.sector'
+$st =  read text: page=$page.id id=1050
+add custom menu heading to array $menu: title=$st
+$v1 = [THIS] -> call script anarkis.ads.lib.get.plsectors :
+$v2 =  size of array $v1
+while $v2
+dec $v2 =
+$v3 = $v1[$v2]
+$v4 = $v3 -> get player owned station array from sector
+$v4 =  size of array $v4
+$v5 = [THIS] -> call script anarkis.ads.lib.get.sectorthreat :  sector=$v3  race=Player
+$x = $v3 -> get universe x index
+$y = $v3 -> get universe y index
+$st = sprintf: pageid=$page.id textid=1051, $x, $y, $v3, $v4, $v5
+add custom menu item to array $menu: text=$st returnvalue=0
+end
+end
+
+* - Handle Carrier and Station Lists
+if $m.menumode == 'list'
+$st = sprintf: pageid=$page.id textid=1017, $m.filter, null, null, null, null
+add custom menu heading to array $menu: title=$st
+if $m.filter == Carrier
+$list = [THIS] -> call script anarkis.acc.get.acc.carriers :  active only?=[FALSE]
+else
+$list =  get station array: of race Player class/type=Dock
+end
+$cnt =  size of array $list
+while $cnt
+dec $cnt =
+$select = $list[$cnt]
+$st = [THIS] -> call script anarkis.ads.lib.shiptostring :  target=$select
+add custom menu item to array $menu: text=$st returnvalue=$select
+end
+
+end
+
+* - If nothing selected
+if $m.selected == null
+$st =  read text: page=$page.id id=1004
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=1006, $m.filter, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='alert'
+
+$st =  read text: page=$page.id id=1089
+add custom menu item to array $menu: text=$st returnvalue='gen.set'
+
+
+if get global variable: name='anarkis.ads.grid.mode'
+$st =  read text: page=$page.id id=201
+else
+$st =  read text: page=$page.id id=202
+end
+
+
+$st = sprintf: pageid=$page.id textid=1058, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='grid.toggle'
+
+if $m.filter != null
+$st = sprintf: pageid=$page.id textid=1008, $m.filter, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='applyall'
+end
+$st = sprintf: pageid=$page.id textid=1007, $m.filter, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='uninstall'
+
+end
+
+* - Info Lines
+if $m.selected != null
+$v1 = $m.selected -> get hull percent
+$v2 = $m.selected -> get shield percent
+$st = sprintf: pageid=$page.id textid=1013, $v1, $v2, null, null, null
+add custom menu info line to array $menu: text=$st
+if $m.selected -> is of class Moveable Ship
+$v1 = $m.selected -> get command
+$v1 = [THIS] -> call script anarkis.lib.shortcmd :  command=$v1
+$v2 = $m.selected -> get command target
+skip if $v2 -> exists
+$v2 = $m.selected -> get destination
+if $v2 -> exists
+$v2 = $v2 -> get name
+else
+$v2 = ' '
+end
+*$v2 = [THIS] -> call script anarkis.lib.shortstring :  string=$v2  max=18
+$st = sprintf: pageid=$page.id textid=1014, $v1, $v2, null, null, null
+add custom menu info line to array $menu: text=$st
+end
+
+$v1 = $m.selected -> get sector
+$v1 = [THIS] -> call script anarkis.acc.evalute.danger :  sector=$v1  checker=$m.selected
+
+if $m.selected -> get attacker
+$v2 =  read text: page=$page.id id=203
+else
+$v2 =  read text: page=$page.id id=204
+end
+
+if $m.selected -> get local variable: name='anarkis.acc.battle'
+$v3 =  read text: page=$page.id id=203
+else
+$v3 =  read text: page=$page.id id=204
+end
+
+$st = sprintf: pageid=$page.id textid=1015, $v1, $v2, $v3, null, null
+add custom menu info line to array $menu: text=$st
+$v1 = $m.selected -> get owned ships: class/type=Ship
+$v1 =  size of array $v1
+$v2 = $m.selected -> get number of landed ships
+$v3 = [THIS] -> call script anarkis.acc.lib.get.adsonly.from :  from=$m.selected
+$v3 =  size of array $v3
+$st = sprintf: pageid=$page.id textid=1016, $v1, $v2, $v3, null, null
+add custom menu info line to array $menu: text=$st
+
+else
+$st =  read text: page=$page.id id=1010
+add custom menu info line to array $menu: text=$st
+$st =  read text: page=$page.id id=1011
+add custom menu info line to array $menu: text=$st
+end
+
+if $m.selected
+$v1 = $m.selected -> get name
+$v1 = [THIS] -> call script anarkis.lib.shortstring :  string=$v1  max=25
+$v2 = $m.selected -> get sector
+$v2 = sprintf: pageid=$page.id textid=1012, $v2, $v1, null, null, null
+else
+$v2 =  read text: page=$page.id id=100
+end
+$v1 =  read text: page=$page.id id=1000
+
+= wait 100 ms
+end
+
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.comm.wingmenu.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.comm.wingmenu.x3s
@@ -1,0 +1,152 @@
+#name: anarkis.ads.comm.wingmenu
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.comm.wingmenu.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+
+load text: id=$page.id
+
+[THIS] -> set local variable: name='anarkis.menu.result' value=null
+
+$sel.role =  array alloc: size=0
+$sel.active =  read text: page=$page.id id=1069
+$sel.active = sprintf: pageid=$page.id textid=1066, $sel.active, null, null, null, null
+append $sel.active to array $sel.role
+$sel.active =  read text: page=$page.id id=1068
+$sel.active = sprintf: pageid=$page.id textid=1071, $sel.active, null, null, null, null
+append $sel.active to array $sel.role
+
+$sel.mode =  array alloc: size=0
+$sel.active = sprintf: pageid=$page.id textid=1073, null, null, null, null, null
+append $sel.active to array $sel.mode
+$sel.active = sprintf: pageid=$page.id textid=1072, null, null, null, null, null
+append $sel.active to array $sel.mode
+$sel.mode.id = 'mode'
+$sel.mode.select = 0
+
+$v1 = [THIS] -> call script anarkis.lib.get.dockedowned :  ship class=Moveable Ship  local to check=null
+$cnt =  size of array $v1
+$sel.cnt =  array alloc: size=0
+$x = 0
+while $x < $cnt
+inc $x =
+append $x to array $sel.cnt
+end
+$sel.count.id = 'count'
+if  find $defaultcount in array: $sel.cnt
+$sel.count.select =  get index of $defaultcount in array $sel.cnt offset=-1 + 1
+else
+$sel.count.select = $cnt - 1
+end
+
+$ship.count = $defaultcount
+$ship.list =  array alloc: size=0
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=1061
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=1062
+add custom menu item to array $menu: text=$st returnvalue='launch'
+$st = sprintf: pageid=$page.id textid=1063, $target, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='change.tg'
+
+$st =  read text: page=$page.id id=803
+add value selection to menu: $menu, text=$st, value array=$sel.mode, default=$sel.mode.select, return id=$sel.mode.id
+$st =  read text: page=$page.id id=1064
+add value selection to menu: $menu, text=$st, value array=$sel.cnt, default=$sel.count.select, return id=$sel.count.id
+
+$st = sprintf: pageid=$page.id textid=1065, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$array = [THIS] -> call script anarkis.lib.get.dockedowned :  ship class=Moveable Ship  local to check=null
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$sel.class = $select -> get object class
+$sel.hull = $select -> get hull percent
+if $sel.hull == 100
+$sel.hull = sprintf: pageid=$page.id textid=1070, $sel.hull, null, null, null, null
+$sel.hull = sprintf: pageid=$page.id textid=1066, $sel.hull, null, null, null, null
+else if $sel.hull > 87
+$sel.hull = sprintf: pageid=$page.id textid=1070, $sel.hull, null, null, null, null
+$sel.hull = sprintf: pageid=$page.id textid=1067, $sel.hull, null, null, null, null
+else
+$sel.hull = sprintf: pageid=$page.id textid=1070, $sel.hull, null, null, null, null
+$sel.hull = sprintf: pageid=$page.id textid=1068, $sel.hull, null, null, null, null
+end
+$v1 =  size of array $ship.list
+if  find $select in array: $ship.list
+$sel.role.select = 0
+else
+$sel.role.select = 1
+end
+
+$sel.name = $select -> get name
+$sel.name = [THIS] -> call script anarkis.lib.shortstring :  string=$sel.name  max=30
+$st = sprintf: pageid=$page.id textid=1060, $sel.class, $sel.hull, $sel.name, $sel.active, null
+add value selection to menu: $menu, text=$st, value array=$sel.role, default=$sel.role.select, return id=$select
+end
+
+
+$v1 =  read text: page=$page.id id=420
+$v2 =  read text: page=$page.id id=260
+
+$menu.result =  open custom menu: title=$title description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if  is datatyp[ $menu.result ] == DATATYP_ARRAY
+$cnt =  size of array $menu.result
+* ==
+while $cnt
+dec $cnt =
+$r.id = $menu.result[$cnt][0]
+$r.val = $menu.result[$cnt][1]
+if $r.id == $sel.mode.id
+$sel.mode.select = $r.val
+else if $r.id == $sel.count.id
+$sel.count.select = $r.val
+else if $r.id -> is of class Moveable Ship
+if $r.val == 0
+skip if  find $r.id in array: $ship.list
+append $r.id to array $ship.list
+else
+if  find $r.id in array: $ship.list
+$v1 =  get index of $r.id in array $ship.list offset=-1 + 1
+remove element from array $ship.list at index $v1
+end
+end
+end
+end
+
+* ==
+$r.id = $menu.result[0]
+if $r.id == 'change.tg'
+$v1 =  read text: page=$page.id id=1027
+$v1 = [THIS] -> get user input: type=Var/Ship/Station, title=$v1
+if $v1 -> exists
+$target = $v1
+end
+else if $r.id == 'launch'
+if $sel.mode.select == 0
+$ship.list =  array alloc: size=0
+end
+$ship.count = $sel.cnt[$sel.count.select]
+$result =  create new array, arguments=$target, $ship.count, $ship.list, null, null
+[THIS] -> set local variable: name='anarkis.menu.result' value=$result
+return [TRUE]
+
+end
+end
+end
+
+
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.crew.getcost.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.crew.getcost.x3s
@@ -1,0 +1,19 @@
+#name: anarkis.ads.crew.getcost
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.crew.getcost.xml
+
+$array = $ref.object -> get marines array
+$cnt =  size of array $array
+$price = 0
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$status = $select -> get local variable: name='anarkis.ads.marine'
+if $status == 1
+$price = $price + 16000
+else if $status == 2
+$price = $price + 24000
+end
+end
+return $price

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.crew.getrepair.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.crew.getrepair.x3s
@@ -1,0 +1,27 @@
+#name: anarkis.ads.crew.getrepair
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.crew.getrepair.xml
+
+$array = $ref.object -> get marines array
+$cnt =  size of array $array
+$result = 0
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$type = $select -> get local variable: name='anarkis.ads.marine'
+* - s
+if $type
+$mech = $select -> get marine mechanical skill
+if $mech > 50
+$result = $result + $mech - 50
+end
+$mech = $select -> get marine engineering skill
+if $mech > 50
+$result = $result + $mech - 50
+end
+end
+* - s
+
+end
+return $result

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.crew.sleep.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.crew.sleep.x3s
@@ -1,0 +1,14 @@
+#name: anarkis.ads.crew.sleep
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.crew.sleep.xml
+
+$array = $ref.object -> get marines array
+$cnt =  size of array $array
+$price = 0
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$select -> set local variable: name='anarkis.ads.marine' value=0
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.crew.train.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.crew.train.x3s
@@ -1,0 +1,53 @@
+#name: anarkis.ads.crew.train
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.crew.train.xml
+
+$array = $ref.object -> get marines array
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$type = $select -> get local variable: name='anarkis.ads.marine'
+* - s
+if $type == 1
+
+$add =  = random value from 0 to 8 - 1
+$mech = $select -> get marine mechanical skill
+$add = $mech + $add + 4
+if $add > 100
+$add = 100
+end
+$select -> set marine skill: mechanical=$add
+
+$add =  = random value from 0 to 8 - 1
+$mech = $select -> get marine hacking skill
+$add = $mech + $add + 4
+if $add > 100
+$add = 100
+end
+$select -> set marine skill: hacking=$add
+
+$add =  = random value from 0 to 8 - 1
+$mech = $select -> get marine engineering skill
+$add = $mech + $add + 4
+if $add > 100
+$add = 100
+end
+$select -> set marine skill: engineering=$add
+
+else if $type == 2
+$add =  = random value from 0 to 7 - 1
+$mech = $select -> get marine fighting skill
+$add = $mech + $add + 4
+if $add > 100
+$add = 100
+$select -> set local variable: name='anarkis.ads.marine' value=0
+end
+$mech -> set marine skill: fighting=$add
+
+end
+* - s
+
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.lib.enemy.strongest.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.lib.enemy.strongest.x3s
@@ -1,0 +1,32 @@
+#name: anarkis.ads.lib.enemy.strongest
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.lib.enemy.strongest.xml
+
+$refobject =  find station: sector=$sector class or type=Station race=$race flags=[Find.Random] refobj=null maxdist=null maxnum=1 refpos=null
+skip if $refobject -> exists
+$refobject =  find ship: sector=$sector class or type=Ship race=$race flags=[Find.Random] refobj=null maxdist=null maxnum=1 refpos=null
+skip if $refobject -> exists
+return null
+
+
+$flags = [Find.Enemy] | [Find.Multiple]
+$max.threat = 0
+$result.ship = null
+$ship.list =  find ship: sector=$sector class or type=Moveable Ship race=null flags=$flags refobj=$refobject maxdist=null maxnum=50 refpos=null
+$ship.count =  size of array $ship.list
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+skip if $ship -> is $refobject a enemy
+continue
+skip if not $ship -> is civilian ship
+continue
+$threat = [THIS] -> call script anarkis.ads.lib.get.shipthreat :  ship/class=$ship
+if $threat > $max.threat
+$max.threat = $threat
+$result.ship = $ship
+end
+end
+
+return $result.ship

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.lib.get.gridships.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.lib.get.gridships.x3s
@@ -1,0 +1,37 @@
+#name: anarkis.ads.lib.get.gridships
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.lib.get.gridships.xml
+
+$arr =  get ship array: of race $race class/type=Big Ship
+$cnt =  size of array $arr
+
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+if $select == [PLAYERSHIP]
+remove element from array $arr at index $cnt
+continue
+end
+if not $select -> get local variable: name='anarkis.ads.grid'
+remove element from array $arr at index $cnt
+continue
+end
+$grid.state = $select -> get local variable: name='anarkis.ads.grid.busy'
+if $grid.state == [TRUE] AND $avail == [TRUE]
+remove element from array $arr at index $cnt
+continue
+end
+
+
+if $sector.base -> exists
+$select.sector = $select -> get sector
+$distance = get jumps from sector $select.sector to sector $sector.base
+if $distance > $sector.dist
+remove element from array $arr at index $cnt
+continue
+end
+end
+end
+
+return $arr

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.lib.get.plsectors.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.lib.get.plsectors.x3s
@@ -1,0 +1,23 @@
+#name: anarkis.ads.lib.get.plsectors
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.lib.get.plsectors.xml
+
+* ===========================================
+* Retrieve an array of sectors 'owned' by the player
+* ===========================================
+
+$station.array =  get station array: of race Player class/type=Station
+$station.count =  size of array $station.array
+$sector.array =  array alloc: size=0
+
+while $station.count
+dec $station.count =
+$station = $station.array[$station.count]
+$station.sector = $station -> get sector
+$sector.already =  find $station.sector in array: $sector.array
+skip if $sector.already == [TRUE]
+append $station.sector to array $sector.array
+end
+
+return $sector.array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.lib.get.racesectors.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.lib.get.racesectors.x3s
@@ -1,0 +1,32 @@
+#name: anarkis.ads.lib.get.racesectors
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.lib.get.racesectors.xml
+
+* ===========================================
+* Retrieve an array of sectors 'owned' by a race
+* ===========================================
+
+if $race == Player
+
+$station.array =  get station array: of race $race class/type=Station
+
+$station.count =  size of array $station.array
+$sector.array =  array alloc: size=0
+
+while $station.count
+dec $station.count =
+$station = $station.array[$station.count]
+$station.sector = $station -> get sector
+$sector.already =  find $station.sector in array: $sector.array
+skip if $sector.already == [TRUE]
+append $station.sector to array $sector.array
+end
+
+else
+
+$sector.array = [THIS] -> call script anarkis.lib.get.racesectors :  race=$race
+
+end
+
+return $sector.array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.lib.get.sectorthreat.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.lib.get.sectorthreat.x3s
@@ -1,0 +1,47 @@
+#name: anarkis.ads.lib.get.sectorthreat
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.lib.get.sectorthreat.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$ignore.list = $gl.setup[7]
+
+
+if $race == Player
+$flags = [Find.Enemy] | [Find.Multiple]
+$ship.list =  find ship: sector=$sector class or type=Ship race=null flags=$flags refobj=[PLAYERSHIP] maxdist=null maxnum=50 refpos=null
+else
+$ship.list = $sector -> get ship array from sector/ship/station
+end
+$ship.count =  size of array $ship.list
+
+$threat.level = 0
+
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$class = $ship -> get object class
+$owner = $ship -> get owner race
+if $owner == Neutral Race OR $owner == Unknown
+remove element from array $ship.list at index $ship.count
+continue
+end
+$rel = $ship -> get relation to race $race
+if  find $owner in array: $ignore.list
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $rel != Foe
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $ship -> is civilian ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+$ship.threat = [THIS] -> call script anarkis.ads.lib.get.shipthreat :  ship/class=$ship
+$threat.level = $threat.level + $ship.threat
+end
+
+return $threat.level

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.lib.get.shipthreat.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.lib.get.shipthreat.x3s
@@ -1,0 +1,35 @@
+#name: anarkis.ads.lib.get.shipthreat
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.lib.get.shipthreat.xml
+
+skip if  is datatyp[ $class ] == DATATYP_OBJCLASS
+$class = $class -> get object class
+
+if $class == M5
+$threat.level = 1
+else if $class == M4
+$threat.level = 2
+else if $class == M3
+$threat.level = 5
+else if $class == M6
+$threat.level = 14
+else if $class == M7
+$threat.level = 35
+else if $class == M8
+$threat.level = 10
+else if $class == M2
+$threat.level = 50
+else if $class == M1
+$threat.level = 30
+else if $class == TL
+$threat.level = 15
+else if $class == TM
+$threat.level = 2
+else if $class == TP OR $class == TS
+$threat.level = 1
+else
+$threat.level = 0
+end
+
+return $threat.level

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.lib.shiptostring.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.lib.shiptostring.x3s
@@ -1,0 +1,59 @@
+#name: anarkis.ads.lib.shiptostring
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.lib.shiptostring.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+
+$isadscompat = [THIS] -> call script anarkis.acc.is.compatible :  target=$ship
+$isadsactive = [THIS] -> call script anarkis.acc.lib.isadsactive :  target=$ship
+
+$class = $ship -> get object class
+$sector = $ship -> get sector
+$sector.x = $sector -> get universe x index
+$sector.y = $sector -> get universe y index
+skip if not $sector.x < 10
+$sector.x = sprintf: fmt='0%s', $sector.x, null, null, null, null
+skip if not $sector.y < 10
+$sector.y = sprintf: fmt='0%s', $sector.y, null, null, null, null
+$ship.name = $ship -> get name
+if $ship -> is of class Station
+$class = Dock
+end
+
+if not $ship -> get local variable: name='anarkis.ads.grid'
+$beginning = sprintf: pageid=$page.id textid=1122, $sector.x, $sector.y, $sector, $ship.name, null
+else
+if $ship -> get local variable: name='anarkis.ads.grid.busy'
+$beginning = sprintf: pageid=$page.id textid=1121, $sector.x, $sector.y, $sector, $ship.name, null
+else
+$beginning = sprintf: pageid=$page.id textid=1114, $sector.x, $sector.y, $sector, $ship.name, null
+end
+end
+
+
+
+
+if $isadscompat
+if $isadsactive
+$beginning = [THIS] -> call script anarkis.lib.shortstring :  string=$beginning  max=63
+$count = [THIS] -> call script anarkis.acc.lib.get.adsonly.from :  from=$ship
+$count =  size of array $count
+if $ship -> get local variable: name='anarkis.acc.battle'
+$end = sprintf: pageid=$page.id textid=1120, $beginning, $class, $count, null, null
+else
+$end = sprintf: pageid=$page.id textid=1115, $beginning, $class, $count, null, null
+end
+else
+$beginning = [THIS] -> call script anarkis.lib.shortstring :  string=$beginning  max=60
+$count = $ship -> get owned ships: class/type=Moveable Ship
+$count =  size of array $count
+$end = sprintf: pageid=$page.id textid=1116, $beginning, $class, $count, null, null
+end
+else
+$beginning = [THIS] -> call script anarkis.lib.shortstring :  string=$beginning  max=75
+$end = sprintf: pageid=$page.id textid=1117, $beginning, $class, $count, null, null
+end
+
+return $end

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.settings.default.app.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.settings.default.app.x3s
@@ -1,0 +1,10 @@
+#name: anarkis.ads.settings.default.app
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.settings.default.app.xml
+
+$setup = [THIS] -> call script anarkis.ads.settings.default.get :
+
+$tg -> set local variable: name='anarkis.acc.setup' value=$setup
+
+return $setup

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.settings.default.get.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.settings.default.get.x3s
@@ -1,0 +1,11 @@
+#name: anarkis.ads.settings.default.get
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.settings.default.get.xml
+
+
+$setup = get global variable: name='anarkis.ads.default'
+skip if $setup
+$setup = [THIS] -> call script anarkis.ads.settings.default.ini :
+
+return $setup

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.settings.default.ini.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.settings.default.ini.x3s
@@ -1,0 +1,60 @@
+#name: anarkis.ads.settings.default.ini
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.settings.default.ini.xml
+
+$setup =  array alloc: size=0
+
+* 0 threat level
+append 15 to array $setup
+* 1 Radar Range
+append 20000 to array $setup
+* 2 Defense Ship count
+append 5 to array $setup
+* 3 Damaged ships retreat
+append [TRUE] to array $setup
+* 4 Display warning
+append [TRUE] to array $setup
+* 5 warning type (0 subtitle, 1 audio, 2 text)
+append 2 to array $setup
+* 6 attack mode (3 auto, 1 nearest first, 2 strongest first)
+append 3 to array $setup
+* 7 docked ship autojump on / off
+append [TRUE] to array $setup
+* 8 docked ship autojump distance
+append 1 to array $setup
+* 9 docked ship fuel resupply (jumps)
+append 10 to array $setup
+* 10 docked ship emergency jump/escape
+append [TRUE] to array $setup
+* 11 docked ship shield threshold (in percent)
+append 10 to array $setup
+* 12 docked ship missile usage
+append 15 to array $setup
+* 13 use logfile
+append [FALSE] to array $setup
+* 14 turret settings
+append 246 to array $setup
+* 15 enable auto rename
+append [TRUE] to array $setup
+
+* 16 Ignore List (array)
+$ignore =  array alloc: size=0
+append $ignore to array $setup
+
+* 17 Mechanics
+$mechanists =  array alloc: size=0
+* - 0 Count
+append 0 to array $mechanists
+* - 1 Allow ship repairs
+append [FALSE] to array $mechanists
+* - 2 Allow carrier repairs
+append [FALSE] to array $mechanists
+append $mechanists to array $setup
+
+* 18 Delay before the autocarrier docks its ships
+append 300 to array $setup
+
+set global variable: name='anarkis.ads.default' value=$setup
+
+return $setup

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.settings.default.shi.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.settings.default.shi.x3s
@@ -1,0 +1,58 @@
+#name: anarkis.ads.settings.default.shi
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.settings.default.shi.xml
+
+$setup =  array alloc: size=0
+
+* 0 threat level
+append 15 to array $setup
+* 1 Radar Range
+append 20000 to array $setup
+* 2 Defense Ship count
+append 5 to array $setup
+* 3 Damaged ships retreat
+append [TRUE] to array $setup
+* 4 Display warning
+append [TRUE] to array $setup
+* 5 warning type (0 subtitle, 1 audio, 2 text)
+append 2 to array $setup
+* 6 attack mode (3 auto, 1 nearest first, 2 strongest first)
+append 3 to array $setup
+* 7 docked ship autojump on / off
+append [TRUE] to array $setup
+* 8 docked ship autojump distance
+append 1 to array $setup
+* 9 docked ship fuel resupply (jumps)
+append 10 to array $setup
+* 10 docked ship emergency jump/escape
+append [TRUE] to array $setup
+* 11 docked ship shield threshold (in percent)
+append 10 to array $setup
+* 12 docked ship missile usage
+append 15 to array $setup
+* 13 use logfile
+append [FALSE] to array $setup
+* 14 turret settings
+append 246 to array $setup
+* 15 enable auto rename
+append [TRUE] to array $setup
+
+* 16 Ignore List (array)
+$ignore =  array alloc: size=0
+append $ignore to array $setup
+
+* 17 Mechanics
+$mechanists =  array alloc: size=0
+* - 0 Count
+append 0 to array $mechanists
+* - 1 Allow ship repairs
+append [FALSE] to array $mechanists
+* - 2 Allow carrier repairs
+append [FALSE] to array $mechanists
+append $mechanists to array $setup
+
+* 18 Delay before the autocarrier docks its ships
+append 300 to array $setup
+
+return $setup

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.settings.default.sta.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.settings.default.sta.x3s
@@ -1,0 +1,59 @@
+#name: anarkis.ads.settings.default.sta
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.settings.default.sta.xml
+
+$setup =  array alloc: size=0
+
+* 0 threat level
+append 5 to array $setup
+* 1 Radar Range
+append 100000 to array $setup
+* 2 Defense Ship count
+append 5 to array $setup
+* 3 Damaged ships retreat
+append [TRUE] to array $setup
+* 4 Display warning
+append [TRUE] to array $setup
+* 5 warning type (0 subtitle, 1 audio, 2 text)
+append 2 to array $setup
+* 6 attack mode (3 auto, 1 nearest first, 2 strongest first)
+append 3 to array $setup
+* 7 docked ship autojump on / off
+append [TRUE] to array $setup
+* 8 docked ship autojump distance
+append 1 to array $setup
+* 9 docked ship fuel resupply (jumps)
+append 10 to array $setup
+* 10 docked ship emergency jump/escape
+append [TRUE] to array $setup
+* 11 docked ship shield threshold (in percent)
+append 10 to array $setup
+* 12 docked ship missile usage
+append 15 to array $setup
+* 13 use logfile
+append [FALSE] to array $setup
+* 14 turret settings
+append 246 to array $setup
+* 15 enable auto rename
+append [TRUE] to array $setup
+
+* 16 Ignore List (array)
+$ignore =  array alloc: size=0
+append $ignore to array $setup
+
+* 17 Mechanics
+$mechanists =  array alloc: size=0
+* - 0 Count
+append 0 to array $mechanists
+* - 1 Allow ship repairs
+append [FALSE] to array $mechanists
+* - 2 Allow carrier repairs
+append [FALSE] to array $mechanists
+append $mechanists to array $setup
+
+* 18 Delay before the autocarrier docks its ships
+append 300 to array $setup
+
+
+return $setup

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.setup.createdefault.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.setup.createdefault.x3s
@@ -1,0 +1,22 @@
+#name: anarkis.ads.setup.createdefault
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.setup.createdefault.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+
+if $refobj -> is of class Ship
+$setup = $gl.setup[1]
+else
+$setup = $gl.setup[2]
+end
+
+$cnt =  size of array $setup
+$result =  array alloc: size=$cnt
+
+while $cnt
+dec $cnt =
+$result[$cnt] = $setup[$cnt]
+end
+
+return $result

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.setup.editdefault.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.setup.editdefault.x3s
@@ -1,0 +1,212 @@
+#name: anarkis.ads.setup.editdefault
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.setup.editdefault.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+
+* ====
+* Init selection arrays
+* - Alert Level
+$threat.level = $setup.array[0]
+$sel.threat =  array alloc: size=0
+append 1 to array $sel.threat
+append 3 to array $sel.threat
+append 5 to array $sel.threat
+append 8 to array $sel.threat
+append 10 to array $sel.threat
+append 15 to array $sel.threat
+append 20 to array $sel.threat
+append 25 to array $sel.threat
+append 30 to array $sel.threat
+append 35 to array $sel.threat
+append 40 to array $sel.threat
+$sel.threat.selection =  get index of $threat.level in array $sel.threat offset=-1 + 1
+$sel.threat.id = 'threat'
+* - Radar Range
+$radar.range = $setup.array[1]
+$sel.radar =  array alloc: size=0
+$v1 = 0
+while $v1 < 100000
+$v1 = $v1 + 5000
+append $v1 to array $sel.radar
+end
+$sel.radar.selection =  get index of $radar.range in array $sel.radar offset=-1 + 1
+$sel.radar.id = 'radar'
+* - Retreat Yes/No
+$retreat = $setup.array[3]
+$sel.yesno =  array alloc: size=0
+$v1 =  read text: page=$page.id id=820
+append $v1 to array $sel.yesno
+$v1 =  read text: page=$page.id id=821
+append $v1 to array $sel.yesno
+if $retreat == [TRUE]
+$sel.retreat.selection = 0
+else
+$sel.retreat.selection = 1
+end
+$sel.retreat.id = 'retreat'
+* - Attack Mode
+$sel.attack =  array alloc: size=0
+$v1 =  read text: page=$page.id id=206
+append $v1 to array $sel.attack
+$v1 =  read text: page=$page.id id=207
+append $v1 to array $sel.attack
+$v1 =  read text: page=$page.id id=208
+append $v1 to array $sel.attack
+$sel.attack.selection = $setup.array[6]
+skip if $sel.attack.selection != 3
+$sel.attack.selection = 0
+$sel.attack.id = 'attack'
+* - Defense ship count
+$defence = $setup.array[2]
+$sel.defense =  array alloc: size=0
+append 0 to array $sel.defense
+append 1 to array $sel.defense
+append 3 to array $sel.defense
+append 5 to array $sel.defense
+append 8 to array $sel.defense
+append 10 to array $sel.defense
+append 15 to array $sel.defense
+$sel.defense.selection =  get index of $defence in array $sel.defense offset=-1 + 1
+$sel.defense.id = 'defense'
+* - Delay before docking ships
+$delay = $setup.array[18]
+$sel.delay =  array alloc: size=0
+append 0 to array $sel.delay
+$v1 = 0
+while $v1 < 600
+$v1 = $v1 + 30
+append $v1 to array $sel.delay
+end
+$sel.delay.selection =  get index of $delay in array $sel.delay offset=-1 + 1
+$sel.delay.id = 'delay'
+* - Display Warning message Yes/No
+$warning = $setup.array[4]
+if $warning == [TRUE]
+$sel.warning.selection = 0
+else
+$sel.warning.selection = 1
+end
+$sel.warning.id = 'warning'
+* - Alert Type
+$sel.alert =  array alloc: size=0
+$v1 =  read text: page=$page.id id=233
+append $v1 to array $sel.alert
+$v1 =  read text: page=$page.id id=234
+append $v1 to array $sel.alert
+$v1 =  read text: page=$page.id id=235
+append $v1 to array $sel.alert
+$sel.alert.selection = $setup.array[5]
+skip if $sel.alert.selection != 3
+$sel.alert.selection = 0
+$sel.alert.id = 'warning.type'
+* End of init selection arrays
+* ====
+
+
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=220
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=221, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.threat, default=$sel.threat.selection, return id=$sel.threat.id
+
+$st = sprintf: pageid=$page.id textid=226, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.radar, default=$sel.radar.selection, return id=$sel.radar.id
+
+$st = sprintf: pageid=$page.id textid=223, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.yesno, default=$sel.retreat.selection, return id=$sel.retreat.id
+
+$st = sprintf: pageid=$page.id textid=224, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.attack, default=$sel.attack.selection, return id=$sel.attack.id
+
+$st = sprintf: pageid=$page.id textid=225, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.defense, default=$sel.defense.selection, return id=$sel.defense.id
+
+$st = sprintf: pageid=$page.id textid=238, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.delay, default=$sel.delay.selection, return id=$sel.delay.id
+
+$st =  read text: page=$page.id id=228
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=222, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.yesno, default=$sel.warning.selection, return id=$sel.warning.id
+
+$st = sprintf: pageid=$page.id textid=229, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.alert, default=$sel.alert.selection, return id=$sel.alert.id
+
+$st =  read text: page=$page.id id=403
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=1087
+add custom menu item to array $menu: text=$st returnvalue='save'
+
+$st = sprintf: pageid=$page.id textid=1088, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=200
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if  is datatyp[ $menu.result ] == DATATYP_ARRAY
+$cnt =  size of array $menu.result
+while $cnt
+dec $cnt =
+$r.id = $menu.result[$cnt][0]
+$r.val = $menu.result[$cnt][1]
+* - - - Defense Ships
+if $r.id == $sel.defense.id
+$setup.array[2] = $sel.defense[$r.val]
+$sel.defense.selection = $r.val
+* - - - Radar Range
+else if $r.id == $sel.radar.id
+$setup.array[1] = $sel.radar[$r.val]
+$sel.radar.selection = $r.val
+* - - - Warning Type
+else if $r.id == $sel.alert.id
+$setup.array[5] = $r.val
+$sel.alert.selection = $r.val
+* - - - Attack Mode
+else if $r.id == $sel.attack.id
+skip if not $r.val == 0
+$r.val = 0
+$setup.array[6] = $r.val
+$sel.attack.selection = $r.val
+* - - - Retreat Mode
+else if $r.id == $sel.retreat.id
+if $r.val == 0
+$setup.array[3] = [TRUE]
+else
+$setup.array[3] = [FALSE]
+end
+$sel.retreat.selection = $r.val
+* - - - Delay before dock
+else if $r.id == $sel.delay.id
+$setup.array[18] = $sel.delay[$r.val]
+$sel.delay.selection = $r.val
+* - - - Warning Toggle
+else if $r.id == $sel.warning.id
+if $r.val == 0
+$setup.array[4] = [TRUE]
+else
+$setup.array[4] = [FALSE]
+end
+$sel.warning.selection = $r.val
+* - - - Threat Setting
+else if $r.id == $sel.threat.id
+$setup.array[0] = $sel.threat[$r.val]
+$sel.threat.selection = $r.val
+
+end
+end
+
+end
+
+
+return $setup.array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.setup.global.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.setup.global.x3s
@@ -1,0 +1,181 @@
+#name: anarkis.ads.setup.global
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.setup.global.xml
+
+* Get Global Setup
+$gl.setup = get global variable: name='anarkis.ads.setup'
+skip if $gl.setup
+$gl.setup = [THIS] -> call script anarkis.ads.setup.init :
+
+$page.id = $gl.setup[0]
+
+* Init selection arrays
+* - Init Yes / No type
+$v1 =  read text: page=$page.id id=820
+$v2 =  read text: page=$page.id id=821
+$sel.yesno =  create new array, arguments=$v1, $v2, null, null, null
+* - Grid Max Jump
+$grid.maxjump = $gl.setup[4]
+$sel.grid.jump =  array alloc: size=0
+$v1 = 0
+while $v1 < 15
+inc $v1 =
+append $v1 to array $sel.grid.jump
+end
+$sel.grid.jump.select =  get index of $grid.maxjump in array $sel.grid.jump offset=-1 + 1
+$sel.grid.jump.id = 'grid.jump'
+* - Grid Min Threat
+$grid.threat = $gl.setup[5]
+$sel.grid.threat =  array alloc: size=0
+$v1 = 0
+while $v1 < 20
+inc $v1 =
+append $v1 to array $sel.grid.threat
+end
+$sel.grid.threat.select =  get index of $grid.threat in array $sel.grid.threat offset=-1 + 1
+$sel.grid.threat.id = 'grid.threat'
+* - Grid Display Alert
+$grid.alert = $gl.setup[6]
+if $grid.alert == [TRUE]
+$sel.grid.alert.select = 0
+else
+$sel.grid.alert.select = 1
+end
+$sel.grid.alert.id = 'grid.alert'
+* - Auto Rename
+$auto.rename = $gl.setup[3]
+if $auto.rename == [TRUE]
+$sel.rename.select = 0
+else
+$sel.rename.select = 1
+end
+$sel.rename.id = 'rename'
+
+while $menu.result != -1
+
+* - Ignore Factions
+$race.array = [THIS] -> call script anarkis.lib.get.race.array :
+$v1 =  size of array $race.array
+$sel.ignore.select =  array alloc: size=$v1
+$ignore.list = $gl.setup[7]
+while $v1
+dec $v1 =
+$v2 = $race.array[$v1]
+if  find $v2 in array: $ignore.list
+$sel.ignore.select[$v1] = 0
+else
+$sel.ignore.select[$v1] = 1
+end
+end
+
+$menu =  create custom menu array
+
+* - Default Setup
+$st =  read text: page=$page.id id=1090
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=1091
+add custom menu item to array $menu: text=$st returnvalue='def.carrier'
+$st =  read text: page=$page.id id=1092
+add custom menu item to array $menu: text=$st returnvalue='def.station'
+* - Defense Grid
+$st =  read text: page=$page.id id=1093
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=1094
+add value selection to menu: $menu, text=$st, value array=$sel.grid.jump, default=$sel.grid.jump.select, return id=$sel.grid.jump.id
+$st =  read text: page=$page.id id=1095
+add value selection to menu: $menu, text=$st, value array=$sel.grid.threat, default=$sel.grid.threat.select, return id=$sel.grid.threat.id
+$st =  read text: page=$page.id id=1096
+add value selection to menu: $menu, text=$st, value array=$sel.yesno, default=$sel.grid.alert.select, return id=$sel.grid.alert.id
+* - Ignore Factions
+$st =  read text: page=$page.id id=1097
+add custom menu heading to array $menu: title=$st
+$v1 =  size of array $race.array
+while $v1
+dec $v1 =
+$st = $race.array[$v1]
+$v2 = $sel.ignore.select[$v1]
+add value selection to menu: $menu, text=$st, value array=$sel.yesno, default=$v2, return id=$st
+end
+
+* - General Settings
+$st =  read text: page=$page.id id=1098
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=1099
+add value selection to menu: $menu, text=$st, value array=$sel.yesno, default=$sel.rename.select, return id=$sel.rename.id
+
+$st =  read text: page=$page.id id=1100
+add custom menu item to array $menu: text=$st returnvalue='reset'
+
+$st =  read text: page=$page.id id=1087
+add custom menu item to array $menu: text=$st returnvalue='save'
+
+$v1 =  read text: page=$page.id id=200
+
+$v1 =  read text: page=$page.id id=1089
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+
+* - Handle Results
+if  is datatyp[ $menu.result ] == DATATYP_ARRAY
+$cnt =  size of array $menu.result
+while $cnt
+dec $cnt =
+$r.id = $menu.result[$cnt][0]
+$r.val = $menu.result[$cnt][1]
+
+if $r.id == $sel.grid.alert.id
+if $r.val == 0
+$gl.setup[6] = [TRUE]
+else
+$gl.setup[6] = [FALSE]
+end
+$sel.grid.alert.select = $r.val
+else if $r.id == $sel.grid.jump.id
+$gl.setup[4] = $sel.grid.jump[$r.val]
+$sel.grid.jump.select = $r.val
+else if $r.id == $sel.grid.threat.id
+$gl.setup[5] = $sel.grid.threat[$r.val]
+$sel.grid.threat.select = $r.val
+else if $r.id == $sel.rename.id
+if $r.val == 0
+$gl.setup[3] = [TRUE]
+else
+$gl.setup[3] = [FALSE]
+end
+$sel.rename.select = $r.val
+else if  is datatyp[ $r.id ] == DATATYP_RACE
+if $r.val == 0
+if not  find $r.id in array: $ignore.list
+append $r.id to array $ignore.list
+end
+else
+if  find $r.id in array: $ignore.list
+$v1 =  get index of $r.id in array $ignore.list offset=-1 + 1
+remove element from array $ignore.list at index $v1
+end
+end
+end
+end
+$v2 = $menu.result[0]
+$menu.result[0] = 'noclose'
+if $v2 == 'def.carrier'
+$v1 = $gl.setup[1]
+$v1 = [THIS] -> call script anarkis.ads.setup.editdefault :  setup=$v1
+$gl.setup[1] = $v1
+else if $v2 == 'def.station'
+$v1 = $gl.setup[2]
+$v1 = [THIS] -> call script anarkis.ads.setup.editdefault :  setup=$v1
+$gl.setup[2] = $v1
+else if $v2 == 'reset'
+$gl.setup = [THIS] -> call script anarkis.ads.setup.init :
+else if $v2 == 'save'
+$menu.result = -1
+end
+
+end
+end
+
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.setup.init.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.setup.init.x3s
@@ -1,0 +1,34 @@
+#name: anarkis.ads.setup.init
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.setup.init.xml
+
+$setup =  array alloc: size=0
+$v1 = [THIS] -> call script anarkis.ads.settings.default.shi :
+$v2 = [THIS] -> call script anarkis.ads.settings.default.sta :
+* 0 - Text ID
+append 8510 to array $setup
+* 1 - Default Carrier Setup
+append $v1 to array $setup
+* 2 - Default Station  Setup
+append $v2 to array $setup
+* 3 - AutoRename automated ships
+append [TRUE] to array $setup
+* 4 - Grid Setup : Jump Range
+append 6 to array $setup
+* 5 - Grid Setup : Minimal Threat
+append 3 to array $setup
+* 6 - Grid Setup : Alert Player
+append [TRUE] to array $setup
+* 7 - Ignore List
+$ignore =  array alloc: size=0
+append Player to array $ignore
+append $ignore to array $setup
+* 8 - Unused
+append null to array $setup
+* 9 - Unused
+append null to array $setup
+
+set global variable: name='anarkis.ads.setup' value=$setup
+
+return $setup

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.task.maingrid.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.task.maingrid.x3s
@@ -1,0 +1,70 @@
+#name: anarkis.ads.task.maingrid
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.task.maingrid.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+
+while get global variable: name='anarkis.ads.grid.mode'
+
+$page.id = $gl.setup[0]
+$max.dist = $gl.setup[4]
+$min.threat = $gl.setup[5]
+$show.mess = $gl.setup[6]
+
+
+if $race == Player
+$arr = [THIS] -> call script anarkis.ads.lib.get.plsectors :
+else
+$arr = [THIS] -> call script anarkis.lib.get.sector.plus :  ref object=[PLAYERSHIP]  max jump=100  race=$race  remove border sectors=[FALSE]  remove core=[FALSE]  remove xenon/khaak sectors=[FALSE]  remove unknown=[TRUE]  ignore pirate/yaki=[FALSE]
+end
+$cnt =  size of array $arr
+
+while $cnt
+dec $cnt =
+skip if get global variable: name='anarkis.ads.grid.mode'
+return null
+$sector = $arr[$cnt]
+$threat = [THIS] -> call script anarkis.ads.lib.get.sectorthreat :  sector=$sector  race=$race
+if $threat > $min.threat
+$needed.strength = $threat * 3
+$gridships = [THIS] -> call script anarkis.ads.lib.get.gridships :  Race=$race  available only=[TRUE]  base sector (or null)=$sector  max.dist=$max.dist
+$enemy = [THIS] -> call script anarkis.ads.lib.enemy.strongest :  sector=$sector  race=$race
+$gridships.cnt =  size of array $gridships
+
+if $show.mess == [TRUE]
+$v1 = [THIS] -> call script anarkis.lib.sector.format :  sector=$sector
+$st = sprintf: pageid=$page.id textid=1113, $sector, $threat, null, null, null
+display subtitle text: text=$st duration=10000 ms
+end
+
+while $gridships.cnt AND ( $needed.strength > 0 )
+skip if get global variable: name='anarkis.ads.grid.mode'
+return null
+dec $gridships.cnt =
+$grid.select = $gridships[$gridships.cnt]
+skip if not $grid.select == [PLAYERSHIP]
+continue
+skip if not $grid.select -> get local variable: name='anarkis.acc.battle'
+continue
+$grid.select.sector = $grid.select -> get sector
+skip if not $grid.select.sector == $sector
+continue
+$grid.threat = [THIS] -> call script anarkis.ads.lib.get.shipthreat :  ship/class=$grid.select
+$needed.strength = $needed.strength - $grid.threat
+if not $grid.select -> is task 0 in use
+START $grid.select -> call script !ship.cmd.idle.std :
+= wait randomly from 500 to 600 ms
+end
+$grid.select -> interrupt with script anarkis.ads.cmd.protectgrid and prio 10: arg1=$enemy arg2=$sector arg3=null arg4=null
+= wait randomly from 1000 to 2000 ms
+end
+
+end
+= [THIS] -> call script anarkis.lib.wait.not :  wait time (in sec)=15  global to check='anarkis.ads.grid.mode'
+end
+= [THIS] -> call script anarkis.lib.wait.not :  wait time (in sec)=20  global to check='anarkis.ads.grid.mode'
+end
+
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.task.sectorgrid.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.task.sectorgrid.x3s
@@ -1,0 +1,37 @@
+#name: anarkis.ads.task.sectorgrid
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.task.sectorgrid.xml
+
+if [THIS] -> exists
+$race = [THIS] -> get owner race
+$sector = [THIS] -> get sector
+end
+
+$alert.level = 3
+
+while [TRUE]
+= [THIS] -> call script anarkis.lib.wait :  wait time (in sec)=30  global to check=null
+
+$threat = [THIS] -> call script anarkis.ads.lib.get.sectorthreat :  sector=$sector  race=$race
+if $threat >= $alert.level
+$gridships = [THIS] -> call script anarkis.ads.lib.get.gridships :  Race=$race  available only=[TRUE]  base sector (or null)=$sector
+$gridships.cnt =  size of array $gridships
+$enemy = [THIS] -> call script anarkis.ads.lib.enemy.strongest :  sector=$sector  race=$race
+$needed.strength = $threat * 3
+while $gridships.cnt AND ( $needed.strength > 0 )
+dec $gridships.cnt =
+$grid.select = $gridships[$gridships.cnt]
+$grid.threat = [THIS] -> call script anarkis.ads.lib.get.shipthreat :  ship/class=$grid.select
+$needed.strength = $needed.strength - $grid.threat
+$grid.select -> interrupt with script anarkis.ads.cmd.protectgrid and prio 10: arg1=$enemy arg2=$sector arg3=null arg4=null
+end
+= [THIS] -> call script anarkis.lib.wait :  wait time (in sec)=300  global to check=null
+end
+
+end
+
+
+
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.toggle.task.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.toggle.task.x3s
@@ -1,0 +1,46 @@
+#name: anarkis.ads.toggle.task
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.toggle.task.xml
+
+$npc = [FALSE]
+if $target -> is script anarkis.acc.task.autocarrier on stack of task=10
+$task.id = 10
+else if $target -> is script anarkis.acc.task.autocarrier on stack of task=11
+$task.id = 11
+else if $target -> is script anarkis.acc.task.autocarrier on stack of task=894
+$task.id = 894
+else if $target -> is script anarkis.acc.task.autocarrier.npc on stack of task=894
+$npc = [TRUE]
+$task.id = 894
+end
+$target -> start task 900 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+skip if not $task.id
+$target -> start task $task.id with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+= wait 200 ms
+
+if $active
+
+if not $task.id
+$owner = $target -> get owner race
+if $owner != Player
+$npc = [TRUE]
+$task.id = 894
+else
+$npc = [FALSE]
+if $target -> is task 10 in use
+$task.id = 11
+else
+$task.id = 10
+end
+end
+end
+
+if $npc
+$target -> start task $task.id with script anarkis.acc.task.autocarrier.npc and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+else
+$target -> start task $task.id with script anarkis.acc.task.autocarrier and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.wing.attack.pl.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.wing.attack.pl.x3s
@@ -1,0 +1,53 @@
+#name: anarkis.ads.wing.attack.pl
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.wing.attack.pl.xml
+
+* ===========================================
+* Wing : Send a wing to attack a given target
+* ===========================================
+
+$title =  read text: page=2010 id=834
+$obj.class = $target -> get object class
+$wing.size = 5
+if $target -> is of class Fighter
+$wing.size = 5
+else if $target -> is of class Freighter
+$wing.size = 3
+else if $obj.class == TL
+$wing.size = 10
+else if $obj.class == M8
+$wing.size = 7
+else if $obj.class == M6
+$wing.size = 12
+else if $obj.class == M7
+$wing.size = 15
+else if $obj.class == M2
+$wing.size = 30
+else if $obj.class == M1
+$wing.size = 25
+end
+
+$res = [THIS] -> call script anarkis.lib.get.dockedowned :  ship class=Moveable Ship  local to check='anarkis.acc.ship'
+$res =  size of array $res
+skip if not $res < $wing.size
+$wing.size = $res
+
+skip if [THIS] -> call script anarkis.ads.comm.wingmenu :  title=$title  target=$target  default count=$wing.size
+return null
+
+$res = [THIS] -> get local variable: name='anarkis.menu.result'
+$target = $res[0]
+$wing.size = $res[1]
+$wing.list = $res[2]
+
+$wing.count =  size of array $wing.list
+[THIS] -> set command: ANARKIS_ATTACKWING  target=$target target2=$wing.size par1=null par2=null
+if $wing.count > 0
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$target  wing size=$wing.list  wing ID='A'
+else
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$target  wing size=$wing.size  wing ID='A'
+end
+[THIS] -> set local variable: name='anarkis.menu.result' value=null
+
+return [TRUE]

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.wing.defense.pl.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ads.wing.defense.pl.x3s
@@ -1,0 +1,53 @@
+#name: anarkis.ads.wing.defense.pl
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.wing.defense.pl.xml
+
+* ===========================================
+* Wing : Send a wing to attack a given target
+* ===========================================
+
+$title =  read text: page=2010 id=833
+$obj.class = $target -> get object class
+$wing.size = 5
+if $target -> is of class Fighter
+$wing.size = 5
+else if $target -> is of class Freighter
+$wing.size = 3
+else if $obj.class == TL
+$wing.size = 10
+else if $obj.class == M8
+$wing.size = 7
+else if $obj.class == M6
+$wing.size = 12
+else if $obj.class == M7
+$wing.size = 15
+else if $obj.class == M2
+$wing.size = 30
+else if $obj.class == M1
+$wing.size = 25
+end
+
+$res = [THIS] -> call script anarkis.lib.get.dockedowned :  ship class=Moveable Ship  local to check='anarkis.acc.ship'
+$res =  size of array $res
+skip if not $res < $wing.size
+$wing.size = $res
+
+skip if [THIS] -> call script anarkis.ads.comm.wingmenu :  title=$title  target=$target  default count=$wing.size
+return null
+
+$res = [THIS] -> get local variable: name='anarkis.menu.result'
+$target = $res[0]
+$wing.size = $res[1]
+$wing.list = $res[2]
+
+$wing.count =  size of array $wing.list
+[THIS] -> set command: ANARKIS_DEFENSIVEWING  target=$target target2=$wing.size par1=null par2=null
+if $wing.count > 0
+= [THIS] -> call script anarkis.acc.wing.defence :  target=$target  wing size=$wing.list
+else
+= [THIS] -> call script anarkis.acc.wing.defence :  target=$target  wing size=$wing.size
+end
+[THIS] -> set local variable: name='anarkis.menu.result' value=null
+
+return [TRUE]

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.debug.off.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.debug.off.x3s
@@ -1,0 +1,7 @@
+#name: anarkis.debug.off
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.debug.off.xml
+
+set global variable: name='anarkis.debug' value=null
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.debug.on.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.debug.on.x3s
@@ -1,0 +1,7 @@
+#name: anarkis.debug.on
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.debug.on.xml
+
+set global variable: name='anarkis.debug' value=[TRUE]
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.debug.output.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.debug.output.x3s
@@ -1,0 +1,17 @@
+#name: anarkis.debug.output
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.debug.output.xml
+
+$debug.on = get global variable: name='anarkis.debug'
+if $debug.on
+*write to player logbook $message
+$playtime = playing time
+$playtime =  format time: $playtime
+*$playtime = $playtime / 60
+
+$m = '(' + $playtime + ') ' + $message
+write to log file #8513  append=1  value=$m
+display subtitle text: text=$m duration=5000 ms
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.ecs.al.init.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.ecs.al.init.x3s
@@ -1,0 +1,29 @@
+#name: anarkis.ecs.al.init
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ecs.al.init.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+if  is datatyp[ $ecs.setup ] == DATATYP_ARRAY
+$ecs.setup[3] = [TRUE]
+else
+$ecs.setup =  array alloc: size=6
+$ecs.installed =  array alloc: size=0
+$ecs.configs =  array alloc: size=0
+$ecs.news =  array alloc: size=0
+$ecs.guilds =  array alloc: size=0
+$ecs.setup[0] = 250
+$ecs.setup[1] = $ecs.installed
+$ecs.setup[2] = $ecs.configs
+$ecs.setup[3] = [TRUE]
+$ecs.setup[4] = null
+$ecs.setup[5] = $ecs.news
+$ecs.setup[6] = $ecs.guilds
+end
+set global variable: name='plugin.ecs.setup' value=$ecs.setup
+= [THIS] -> call script plugin.sk.ecs.hotkey.install :
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.add.software.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.add.software.x3s
@@ -1,0 +1,77 @@
+#name: anarkis.lib.add.software
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.add.software.xml
+
+$r = [THIS]
+
+= $r -> install 1 units of Docking Computer
+= $r -> install 1 units of Boost Extension
+
+$rnd =  = random value from 0 to 2 - 1
+if $rnd == 1
+= $r -> install 1 units of Triplex Scanner
+else
+= $r -> install 1 units of Duplex Scanner
+end
+
+= $r -> install 1 units of Jumpdrive
+= $r -> install 1 units of Fight Command Software MK1
+= $r -> install 1 units of SETA Boost Extension
+= $r -> install 1 units of Singularity Engine Time Accelerator
+= $r -> install 1 units of Strafe Drive Extension
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Special Command Software MK1
+= $r -> install 1 units of Trade Command Software MK1
+= $r -> install 1 units of Navigation Command Software MK1
+
+if $r -> is of class Fighter
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Transporter Device
+= $r -> install 1 units of Fight Command Software MK2
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Explorer Command Software
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Patrol Command Software
+= $r -> install 1 units of Freight Scanner
+end
+
+if $r -> is of class Freighter
+= $r -> install 1 units of Trade Command Software MK2
+= $r -> install 1 units of Cargo Lifesupport System
+= $r -> install 1 units of Transporter Device
+= $r -> install 1 units of Trading System Extension
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Mineral Scanner
+end
+
+if $r -> is of class Big Ship
+= $r -> install 1 units of Carrier Command Software
+= $r -> install 1 units of Cargo Lifesupport System
+= $r -> install 1 units of Patrol Command Software
+end
+if $r -> is of class Huge Ship
+= $r -> install 1 units of Cargo Lifesupport System
+= $r -> install 1 units of Carrier Command Software
+= $r -> install 1 units of Patrol Command Software
+= $r -> install 1 units of Transporter Device
+end
+
+if $r -> is of class TS
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Best Buys Locator
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Best Selling Price Locator
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Trade Command Software MK3
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.armship.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.armship.x3s
@@ -1,0 +1,13 @@
+#name: anarkis.lib.armship
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.armship.xml
+
+$turret.cnt = [THIS] -> get number of turrets
+while $turret.cnt
+dec $turret.cnt =
+$r =  = random value from 0 to 7 - 1
+= [THIS] -> call script anarkis.lib.armturret :  turret ID=$turret.cnt  weapon selection mode=$r  no ion=[FALSE]  no ammo weapons=[FALSE]
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.armturret.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.armturret.x3s
@@ -1,0 +1,222 @@
+#name: anarkis.lib.armturret
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.armturret.xml
+
+* ===========================================
+* Custom Weapon Installation Script v1.1.1
+* ===========================================
+* weapon.select :
+* - 0 : Fully Random Setup
+* - 1 : Favor Shield Damage
+* - 2 : Favor Hull Damage
+* - 3 : Favor Weapon Range
+* - 4 : Favor Weapon Speed
+* - 5 : Overall Weapon Performances
+* - 6 : Most Expensive Weapon
+* ===========================================
+* disable.ion = Disable ion disruptors
+* disable.ammo = Disable all weapons using ammunitions
+* ===========================================
+* Fix 1 : No ammo weapon in turret 0 (avoid defenceless ships)
+* Fix 2 : Default "attack enemies" turret settings
+* Fix 3 : Dual weapon in slot 0
+* Fix 4 : No turret script on OOS NPC ships
+* Fix 4 : Replaced disable all ion by ion disruptor only
+* Fix 5 : Reduced ion probability to 1/3
+* ===========================================
+* TODO : Better Missile turrets handling
+* ===========================================
+
+* Get all compatible laser types
+$weap.array = [THIS] -> get compatible laser array: turret=$turret.nb
+$turret.laser.cnt = [THIS] -> get max. number of lasers in turret $turret.nb
+$weap.size =  size of array $weap.array
+skip if $turret.laser.cnt
+return [FALSE]
+
+* Remove crappy and forbidden laser types
+while $weap.size
+*= wait randomly from 10 to 50 ms
+dec $weap.size =
+$test = $weap.array[$weap.size]
+* - Remove useless laser types
+if $test == Tractor Beam OR $test == Repair Laser OR $test == Mobile Drilling System OR $test == Impulse Ray Emitter
+remove element from array $weap.array at index $weap.size
+continue
+end
+* - Remove Ammo weapons
+* - Fix 1 : No ammo weapon in turret 0 (avoid defenseless ships)
+if $disable.ammo == [TRUE] OR $turret.nb == 0
+$ammo.type =  get ammunition of laser $test
+if $ammo.type
+remove element from array $weap.array at index $weap.size
+continue
+end
+end
+* - Remove Ion weapons
+* - Fix 5 : Reduced ion probability to 1/3
+$third =  = random value from 0 to 3 - 1
+if $disable.ion == [TRUE] OR ( $disable.ion == [FALSE] AND $third != 1 )
+if $test == Ion Disruptor
+remove element from array $weap.array at index $weap.size
+continue
+end
+end
+end
+
+$weap.size =  size of array $weap.array
+skip if $weap.size
+return [FALSE]
+
+* Random selection
+if $weapon.select == 0
+$weap.id =  = random value from 0 to $weap.size - 1
+$weap.selected = $weap.array[$weap.id]
+* Favor Shield Damage
+else if $weapon.select == 1
+$x = $weap.size
+$dmg.last = 0
+$weap.id = 0
+while $x
+dec $x =
+$weap.selected = $weap.array[$x]
+$dmg.tot =  get shield damage of laser $weap.selected
+if $dmg.tot > $dmg.last
+$weap.id = $x
+$dmg.last = $dmg.tot
+end
+end
+$weap.selected = $weap.array[$weap.id]
+* Favor Hull Damage
+else if $weapon.select == 2
+$x = $weap.size
+$dmg.last = 0
+$weap.id = 0
+while $x
+dec $x =
+$weap.selected = $weap.array[$x]
+$dmg.tot =  get hull damage of laser $weap.selected
+if $dmg.tot > $dmg.last
+$weap.id = $x
+$dmg.last = $dmg.tot
+end
+end
+* Favor Weapon Range
+else if $weapon.select == 3
+$x = $weap.size
+$dmg.last = 0
+$weap.id = 0
+while $x
+dec $x =
+$weap.selected = $weap.array[$x]
+$dmg.tot =  get range of laser $weap.selected
+if $dmg.tot > $dmg.last
+$weap.id = $x
+$dmg.last = $dmg.tot
+end
+end
+* Favor Weapon Bullet Speed
+else if $weapon.select == 4
+$x = $weap.size
+$dmg.last = 0
+$weap.id = 0
+while $x
+*= wait randomly from 10 to 50 ms
+dec $x =
+$weap.selected = $weap.array[$x]
+$dmg.tot =  get bullet speed of laser $weap.selected
+if $dmg.tot > $dmg.last
+$weap.id = $x
+$dmg.last = $dmg.tot
+end
+end
+* Overal Weapon Strength
+else if $weapon.select == 5
+$x = $weap.size
+$dmg.last = 0
+$weap.id = 0
+while $x
+*= wait randomly from 10 to 50 ms
+dec $x =
+$weap.selected = $weap.array[$x]
+$w.shield =  get shield damage of laser $weap.selected
+$w.hull =  get hull damage of laser $weap.selected
+$w.range =  get range of laser $weap.selected
+$w.speed =  get bullet speed of laser $weap.selected
+$dmg.tot = 5 * $w.hull + $w.shield + 2 * $w.speed + 2 * $w.range
+if $dmg.tot > $dmg.last
+$weap.id = $x
+$dmg.last = $dmg.tot
+end
+end
+* Weapon Price
+else if $weapon.select == 6
+$x = $weap.size
+$dmg.last = 0
+$weap.id = 0
+while $x
+dec $x =
+$weap.selected = $weap.array[$x]
+$dmg.tot = get average price of ware $weap.selected
+if $dmg.tot > $dmg.last
+$weap.id = $x
+$dmg.last = $dmg.tot
+end
+end
+end
+
+* Add and install
+
+* Fix 3 : Dual weapon in slot 0
+if $turret.laser.cnt >= 6 AND $turret.nb == 0
+$fix = $turret.laser.cnt / 2
+$weap.selected = $weap.array[$weap.id]
+= [THIS] -> add $fix units of $weap.selected
+$rnd =  = random value from 0 to $weap.size - 1
+$fix.weapon = $weap.array[$rnd]
+= [THIS] -> add $fix units of $fix.weapon
+$x = $fix
+while $x
+dec $x =
+[THIS] -> switch laser in turret $turret.nb gun $x to $weap.selected
+end
+$x = $fix
+while $x
+dec $x =
+$rnd = $fix + $x
+[THIS] -> switch laser in turret $turret.nb gun $rnd to $fix.weapon
+end
+else
+$weap.selected = $weap.array[$weap.id]
+= [THIS] -> add $turret.laser.cnt units of $weap.selected
+$x = $turret.laser.cnt
+while $x
+dec $x =
+[THIS] -> switch laser in turret $turret.nb gun $x to $weap.selected
+end
+end
+
+* Check for ammo
+$ammo.type =  get ammunition of laser $weap.selected
+if $ammo.type
+$test = 5 * $turret.laser.cnt
+= [THIS] -> add $test units of $ammo.type
+[THIS] -> set ammo resupply: ammo=$ammo.type amount=20
+end
+
+skip if not $turret.nb == 0
+return $weap.selected
+
+* Fix 4 : No turret script on OOS NPC ships
+$pl.sector = [PLAYERSHIP] -> get sector
+$owner = [THIS] -> get owner race
+if $owner != Player AND [SECTOR] != $pl.sector
+return $weap.selected
+end
+
+* Fix 2 : Default "attack enemies" turret settings
+[THIS] -> start task $turret.nb with script !turret.killenemies.std and prio 0: arg1=$turret.nb arg2=null arg3=null arg4=null arg5=null
+
+
+return $weap.selected

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.array.append.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.array.append.x3s
@@ -1,0 +1,14 @@
+#name: anarkis.lib.array.append
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.array.append.xml
+
+$append.size =  size of array $append.array
+
+while $append.size
+dec $append.size =
+$val = $append.array[$append.size]
+append $val to array $base.array
+end
+
+return $base.array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.ask.shiparray.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.ask.shiparray.x3s
@@ -1,0 +1,39 @@
+#name: anarkis.lib.ask.shiparray
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.ask.shiparray.xml
+
+$ship.array =  array alloc: size=0
+
+while $menu.result != -1
+$ship.cnt =  size of array $ship.array
+$menu.box =  create custom menu array
+add custom menu heading to array $menu.box: title='Commands'
+add custom menu item to array $menu.box: text='Add a ship' returnvalue='add.ship'
+skip if not $ship.cnt
+add custom menu item to array $menu.box: text='Clear the list' returnvalue='clear'
+
+add custom menu heading to array $menu.box: title='Selected Ships'
+while $ship.cnt
+dec $ship.cnt =
+$ship = $ship.array[$ship.cnt]
+$sector = $ship -> get sector
+$st = sprintf: fmt='%s - %s <remove>', $ship, $sector, null, null, null
+$x = $ship.cnt + 10
+add custom menu item to array $menu.box: text=$st returnvalue=$x
+end
+
+$menu.result =  open custom menu: title=$menu.title description=$menu.desc option array=$menu.box
+
+if $menu.result == 'add.ship'
+$addship = [THIS] -> get user input: type=Var/Ship, title='Select a ship'
+skip if not $addship -> exists
+append $addship to array $ship.array
+else if $menu.result == 'clear'
+$ship.array =  array alloc: size=0
+else if $menu.result >= 10
+$x = $menu.result - 10
+remove element from array $ship.array at index $x
+end
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.build.ships.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.build.ships.x3s
@@ -1,0 +1,39 @@
+#name: anarkis.lib.build.ships
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.build.ships.xml
+
+* ===========================================
+* Build a given amount of ships
+* ===========================================
+
+$null = null
+
+$class.list =  get ship type array: maker race=$race class=Fighter
+$class.cnt =  size of array $class.list
+
+$result =  array alloc: size=0
+while $ship.count
+dec $ship.count =
+if $shiptype == null
+$rnd =  = random value from 0 to $class.cnt - 1
+$new.class = $class.list[$rnd]
+else
+$new.class = $shiptype
+end
+
+$rnd =  = random value from 0 to 7 - 1
+$ship = $null -> call script anarkis.lib.createship :  Ship Type=$new.class  location=$sector  race=$race  best weapon ?=$rnd  no.ion=[FALSE]  no ammo=[FALSE]
+append $ship to array $result
+= $ship -> install 1 units of Jumpdrive
+= $ship -> install 1 units of Transporter Device
+
+$ship -> set homebase to $ship.homebase
+
+if $Put.in.Home == [TRUE]
+$ship -> put into environment $ship.homebase ->
+end
+
+end
+
+return $result

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.change.race.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.change.race.x3s
@@ -1,0 +1,14 @@
+#name: anarkis.lib.change.race
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.change.race.xml
+
+$l = $tg -> get ship array from sector/ship/station
+$c =  size of array $l
+while $c
+dec $c =
+$s = $l[$c]
+$s -> set owner race to $race
+end
+$tg -> set owner race to $race
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.clear.shiparray.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.clear.shiparray.x3s
@@ -1,0 +1,16 @@
+#name: anarkis.lib.clear.shiparray
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.clear.shiparray.xml
+
+*$result =  array alloc: size=0
+$cnt =  size of array $ship.list
+while $cnt
+dec $cnt =
+$ship = $ship.list[$cnt]
+if not $ship -> exists
+remove element from array $ship.list at index $cnt
+end
+end
+
+return $ship.list

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.attack.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.attack.x3s
@@ -1,0 +1,77 @@
+#name: anarkis.lib.cmd.attack
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.attack.xml
+
+* ===========================================
+* CMD : Tell a ship to attack a ship with sector following
+* ===========================================
+
+* Init Command
+[THIS] -> set command: COMMAND_ATTACK  target=$victim target2=null par1=null par2=null
+
+$victim.sector = $victim -> get sector
+[THIS] -> set destination to $victim.sector
+[THIS] -> set attack target to $victim
+[THIS] -> set local variable: name='anarkis.acc.skipme' value=[TRUE]
+
+while $victim -> exists
+* - If the victim is of a weird race, cancel
+$victim.race = $victim -> get true owner
+skip if $victim.race
+$victim.race = $victim -> get owner race
+if $victim.race == Neutral Race OR $victim.race == Unknown OR $victim.race == Friendly Race OR $victim.race == [OWNER]
+goto label exit
+end
+
+* - If the victim is player owned, check if enemy
+*$pl.rel = [THIS] -> get relation to race Player
+*if $victim.race == Player AND $pl.rel != Foe
+*goto label exit
+*end
+
+* - If in different sector, we have to go there
+while $victim.sector != [SECTOR]
+skip if $victim -> exists
+goto label exit
+
+$res = FLRET_ERROR
+* - - Try jumping ?
+if [THIS] -> is autojump activated
+$victim.dest = $victim -> get destination
+if $victim.dest == null
+$victim.leader = $victim -> get formation leader
+skip if not $victim.leader
+$victim.dest = $victim.leader -> get destination
+end
+
+if $victim.dest != null
+skip if  is datatyp[ $victim.dest ] == DATATYP_SECTOR
+$victim.dest = $victim.dest -> get sector
+$gate =  get next gate on route from $victim.sector to $victim.dest
+else
+$gate =  get next gate on route from $victim.sector to [SECTOR]
+end
+$res = [THIS] -> call script !move.jump :  gate or sector=$gate  followers should jump too=[TRUE]
+end
+* - - Else move to
+if $res == FLRET_ERROR
+$next.sector = get next sector on route from sector [SECTOR] to sector $victim.sector
+= [THIS] -> call script !move.movetosector :  sector=$next.sector
+end
+= wait 100 ms
+skip if $victim -> exists
+goto label exit
+$victim.sector = $victim -> get sector
+end
+
+* - Here we go i guess
+[THIS] -> set command: COMMAND_ATTACK  target=$victim target2=null par1=null par2=null
+= [THIS] -> call script !fight.attack.object :  the victim=$victim  follow in new sector=[TRUE]  Only attack shields=[FALSE]
+= wait 100 ms
+end
+
+exit:
+[THIS] -> set command: null  target=null target2=null par1=null par2=null
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.attackland.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.attackland.x3s
@@ -1,0 +1,92 @@
+#name: anarkis.lib.cmd.attackland
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.attackland.xml
+
+* ===========================================
+* CMD : Tell a ship to attack a ship and land (with sector follow)
+* ===========================================
+
+* Init Command
+[THIS] -> set command: COMMAND_ATTACK_RETURN  target=$victim target2=$dst par1=null par2=null
+
+$cmd =  array alloc: size=0
+append 'anarkis.lib.cmd.attackland' to array $cmd
+append $victim to array $cmd
+append $dst to array $cmd
+[THIS] -> set local variable: name='anarkis.acc.skipme' value=[TRUE]
+[THIS] -> set local variable: name='anarkis.lib.cmd' value=$cmd
+$autojump = [THIS] -> is autojump activated
+$victim.sector = $victim -> get sector
+[THIS] -> set destination to $victim.sector
+[THIS] -> set attack target to $victim
+
+while $victim -> exists
+* - If the victim is of a weird race, cancel
+$victim.race = $victim -> get true owner
+skip if $victim.race
+$victim.race = $victim -> get owner race
+if $victim.race == Neutral Race OR $victim.race == Unknown OR $victim.race == Friendly Race OR $victim.race == [OWNER]
+goto label exit
+end
+* - If the victim is player owned, check if enemy
+$pl.rel = [THIS] -> get relation to race Player
+if $victim.race == Player AND $pl.rel != Foe
+goto label exit
+end
+
+* - If in different sector, we have to go there
+while $victim.sector != [SECTOR]
+skip if $victim -> exists
+goto label exit
+
+$res = FLRET_ERROR
+* - - Try jumping ?
+if [THIS] -> is autojump activated
+$victim.dest = $victim -> get destination
+if $victim.dest == null
+$victim.leader = $victim -> get formation leader
+skip if not $victim.leader
+$victim.dest = $victim.leader -> get destination
+end
+
+if $victim.dest != null
+skip if  is datatyp[ $victim.dest ] == DATATYP_SECTOR
+$victim.dest = $victim.dest -> get sector
+$gate =  get next gate on route from $victim.sector to $victim.dest
+else
+$gate =  get next gate on route from $victim.sector to [SECTOR]
+end
+$res = [THIS] -> call script !move.jump :  gate or sector=$gate  followers should jump too=[TRUE]
+end
+* - - Else move to
+if $res == FLRET_ERROR
+$next.sector = get next sector on route from sector [SECTOR] to sector $victim.sector
+= [THIS] -> call script !move.movetosector :  sector=$next.sector
+end
+= wait 250 ms
+skip if $victim -> exists
+goto label exit
+$victim.sector = $victim -> get sector
+end
+
+* - Here we go i guess
+[THIS] -> set command: COMMAND_ATTACK_RETURN  target=$victim target2=$dst par1=null par2=null
+= [THIS] -> call script !fight.attack.object :  the victim=$victim  follow in new sector=[TRUE]  Only attack shields=[FALSE]
+= wait 250 ms
+end
+
+exit:
+[THIS] -> set local variable: name='anarkis.job' value=0
+[THIS] -> set local variable: name='anarkis.lib.cmd' value=null
+
+if not $dst -> exists
+[THIS] -> jump out of existence
+return null
+end
+
+[THIS] -> set destination to $dst
+= [THIS] -> call script !ship.cmd.jumpstation.std :  object to land on=$dst  Should followers jump too=[TRUE]
+[THIS] -> set local variable: name='anarkis.acc.skipme' value=null
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.attacksame.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.attacksame.x3s
@@ -1,0 +1,18 @@
+#name: anarkis.lib.cmd.attacksame
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.attacksame.xml
+
+* ===========================================
+* CMD : Wingmates will resume the cmd now
+* ===========================================
+= wait 2000 ms
+
+$a = $leader -> get attack target
+
+[THIS] -> set attack target to $a
+[THIS] -> set local variable: name='anarkis.acc.skipme' value=[TRUE]
+= [THIS] -> call script !ship.cmd.attacksame.std :  the target=$leader  stop if leader is docked=[TRUE]
+[THIS] -> set local variable: name='anarkis.acc.skipme' value=null
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.dock.all.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.dock.all.x3s
@@ -1,0 +1,13 @@
+#name: anarkis.lib.cmd.dock.all
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.dock.all.xml
+
+[THIS] -> start task 896 with script anarkis.lib.dockall.secure and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+while [TRUE]
+= wait 1000 ms
+skip if [THIS] -> is script anarkis.lib.dockall.secure on stack of task=896
+break
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.dock.custom.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.dock.custom.x3s
@@ -1,0 +1,14 @@
+#name: anarkis.lib.cmd.dock.custom
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.dock.custom.xml
+
+[THIS] -> start task 896 with script anarkis.lib.dockcustom.secure and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+
+while [TRUE]
+= wait 1000 ms
+skip if [THIS] -> is script anarkis.lib.dockcustom.secure on stack of task=896
+break
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.donothing.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.donothing.x3s
@@ -1,0 +1,7 @@
+#name: anarkis.lib.cmd.donothing
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.donothing.xml
+
+= wait 20 ms
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.jumpnearobject.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.jumpnearobject.x3s
@@ -1,0 +1,32 @@
+#name: anarkis.lib.cmd.jumpnearobject
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.jumpnearobject.xml
+
+* ===========================================
+* This command allows a ship to jump to an object. To the contrary of
+* move.jumptoposition, it will stop if the object get destroyed
+* ===========================================
+
+skip if $object -> exists
+return null
+
+$object.sector = $object -> get sector
+$pos.array = $object -> get position as array
+$p.x = $pos.array[0]
+$p.y = $pos.array[1]
+$p.z = $pos.array[2]
+append $object.sector to array $pos.array
+
+= [THIS] -> call script !move.jumptogate.nearest :  targetpos=$pos.array  should followers jump too=[TRUE]
+= [THIS] -> call script !move.movetosector :  sector=$object.sector
+
+while $object -> exists
+$flt.ret = [THIS] -> move to position: x=$p.x y=$p.y z=$p.z with precision 5000 m
+if $flt.ret != FLRET_INTERRUPTED
+break
+end
+= wait randomly from 100 to 200 ms
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.jumptobeacon.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.jumptobeacon.x3s
@@ -1,0 +1,22 @@
+#name: anarkis.lib.cmd.jumptobeacon
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.jumptobeacon.xml
+
+
+skip if $beacon -> exists
+return null
+
+$object.sector = $beacon -> get sector
+$pos.array = $beacon -> get position as array
+$p.x = $pos.array[0]
+$p.y = $pos.array[1]
+$p.z = $pos.array[2]
+append $object.sector to array $pos.array
+
+= [THIS] -> use jump drive: target=$object.sector
+if [SECTOR] == $object.sector
+[THIS] -> set position: x=$p.x y=$p.y z=$p.z
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.killandland.timeout.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.cmd.killandland.timeout.x3s
@@ -1,0 +1,111 @@
+#name: anarkis.lib.cmd.killandland.timeout
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.killandland.timeout.xml
+
+* ===========================================
+* Altered 2.0a official script to allow a timeout
+* ===========================================
+* Added :
+* - Timeout
+* - Runaway code if damaged
+* - Uses jumptostation instead of movetostation
+* ===========================================
+* Removed : OWP, resupply, player code
+* ===========================================
+
+skip if [THIS] -> is of class Ship
+return null
+
+skip if not [THIS] -> is docked
+= [THIS] -> call script !move.undock :
+
+$returntostation = [FALSE]
+
+$isBig = [THIS] -> is of class M2
+skip if $isBig
+$isBig = [THIS] -> is of class M1
+
+
+* pirate fighter in pirate sector..
+$secowner = [SECTOR] -> get owner race
+$ispirate = $secowner == Pirates AND [OWNER] == Pirates
+
+skip if $range
+$range = [THIS] -> get scanner range
+$halfrange = $range / 2
+$refuel.runs = 0
+
+* Added : timeout
+$pltime = playing time
+$endtime = $pltime + $timeout
+
+while $pltime < $endtime
+= wait 10 ms
+$pltime = playing time
+
+* -------------------------------------------------------------------------
+* Targeting
+* -------------------------------------------------------------------------
+* find enemy in range.
+$enemy = [THIS] -> call script !fight.targeting :  the max scan range=$range  refpos array   x y z=$arefpos  Target Class=null
+
+* Pirates target a station nearby if no other target
+if ! $enemy AND $ispirate
+if not  = random value from 0 to 20 - 1
+$enemy = [THIS] -> call script !fight.targeting :  the max scan range=5000  refpos array   x y z=$arefpos  Target Class=Station
+end
+end
+
+* -------------------------------------------------------------------------
+* engage enemy if found
+* -------------------------------------------------------------------------
+$hull = [THIS] -> get hull percent
+$enemy.exists = $enemy -> exists
+if $hull > 92 AND $enemy.exists
+= [THIS] -> call script !fight.attack.object :  the victim=$enemy  follow in new sector=null
+$returntostation = [FALSE]
+inc $refuel.runs =
+else
+$stok = $station -> exists
+if not ( $stok AND $returntostation )
+$returntostation = [TRUE]
+if $arefpos AND $range
+$dist = [THIS] -> get distance to: position array=$arefpos
+if $dist > $range AND $moveable.ship
+$x = $arefpos[0]
+$y = $arefpos[1]
+$z = $arefpos[2]
+= [THIS] -> move to position: x=$x y=$y z=$z with precision $halfrange m
+continue
+end
+end
+if [THIS] -> is in active sector
+$time =  = random value from 10000 to 20000 - 1
+else
+$time =  = random value from 50000 to 59000 - 1
+end
+if $noidle
+= wait $time ms
+else
+$time = $time / 1000
+= [THIS] -> call script !move.idle.timeout :  timeout in sec=$time  wait while docked=[FALSE]
+end
+else if [ENVIRONMENT] != $station AND $moveable.ship
+$station.sector = $station -> get sector
+if $station.sector != [SECTOR]
+= [THIS] -> call script !move.jumptostation :  station=$station  should followers jump too=[TRUE]
+else
+= [THIS] -> call script !move.movetostation :  station=$station
+end
+skip if not [ENVIRONMENT] == $station
+return null
+= wait randomly from 1000 to 3000 ms
+else
+return null
+end
+end
+
+$pltime = playing time
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.create.marine.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.create.marine.x3s
@@ -1,0 +1,21 @@
+#name: anarkis.lib.create.marine
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.create.marine.xml
+
+skip if $ship -> exists
+return null
+
+$pass = [THIS] -> call script anarkis.lib.create.passenger :  ship=$ship  race=$race
+$pass -> train passenger to marine
+
+$skill =  = random value from 20 to 80 - 1
+$pass -> set marine skill: fighting=$skill
+$skill =  = random value from 20 to 80 - 1
+$pass -> set marine skill: hacking=$skill
+$skill =  = random value from 20 to 80 - 1
+$pass -> set marine skill: mechanical=$skill
+$skill =  = random value from 20 to 80 - 1
+$ship -> set marine skill: engineering=$skill
+
+return $pass

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.create.passenger.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.create.passenger.x3s
@@ -1,0 +1,16 @@
+#name: anarkis.lib.create.passenger
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.create.passenger.xml
+
+skip if $ship -> exists
+return null
+skip if $race
+$race = $ship -> get true owner
+
+$p.name = get random name: race=$race
+$p.face =  = random value from 0 to 4 - 1
+$p.voice =  = random value from 0 to 4 - 1
+$pass = $ship -> create passenger in ship: name=$p.name race=$race voice=$p.voice face=$p.face
+
+return $pass

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.createfactory.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.createfactory.x3s
@@ -1,0 +1,41 @@
+#name: anarkis.lib.createfactory
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.createfactory.xml
+
+* ===========================================
+* Build a factory according to params
+* ===========================================
+
+$x = $location[0]
+$y = $location[1]
+$z = $location[2]
+$sector = $location[3]
+$select =  create station: type=$station.type owner=$race addto=$sector x=$x y=$y z=$z
+$select -> add default wares to station/dock
+$v1 = $select -> get maximum shield strength
+$select -> set current shield strength to $v1
+
+$select -> factory production task: on=[FALSE]
+$arr = $select -> get tradeable ware array from station
+$v1 =  size of array $arr
+while $v1
+dec $v1 =
+$v2 = $arr[$v1]
+if $select -> uses ware $v2 as product
+$select -> remove product from factory or dock: $v2
+else if $select -> uses ware $v2 as primary resource
+$select -> remove primary resource from factory: $v2
+else
+$select -> remove second resource from factory: $v2
+end
+end
+skip if not $product
+$select -> add product to factory or dock: $product
+skip if not $ressource1
+$select -> add primary resource to factory: $ressource1
+skip if not $ressource2
+$select -> add primary resource to factory: $ressource2
+$select -> factory production task: on=[TRUE]
+
+return $select

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.createship.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.createship.x3s
@@ -1,0 +1,54 @@
+#name: anarkis.lib.createship
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.createship.xml
+
+* Create ship
+$x =  = random value from -10000 to 10001 - 1
+$y =  = random value from -10000 to 10001 - 1
+$z =  = random value from -10000 to 10001 - 1
+$r =  create ship: type=$shiptype owner=$owner.race addto=$location x=$x y=$y z=$z
+$r -> set pirate cover state to [FALSE]
+* Add max shields
+$nb.shield = $r -> get number of shield bays
+$type.shield = $r -> get max. shield type that can be installed
+= $r -> install $nb.shield units of $type.shield
+* Extensions
+$x = $r -> get max upgrades for upgrade Cargo Bay Extension
+= $r -> install $x units of Cargo Bay Extension
+$x = $r -> get max upgrades for upgrade Engine Tuning
+= $r -> install $x units of Engine Tuning
+$x = $r -> get max upgrades for upgrade Rudder Optimisation
+= $r -> install $x units of Rudder Optimisation
+* Softwares
+= $r -> call script anarkis.lib.add.software :
+* Weapons
+$turret.cnt = $r -> get number of turrets
+while $turret.cnt
+dec $turret.cnt =
+= $r -> call script anarkis.lib.armturret :  turret ID=$turret.cnt  weapon selection mode=$weapon.type  no ion=$no.ion  no ammo weapons=$no.ammo
+end
+
+* Missiles
+$array = $r -> get compatible missile array
+$cnt =  size of array $array
+if $cnt
+$id =  = random value from 0 to $cnt - 1
+$select.a = $array[$id]
+$id =  = random value from 0 to $cnt - 1
+$select.b = $array[$id]
+if $r -> is of class M8
+$x =  = random value from 15 to 25 - 1
+$y =  = random value from 15 to 25 - 1
+else if $r -> is missile boat
+$x =  = random value from 25 to 60 - 1
+$y =  = random value from 25 to 60 - 1
+else
+$x =  = random value from 2 to 5 - 1
+$y =  = random value from 2 to 5 - 1
+end
+= $r -> install $x units of $select.a
+= $r -> install $y units of $select.b
+end
+
+return $r

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.addship.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.addship.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.lib.custowned.addship
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.addship.xml
+
+$var = [THIS] -> get local variable: name='anarkis.owned'
+append $ship to array $var
+[THIS] -> set local variable: name='anarkis.owned' value=$var
+return $var

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.cleanarr.f.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.cleanarr.f.x3s
@@ -1,0 +1,15 @@
+#name: anarkis.lib.custowned.cleanarr.f
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.cleanarr.f.xml
+
+$var = $from -> get local variable: name='anarkis.owned'
+$cnt =  size of array $var
+while $cnt
+dec $cnt =
+$ship = $var[$cnt]
+skip if $ship -> exists
+remove element from array $var at index $cnt
+end
+$from -> set local variable: name='anarkis.owned' value=$var
+return $var

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.cleanarray.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.cleanarray.x3s
@@ -1,0 +1,15 @@
+#name: anarkis.lib.custowned.cleanarray
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.cleanarray.xml
+
+$var = [THIS] -> get local variable: name='anarkis.owned'
+$cnt =  size of array $var
+while $cnt
+dec $cnt =
+$ship = $var[$cnt]
+skip if $ship -> exists
+remove element from array $var at index $cnt
+end
+[THIS] -> set local variable: name='anarkis.owned' value=$var
+return $var

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.getarray.f.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.getarray.f.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.lib.custowned.getarray.f
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.getarray.f.xml
+
+
+= [THIS] -> call script anarkis.lib.custowned.cleanarr.f :  from=$from
+$var = $from -> get local variable: name='anarkis.owned'
+return $var

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.getarray.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.getarray.x3s
@@ -1,0 +1,8 @@
+#name: anarkis.lib.custowned.getarray
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.getarray.xml
+
+= [THIS] -> call script anarkis.lib.custowned.cleanarray :
+$var = [THIS] -> get local variable: name='anarkis.owned'
+return $var

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.getdocked.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.getdocked.x3s
@@ -1,0 +1,20 @@
+#name: anarkis.lib.custowned.getdocked
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.getdocked.xml
+
+$docked =  array alloc: size=0
+
+= [THIS] -> call script anarkis.lib.custowned.cleanarray :
+$array = [THIS] -> get local variable: name='anarkis.owned'
+$cnt =  size of array $array
+
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$env = $select -> get environment
+skip if not $env == [THIS]
+append $select to array $docked
+end
+
+return $docked

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.init.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.init.x3s
@@ -1,0 +1,8 @@
+#name: anarkis.lib.custowned.init
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.init.xml
+
+$var =  array alloc: size=0
+[THIS] -> set local variable: name='anarkis.owned' value=$var
+return $var

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.kill.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.custowned.kill.x3s
@@ -1,0 +1,7 @@
+#name: anarkis.lib.custowned.kill
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.kill.xml
+
+[THIS] -> set local variable: name='anarkis.owned' value=null
+return $var

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.disable.ai.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.disable.ai.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.lib.disable.ai
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.disable.ai.xml
+
+[THIS] -> set race logic control enabled to [FALSE]
+[THIS] -> disable ship rebuild
+[THIS] -> set StartAction enabled to [FALSE]
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.display.message.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.display.message.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.lib.display.message
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.display.message.xml
+
+$menu =  create custom menu array
+$message = sprintf: pageid=$page.id textid=$text.id, $v1, $v2, $v3, null, null
+add custom menu heading to array $menu: title='-'
+add custom menu item to array $menu: text='OK' returnvalue=-1
+add custom menu info line to array $menu: text=$message
+$res =  open custom menu: title=$title description=null option array=$menu
+return $res

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.dockall.adsonly.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.dockall.adsonly.x3s
@@ -1,0 +1,127 @@
+#name: anarkis.lib.dockall.adsonly
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.dockall.adsonly.xml
+
+* ===========================================
+* Securely Dock All Ships to a Carrier / Station
+* ===========================================
+
+$ship.list = $carrier -> call script anarkis.acc.lib.get.adsonly :
+$global =  size of array $ship.list
+$myowner = $carrier -> get owner race
+
+* 1st Pass
+while $global
+$ship.count =  size of array $ship.list
+
+$pl.sec = [PLAYERSHIP] -> get sector
+$carrier.sector = $carrier -> get sector
+if $pl.sec == $carrier.sector
+$OOS = [FALSE]
+else
+$OOS = [TRUE]
+end
+
+while $ship.count
+= wait 10 ms
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$env = $ship -> get environment
+if not $carrier -> is docking possible of $ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $env == $carrier
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> exists
+remove element from array $ship.list at index $ship.count
+continue
+end
+$ship.owner = $ship -> get owner race
+if not $ship.owner == $myowner
+remove element from array $ship.list at index $ship.count
+continue
+end
+skip if not $ship -> is script anarkis.acc.task.hullcheck on stack of task=900
+$ship -> start task 900 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+if not $ship -> is task 0 in use
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=$carrier arg2=null arg3=null arg4=null arg5=null
+continue
+end
+
+$runthis = [FALSE]
+skip if not $ship -> is script !move.movetostation on stack of task=0
+$runthis = [TRUE]
+skip if not $ship -> is script !ship.cmd.retreat.std on stack of task=0
+$runthis = [TRUE]
+$isjump = $ship -> is script !move.jumptosector on stack of task=0
+
+if $runthis == [TRUE]
+
+$ship.sec = $ship -> get sector
+* - - Don't touch ships in different sector or they'll go sluggish
+skip if [SECTOR] == $ship.sec
+continue
+
+$transport.device = $ship -> get true amount of ware Transporter Device in cargo bay
+$distance = get distance between $ship and $carrier
+
+* - - Teleport ships with transporter device (or when OOS)
+if $distance <= 5000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+* - - Same for OOS at smaller distance to avoid rare bug
+if $distance <= 2000 AND $OOS == [TRUE]
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+* - Check for buggy ships
+$speed = $ship -> get current speed
+if $speed == 0 AND $isjump != [TRUE]
+* - - Transporter Device Teleportation possible ?
+if $distance <= 6000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+* - - - Go Idle and hope it'll work next try
+else
+START $ship -> call script !ship.cmd.idle.std :
+= wait 5000 ms
+end
+end
+else
+$env = $ship -> get environment
+if $env != [THIS]
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=$carrier arg2=null arg3=null arg4=null arg5=null
+else if $env == [THIS]
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+end
+end
+$global =  size of array $ship.list
+= wait 5000 ms
+end
+
+return null
+
+dodock:
+$ship -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$ship -> set destination to null
+$ship -> set command: COMMAND_NONE  target=null target2=null par1=null par2=null
+$v1 = $ship -> get maximum shield strength
+$ship -> set current shield strength to $v1
+endsub
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.dockall.full.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.dockall.full.x3s
@@ -1,0 +1,129 @@
+#name: anarkis.lib.dockall.full
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.dockall.full.xml
+
+* ===========================================
+* Securely Dock All Ships to a Carrier / Station
+* ===========================================
+
+
+if $ads.only
+$owned.list = $carrier -> call script anarkis.acc.lib.get.adsonly :
+else
+$owned.list = $carrier -> get owned ships: class/type=Moveable Ship
+end
+$owned.cnt =  size of array $owned.list
+while $owned.cnt
+dec $owned.cnt =
+$ship = $owned.list[$owned.cnt]
+end
+
+$myowner = $carrier -> get owner race
+
+
+* 1st Pass
+while $global
+$ship.count =  size of array $ship.list
+
+while $ship.count
+
+= wait 10 ms
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$env = $ship -> get environment
+if not $carrier -> is docking possible of $ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $env == $carrier
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> exists
+remove element from array $ship.list at index $ship.count
+continue
+end
+$ship.owner = $ship -> get owner race
+if not $ship.owner == $myowner
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> is task 0 in use
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=$carrier arg2=null arg3=null arg4=null arg5=null
+continue
+end
+
+$runthis = [FALSE]
+skip if not $ship -> is script !move.movetostation on stack of task=0
+$runthis = [TRUE]
+skip if not $ship -> is script !ship.cmd.retreat.std on stack of task=0
+$runthis = [TRUE]
+$isjump = $ship -> is script !move.jumptosector on stack of task=0
+
+if $runthis == [TRUE]
+
+$ship.sec = $ship -> get sector
+* - - Don't touch ships in different sector or they'll go sluggish
+skip if [SECTOR] == $ship.sec
+continue
+
+$transport.device = $ship -> get true amount of ware Transporter Device in cargo bay
+$distance = get distance between $ship and $carrier
+
+* - - Teleport ships with transporter device (or when OOS)
+if $distance <= 5000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+* - - Same for OOS at smaller distance to avoid rare bug
+if $distance <= 2000 AND $OOS == [TRUE]
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+* - Check for buggy ships
+$speed = $ship -> get current speed
+if $speed == 0 AND $isjump != [TRUE]
+* - - Transporter Device Teleportation possible ?
+if $distance <= 6000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+* - - - Go Idle and hope it'll work next try
+else
+START $ship -> call script !ship.cmd.idle.std :
+= wait 5000 ms
+end
+end
+else
+$env = $ship -> get environment
+if $env != [THIS]
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=$carrier arg2=null arg3=null arg4=null arg5=null
+else if $env == [THIS]
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+end
+end
+$global =  size of array $ship.list
+= wait 5000 ms
+end
+
+return null
+
+dodock:
+$ship -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$ship -> set destination to null
+$ship -> set command: COMMAND_NONE  target=null target2=null par1=null par2=null
+$v1 = $ship -> get maximum shield strength
+$ship -> set current shield strength to $v1
+endsub
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.dockall.insector.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.dockall.insector.x3s
@@ -1,0 +1,91 @@
+#name: anarkis.lib.dockall.insector
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.dockall.insector.xml
+
+* ===========================================
+* Securely Dock All Ships to a Carrier / Station
+* ===========================================
+
+$ship.list = $carrier -> get owned ships: class/type=Moveable Ship
+$global =  size of array $ship.list
+$my.owner = $carrier -> get owner race
+* 1st Pass
+while $global
+$ship.count =  size of array $ship.list
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$env = $ship -> get environment
+if not $carrier -> is docking possible of $ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $env == $carrier
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> exists
+remove element from array $ship.list at index $ship.count
+continue
+end
+$ship.owner = $ship -> get owner race
+if not $ship.owner == $my.owner
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+if $ship -> is script !move.movetostation on stack of task=0
+$distance = get distance between $ship and $carrier
+$transport.device = $ship -> get true amount of ware Transporter Device in cargo bay
+
+* - - Teleport ships with transporter device
+if $distance <= 5000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+* - Check for buggy ships
+$speed = $ship -> get current speed
+if $speed == 0
+* - - Transporter Device Teleportation possible ?
+$distance = get distance between $ship and $carrier
+if $distance <= 6000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+* - - - Go Idle and hope it'll work next try
+else
+START $ship -> call script !ship.cmd.idle.std :
+= wait 5000 ms
+end
+end
+else
+$env = $ship -> get environment
+if $env != [THIS]
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=$carrier arg2=null arg3=null arg4=null arg5=null
+else if $env == [THIS]
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+end
+end
+$global =  size of array $ship.list
+= wait 5000 ms
+end
+
+return null
+
+dodock:
+$ship -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$ship -> set command: COMMAND_NONE  target=null target2=null par1=null par2=null
+$ship -> set destination to null
+$v1 = $ship -> get maximum shield strength
+$ship -> set current shield strength to $v1
+endsub
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.dockall.secure.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.dockall.secure.x3s
@@ -1,0 +1,92 @@
+#name: anarkis.lib.dockall.secure
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.dockall.secure.xml
+
+* ===========================================
+* Securely Dock All Ships to a Carrier / Station
+* ===========================================
+
+$ship.list = $carrier -> get owned ships: class/type=Moveable Ship
+$global =  size of array $ship.list
+
+* 1st Pass
+while $global
+$ship.count =  size of array $ship.list
+while $ship.count
+= wait 50 ms
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$env = $ship -> get environment
+if not $carrier -> is docking possible of $ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $env == $carrier
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> exists
+remove element from array $ship.list at index $ship.count
+continue
+end
+skip if not $ship -> is script anarkis.acc.task.hullcheck on stack of task=900
+$ship -> start task 900 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+
+if $ship -> is script !move.movetostation on stack of task=0
+
+$distance = get distance between $ship and $carrier
+$transport.device = $ship -> get true amount of ware Transporter Device in cargo bay
+
+* - - Teleport ships with transporter device
+if $distance <= 5000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+* - Check for buggy ships
+$speed = $ship -> get current speed
+if $speed == 0
+* - - Transporter Device Teleportation possible ?
+$distance = get distance between $ship and $carrier
+if $distance <= 6000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+* - - - Go Idle and hope it'll work next try
+else
+START $ship -> call script !ship.cmd.idle.std :
+= wait 1000 ms
+end
+end
+else
+$env = $ship -> get environment
+if $env != [THIS]
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=$carrier arg2=null arg3=null arg4=null arg5=null
+else if $env == [THIS]
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+end
+end
+$global =  size of array $ship.list
+= wait 4000 ms
+end
+
+return null
+
+dodock:
+$ship -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$ship -> set command: COMMAND_NONE  target=null target2=null par1=null par2=null
+$ship -> set destination to null
+$v1 = $ship -> get maximum shield strength
+$ship -> set current shield strength to $v1
+
+endsub
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.dockcustom.secure.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.dockcustom.secure.x3s
@@ -1,0 +1,68 @@
+#name: anarkis.lib.dockcustom.secure
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.dockcustom.secure.xml
+
+* ===========================================
+* Securely Dock All Ships to a Carrier / Station
+* ===========================================
+
+$test.arr = [THIS] -> call script anarkis.lib.custowned.getarray :
+$glb.cnt =  size of array $test.arr
+dec $glb.cnt =
+
+* Arrays are POINTER type so we must make a real copy before doing something on it
+$ship.list =  clone array $test.arr : index 0 ... $glb.cnt
+$glb.cnt =  size of array $ship.list
+
+* 1st Pass
+while $glb.cnt
+$ship.count =  size of array $ship.list
+
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$env = $ship -> get environment
+if $env == [THIS]
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> exists
+remove element from array $ship.list at index $ship.count
+continue
+end
+* - Check for buggy ships
+if $ship -> is script !move.movetostation on stack of task=0
+$speed = $ship -> get current speed
+if $speed == 0
+* - - Transporter Device Teleportation possible ?
+$transport.device = $ship -> get amount of ware Transporter Device in cargo bay
+$distance = get distance between $ship and [THIS]
+if $distance <= 5000 AND $transport.device == 1
+
+$ship -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$ship -> put into environment [THIS] ->
+$ship -> set command: COMMAND_NONE  target=null target2=null par1=null par2=null
+$ship -> set destination to null
+remove element from array $ship.list at index $ship.count
+continue
+* - - Go Idle and hope it'll work next try
+else
+START $ship -> call script !ship.cmd.idle.std :
+= wait 5000 ms
+end
+end
+else
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+end
+end
+$glb.cnt =  size of array $ship.list
+* - Cancel if no dock bay free
+$test.dockbaysize = [THIS] -> get dock bay size
+$test.landedcount = [THIS] -> get number of landed ships
+skip if not $test.dockbaysize <= $test.landedcount
+break
+= wait 5000 ms
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.encyclopedia.chapter.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.encyclopedia.chapter.x3s
@@ -1,0 +1,43 @@
+#name: anarkis.lib.encyclopedia.chapter
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.encyclopedia.chapter.xml
+
+$race.arr = [THIS] -> call script anarkis.lib.get.race.array :
+$race.cnt =  size of array $race.arr
+while $race.cnt
+dec $race.cnt =
+$race = $race.arr[$race.cnt]
+set discovered status: type=$race status=$show
+
+if $include.ships
+$ship.arr =  get ship type array: maker race=$race class=Ship
+$ship.cnt =  size of array $ship.arr
+while $ship.cnt
+dec $ship.cnt =
+$ship = $ship.arr[$ship.cnt]
+set discovered status: type=$ship status=$show
+end
+end
+
+if $include.stations
+$st.arr =  get station array: of race $race class/type=Station
+$st.cnt =  size of array $st.arr
+while $st.cnt
+dec $st.cnt =
+$st = $st.arr[$st.cnt]
+$st = $st -> get ware type code of object
+set discovered status: type=$st status=$show
+end
+end
+
+end
+
+$cnt =  get number of subtypes of maintype $chapter
+while $cnt
+dec $cnt =
+$ware =  get ware from maintype $chapter and subtype $cnt
+set discovered status: type=$ware status=$show
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.encyclopedia.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.encyclopedia.x3s
@@ -1,0 +1,42 @@
+#name: anarkis.lib.encyclopedia
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.encyclopedia.xml
+
+$race.arr = [THIS] -> call script anarkis.lib.get.race.array :
+$race.cnt =  size of array $race.arr
+while $race.cnt
+dec $race.cnt =
+$race = $race.arr[$race.cnt]
+set discovered status: type=$race status=$show
+
+$ship.arr =  get ship type array: maker race=$race class=Ship
+$ship.cnt =  size of array $ship.arr
+while $ship.cnt
+dec $ship.cnt =
+$ship = $ship.arr[$ship.cnt]
+set discovered status: type=$ship status=$show
+end
+
+$st.arr =  get station array: of race $race class/type=Station
+$st.cnt =  size of array $st.arr
+while $st.cnt
+dec $st.cnt =
+$st = $st.arr[$st.cnt]
+$st = $st -> get ware type code of object
+set discovered status: type=$st status=$show
+end
+end
+
+$m.cnt = 20
+while $m.cnt
+dec $m.cnt =
+$cnt =  get number of subtypes of maintype $m.cnt
+while $cnt
+dec $cnt =
+$ware =  get ware from maintype $m.cnt and subtype $cnt
+set discovered status: type=$ware status=$show
+end
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.bycargovalue.adv.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.bycargovalue.adv.x3s
@@ -1,0 +1,22 @@
+#name: anarkis.lib.get.bycargovalue.adv
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.bycargovalue.adv.xml
+
+$class =  array alloc: size=3
+$class[0] = TS
+$class[1] = TP
+$class[2] = TM
+$array = [THIS] -> call script anarkis.lib.get.ships.var :  array of class=$class  force race=null  jump.range=$jump.range  ignore khaak/xenon?=[TRUE]  ignore pirate/yaki?=$ignore.pirate  ignore civilians?=[TRUE]  ignore player?=$ignore.player  local.var=null  from=$from
+$cnt =  size of array $array
+$result =  array alloc: size=0
+while $cnt
+dec $cnt =
+$ship = $array[$cnt]
+$value = [THIS] -> call script anarkis.lib.get.ship.cargovalue :  ship=$ship
+if $value < $mincargo
+remove element from array $array at index $cnt
+end
+end
+
+return $array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.bycargovalue.fro.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.bycargovalue.fro.x3s
@@ -1,0 +1,17 @@
+#name: anarkis.lib.get.bycargovalue.fro
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.bycargovalue.fro.xml
+
+$class =  array alloc: size=2
+$class[0] = TS
+$class[1] = TP
+$rel = $from -> get relation to race Player
+if $rel == Foe
+$include = [FALSE]
+else
+$include = [TRUE]
+end
+$array = [THIS] -> call script anarkis.lib.get.bycargovalue.adv :  ref obj=$from  jumprange=$jump.range  min cargo=$mincargo  ignore pirate/yaki=[FALSE]  ignore player ?=$include
+
+return $array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.bycargovalue.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.bycargovalue.x3s
@@ -1,0 +1,28 @@
+#name: anarkis.lib.get.bycargovalue
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.bycargovalue.xml
+
+$class =  array alloc: size=2
+$class[0] = TS
+$class[1] = TP
+$rel = [THIS] -> get relation to race Player
+if $rel == Foe
+$include = [FALSE]
+else
+$include = [TRUE]
+end
+*$array = [THIS] -> call script anarkis.lib.get.ships.from :  array of class=$class  force race=null  jump.range=$jump.range  ignore khaak/xenon?=[FALSE]  ignore pirate/yaki?=[FALSE]  ignore civilians?=[FALSE]  ignore player?=$include  from=$ship
+$array = [THIS] -> call script anarkis.lib.get.ships.var :  array of class=$class  force race=null  jump.range=$jump.range  ignore khaak/xenon?=[TRUE]  ignore pirate/yaki?=[FALSE]  ignore civilians?=[FALSE]  ignore player?=$include  local.var=null  from=$ship
+$cnt =  size of array $array
+$result =  array alloc: size=0
+while $cnt
+dec $cnt =
+$ship = $array[$cnt]
+$value = [THIS] -> call script anarkis.lib.get.ship.cargovalue :  ship=$ship
+if $value < $mincargo
+remove element from array $array at index $cnt
+end
+end
+
+return $array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.dockedowned.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.dockedowned.x3s
@@ -1,0 +1,30 @@
+#name: anarkis.lib.get.dockedowned
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.dockedowned.xml
+
+$ship.array = [THIS] -> get ship array from sector/ship/station
+$ship.cnt =  size of array $ship.array
+while $ship.cnt
+$remove = [FALSE]
+dec $ship.cnt =
+$test.ship = $ship.array[$ship.cnt]
+$homebase = $test.ship -> get homebase
+skip if $test.ship -> is of class $ship.class
+$remove = [TRUE]
+$skipship = $test.ship -> get local variable: name='anarkis.skipme'
+if ( $skipship == [TRUE] ) OR ( [THIS] != $homebase )
+$remove = [TRUE]
+end
+if $localvar
+$var.result = $test.ship -> get local variable: name=$localvar
+if not $var.result == [TRUE]
+$remove = [TRUE]
+end
+end
+if $remove == [TRUE]
+remove element from array $ship.array at index $ship.cnt
+end
+end
+
+return $ship.array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.fighter.array.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.fighter.array.x3s
@@ -1,0 +1,7 @@
+#name: anarkis.lib.get.fighter.array
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.fighter.array.xml
+
+$selected.array = $dock -> get owned ships: class/type=Fighter
+return $selected.array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.military.array.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.military.array.x3s
@@ -1,0 +1,70 @@
+#name: anarkis.lib.get.military.array
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.military.array.xml
+
+* ===========================================
+* Find an array of military ships in the vecinity
+* ===========================================
+
+$null = null
+
+$class.array =  array alloc: size=0
+append M3 to array $class.array
+append M6 to array $class.array
+append M7 to array $class.array
+append M8 to array $class.array
+append M2 to array $class.array
+append M1 to array $class.array
+$class.cnt =  size of array $class.array
+
+$military.array =  array alloc: size=0
+
+
+if $jump.range > 0
+$sector.list = [THIS] -> find all sectors within $jump.range jumps: Only known sectors=[FALSE]
+else
+$sector.list =  array alloc: size=0
+append [SECTOR] to array $sector.list
+end
+
+$cnt =  size of array $sector.list
+* For all sectors
+while $cnt
+dec $cnt =
+$sector = $sector.list[$cnt]
+$ship.array = $sector -> get ship array from sector/ship/station
+$cnt.ship =  size of array $ship.array
+* - For each ship in sector
+while $cnt.ship
+= wait 20 ms
+dec $cnt.ship =
+$test.ship = $ship.array[$cnt.ship]
+* - - Check Race
+$owner = $test.ship -> get owner race
+if $owner == Pirates OR $owner == Yaki OR $owner == Goner
+continue
+end
+if $ignore.player == [TRUE] AND $owner == Player
+continue
+end
+* - - Check Laser strength
+$laser = $test.ship -> get current laser strength
+if $laser == 0
+continue
+end
+* - - Check class
+$ship.class = $test.ship -> get object class
+$x = $class.cnt
+while $x
+dec $x =
+$test.class = $class.array[$x]
+if $ship.class == $test.class
+append $test.ship to array $military.array
+break
+end
+end
+end
+end
+
+return $military.array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.militarybase.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.militarybase.x3s
@@ -1,0 +1,47 @@
+#name: anarkis.lib.get.militarybase
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.militarybase.xml
+
+$military.types =  array alloc: size=0
+append Military Outpost to array $military.types
+append OTAS HQ to array $military.types
+append Terracorp HQ to array $military.types
+append Jonferco Headquarters to array $military.types
+append Plutarch Mining Corporation HQ to array $military.types
+append Atreus Headquarters to array $military.types
+append Military Outpost to array $military.types
+append Military Outpost to array $military.types
+append Strong Arms HQ to array $military.types
+append Military Outpost to array $military.types
+append Military Outpost to array $military.types
+append NMMC Headquarters to array $military.types
+append Duke's Haven to array $military.types
+append Orbital Defence Station to array $military.types
+append Orbital Defence Station to array $military.types
+append Military Base to array $military.types
+append Orbital Defence Station to array $military.types
+append Orbital Patrol Base to array $military.types
+append Headquarters to array $military.types
+append Military Base to array $military.types
+append Orbital Defence Station to array $military.types
+$military.cnt =  size of array $military.types
+
+
+$result =  array alloc: size=0
+
+$sector.stations =  find station: sector=$sector class or type=Dock race=$race flags=[Find.Multiple] refobj=null maxdist=null maxnum=100 refpos=null
+$cnt =  size of array $sector.stations
+while $cnt
+dec $cnt =
+$select = $sector.stations[$cnt]
+$type = $select -> get ware type code of object
+skip if not  find $type in array: $military.types
+append $select to array $result
+end
+
+$cnt =  size of array $result
+skip if $cnt
+return null
+
+return $result

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.plsector.array.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.plsector.array.x3s
@@ -1,0 +1,39 @@
+#name: anarkis.lib.get.plsector.array
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.plsector.array.xml
+
+* ===========================================
+* Retrieve an array of sectors 'owned' by the player
+* ===========================================
+* This script may take a while to run given the amount of player owned stations
+
+$station.array =  get station array: of race Player class/type=Station
+$station.count =  size of array $station.array
+$sector.array =  array alloc: size=0
+
+while $station.count
+dec $station.count =
+$station = $station.array[$station.count]
+$station.sector = $station -> get sector
+$jump.distance = get jumps from sector [SECTOR] to sector $station.sector
+$sector.already =  find $station.sector in array: $sector.array
+skip if $jump.distance > $max.jump OR $sector.already == [TRUE]
+append $station.sector to array $sector.array
+= wait 100 ms
+end
+
+$sector.count =  size of array $sector.array
+
+while $sector.count
+dec $sector.count =
+$sector = $sector.array[$sector.count]
+$station.array =  find station: sector=$sector class or type=Station race=Player flags=[Find.Multiple] refobj=null maxdist=null maxnum=100 refpos=null
+$station.count =  size of array $station.array
+if $station.count < $min.station
+remove element from array $sector.array at index $sector.count
+end
+= wait 100 ms
+end
+
+return $sector.array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.plsector.pership.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.plsector.pership.x3s
@@ -1,0 +1,44 @@
+#name: anarkis.lib.get.plsector.pership
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.plsector.pership.xml
+
+* ===========================================
+* Retrieve a sector with a bunch of ships owned by the player
+* ===========================================
+* This script may take a while to execute given the amount of player owned ships
+* TC Fix : Speed improvement
+* TODO : Speed hack through 2 row array
+
+$ship.array =  get ship array: of race Player class/type=Moveable Ship
+$ship.count =  size of array $ship.array
+$sector.array =  array alloc: size=0
+
+while $ship.count
+dec $ship.count =
+$ship = $ship.array[$ship.count]
+$ship.sector = $ship -> get sector
+$jump.distance = get jumps from sector [SECTOR] to sector $ship.sector
+$sector.already =  find $ship.sector in array: $sector.array
+skip if $jump.distance > $max.jump OR $sector.already == [TRUE]
+append $ship.sector to array $sector.array
+= wait 10 ms
+end
+
+$s.amount = 0
+$s.sector = null
+$sector.count =  size of array $sector.array
+while $sector.count
+dec $sector.count =
+$sector = $sector.array[$sector.count]
+$ship.array =  find ship: sector=$sector class or type=Moveable Ship race=Player flags=[Find.Multiple] refobj=null maxdist=null maxnum=100 refpos=null
+$ship.count =  size of array $ship.array
+$rnd =  = random value from 0 to 2 - 1
+if ( $s.amount < $ship.count ) OR ( $s.amount == $ship.count AND $rnd == 1 )
+$s.amount = $ship.count
+$s.sector = $sector
+end
+= wait 10 ms
+end
+
+return $s.sector

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.plsector.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.plsector.x3s
@@ -1,0 +1,51 @@
+#name: anarkis.lib.get.plsector
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.plsector.xml
+
+* ===========================================
+* Retrieve a sector with the most player stations given a distance to object
+* ===========================================
+* This script may take a while to run given the amount of player owned stations
+* TC Fix : Speed improvement
+* TODO : Speed hack through 2 row array
+
+$station.array =  get station array: of race Player class/type=Station
+$station.count =  size of array $station.array
+$sector.array =  array alloc: size=0
+
+while $station.count
+dec $station.count =
+$station = $station.array[$station.count]
+$station.sector = $station -> get sector
+$jump.distance = get jumps from sector [SECTOR] to sector $station.sector
+$sector.already =  find $station.sector in array: $sector.array
+skip if $jump.distance > $max.jump OR $sector.already == [TRUE]
+append $station.sector to array $sector.array
+= wait 100 ms
+end
+
+$s.amount = 0
+$s.sector = null
+$sector.count =  size of array $sector.array
+
+* If no station, fall back to ship
+if $sector.count == 0
+$s.sector = [THIS] -> call script anarkis.lib.get.plsector.pership :  max jump distance=$max.jump
+return $s.sector
+end
+
+while $sector.count
+dec $sector.count =
+$sector = $sector.array[$sector.count]
+$station.array =  find station: sector=$sector class or type=Station race=Player flags=[Find.Multiple] refobj=null maxdist=null maxnum=100 refpos=null
+$station.count =  size of array $station.array
+$rnd =  = random value from 0 to 2 - 1
+if ( $s.amount < $station.count ) OR ( $s.amount == $station.count AND $rnd == 1 )
+$s.amount = $station.count
+$s.sector = $sector
+end
+= wait 100 ms
+end
+
+return $s.sector

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.race.array.short.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.race.array.short.x3s
@@ -1,0 +1,23 @@
+#name: anarkis.lib.get.race.array.short
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.race.array.short.xml
+
+$res =  array alloc: size=0
+append Argon to array $res
+append Boron to array $res
+append Split to array $res
+append Paranid to array $res
+append Teladi to array $res
+append Xenon to array $res
+append Kha'ak to array $res
+append Pirates to array $res
+append Goner to array $res
+append Player to array $res
+append Unknown to array $res
+append Race 1 to array $res
+append Race 2 to array $res
+append ATF to array $res
+append Terran to array $res
+append Yaki to array $res
+return $res

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.race.array.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.race.array.x3s
@@ -1,0 +1,23 @@
+#name: anarkis.lib.get.race.array
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.race.array.xml
+
+$res =  array alloc: size=0
+append Argon to array $res
+append Boron to array $res
+append Split to array $res
+append Paranid to array $res
+append Teladi to array $res
+append Xenon to array $res
+append Kha'ak to array $res
+append Pirates to array $res
+append Goner to array $res
+append Player to array $res
+append Unknown to array $res
+append Race 1 to array $res
+append Race 2 to array $res
+append ATF to array $res
+append Terran to array $res
+append Yaki to array $res
+return $res

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.racesectors.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.racesectors.x3s
@@ -1,0 +1,22 @@
+#name: anarkis.lib.get.racesectors
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.racesectors.xml
+
+$res =  array alloc: size=0
+
+$m.x = get max sectors in x direction
+while $m.x
+dec $m.x =
+$m.y = get max sectors in y direction
+while $m.y
+dec $m.y =
+$sector = get sector from universe index: x=$m.x, y=$m.y
+if $sector -> exists
+$v1 = $sector -> get owner race
+skip if not $race == $v1
+append $sector to array $res
+end
+end
+end
+return $res

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.random.pos.from.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.random.pos.from.x3s
@@ -1,0 +1,54 @@
+#name: anarkis.lib.get.random.pos.from
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.random.pos.from.xml
+
+$retry.count = 100
+$st.array = $sector -> get all stationary objects: include asteroids=[TRUE]
+
+$o.x = $object -> get x position
+$o.y = $object -> get y position
+$o.z = $object -> get z position
+
+$error = [TRUE]
+while $retry.count
+dec $retry.count =
+$p.x =  = random value from $min.dist to $max.dist - 1
+$rnd =  = random value from 0 to 2 - 1
+if $rnd == 1
+$p.x = $o.x - $p.x
+else
+$p.x = $o.x + $p.x
+end
+$p.y =  = random value from $min.dist to $max.dist - 1
+$rnd =  = random value from 0 to 2 - 1
+if $rnd == 1
+$p.y = $o.y - $p.y
+else
+$p.y = $o.y + $p.y
+end
+$p.z =  = random value from $min.dist to $max.dist - 1
+$rnd =  = random value from 0 to 2 - 1
+if $rnd == 1
+$p.z = $o.z - $p.z
+else
+$p.z = $o.z + $p.z
+end
+$error = [FALSE]
+$cur.pos =  create new array, arguments=$p.x, $p.y, $p.z, null, null
+$station.count =  size of array $st.array
+while $station.count
+dec $station.count =
+$select = $st.array[$station.count]
+$size = $select -> get size of object
+$dist = $select -> get distance to: x=$p.x y=$p.y z=$p.z
+if $dist < $size
+$error = [TRUE]
+break
+end
+end
+if $error == [FALSE]
+break
+end
+end
+return $cur.pos

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.random.pos.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.random.pos.x3s
@@ -1,0 +1,41 @@
+#name: anarkis.lib.get.random.pos
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.random.pos.xml
+
+$retry.count = 100
+$st.array = $sector -> get all stationary objects: include asteroids=[TRUE]
+
+$error = [TRUE]
+while $retry.count
+dec $retry.count =
+$p.x =  = random value from $min.dist to $max.dist - 1
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+$p.x = 0 - $p.x
+$p.y =  = random value from $min.dist to $max.dist - 1
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+$p.y = 0 - $p.y
+$p.z =  = random value from $min.dist to $max.dist - 1
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+$p.z = 0 - $p.z
+$error = [FALSE]
+$cur.pos =  create new array, arguments=$p.x, $p.y, $p.z, null, null
+$station.count =  size of array $st.array
+while $station.count
+dec $station.count =
+$select = $st.array[$station.count]
+$size = $select -> get size of object
+$dist = $select -> get distance to: x=$p.x y=$p.y z=$p.z
+if $dist < $size
+$error = [TRUE]
+break
+end
+end
+if $error == [FALSE]
+break
+end
+end
+return $cur.pos

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.rnd.race.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.rnd.race.x3s
@@ -1,0 +1,41 @@
+#name: anarkis.lib.get.rnd.race
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.rnd.race.xml
+
+* ===========================================
+* Get a random race according to parameters
+* ===========================================
+
+$array =  array alloc: size=0
+
+append Argon to array $array
+append Boron to array $array
+append Split to array $array
+append Paranid to array $array
+append Teladi to array $array
+append Terran to array $array
+
+if $include.aliens
+append Xenon to array $array
+append Kha'ak to array $array
+end
+
+skip if not $include.unknown
+append Unknown to array $array
+
+if $include.renegades
+append Pirates to array $array
+append Yaki to array $array
+end
+
+skip if not $add.race1
+append $add.race1 to array $array
+skip if not $add.race2
+append $add.race2 to array $array
+
+$cnt =  size of array $array
+$nb =  = random value from 0 to $cnt - 1
+$race = $array[$nb]
+
+return $race

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.sector.plus.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.sector.plus.x3s
@@ -1,0 +1,52 @@
+#name: anarkis.lib.get.sector.plus
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.sector.plus.xml
+
+* ===========================================
+* Get a sector according to the params
+* ===========================================
+
+$retry = 25
+$flags = [Find.Random]
+$random.race = null
+$sector = null
+$sector.list = $ref.object -> find all sectors within $max.jump jumps: Only known sectors=[FALSE]
+$sector.cnt =  size of array $sector.list
+
+while $sector.cnt
+dec $sector.cnt =
+$sector = $sector.list[$sector.cnt]
+$sector.owner = $sector -> get owner race
+if $race != null AND $sector.owner != $race
+remove element from array $sector.list at index $sector.cnt
+continue
+end
+if $no.unknown == [TRUE] AND $sector.owner == Unknown
+remove element from array $sector.list at index $sector.cnt
+continue
+end
+if $ignore.alien == [TRUE] AND ( $sector.owner == Xenon OR $sector.owner == Kha'ak )
+remove element from array $sector.list at index $sector.cnt
+continue
+end
+if $ignore.pirate == [TRUE] AND ( $sector.owner == Pirates OR $sector.owner == Yaki )
+remove element from array $sector.list at index $sector.cnt
+continue
+end
+$is.core = $sector -> is core sector
+if $remove.border == [TRUE] AND $is.core == [FALSE]
+remove element from array $sector.list at index $sector.cnt
+continue
+end
+if $remove.core == [TRUE] AND $is.core == [TRUE]
+remove element from array $sector.list at index $sector.cnt
+continue
+end
+end
+
+$sector.cnt =  size of array $sector.list
+$sector.cnt =  = random value from 0 to $sector.cnt - 1
+$sector = $sector.list[$sector.cnt]
+
+return $sector

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.sector.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.sector.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.lib.get.sector
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.sector.xml
+
+* ===========================================
+* Get a sector according to the params
+* ===========================================
+
+$sector = [THIS] -> call script anarkis.lib.get.sector.plus :  ref object=[THIS]  max jump=$max.jump  race=$race  remove border sectors=$only.core  remove core=[FALSE]  remove xenon/khaak sectors=[TRUE]  remove unknown=[TRUE]  ignore pirate/yaki=[TRUE]
+
+return $sector

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.ship.cargovalue.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.ship.cargovalue.x3s
@@ -1,0 +1,23 @@
+#name: anarkis.lib.get.ship.cargovalue
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.ship.cargovalue.xml
+
+* 1.02 - Added player support
+$owner = $ship -> get owner race
+if $owner != Player
+$ware.list =  get warearray for $ship
+else
+$ware.list = $ship -> get tradeable ware array from ship
+end
+
+$ware.cnt =  size of array $ware.list
+$total = 0
+while $ware.cnt
+dec $ware.cnt =
+$ware = $ware.list[$ware.cnt]
+$amount = $ship -> get amount of ware $ware in cargo bay
+$price = get average price of ware $ware
+$total = $total + ( $amount * $price )
+end
+return $total

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.shipcount.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.shipcount.x3s
@@ -1,0 +1,39 @@
+#name: anarkis.lib.get.shipcount
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.shipcount.xml
+
+* ===========================================
+* Get minimal ship count against a target
+* ===========================================
+
+$res = 3
+if $class == M2
+$res = 35
+else if $class == M1
+$res = 30
+else if $class == M7
+$res = 25
+else if $class == TL
+$res = 15
+else if $class == M6
+$res = 14
+else if $class == M8
+$res = 6
+else if $class == M3
+$res = 4
+else if $class == M4
+$res = 3
+else if $class == M5
+$res = 2
+else if $class == TM
+$res = 4
+else if $class == TS OR $class == TP
+$res = 3
+else if $class == Lasertower
+$res = 8
+else if $class == Dock
+$res = 20
+end
+
+return $res

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.shiplist.from.sy.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.shiplist.from.sy.x3s
@@ -1,0 +1,25 @@
+#name: anarkis.lib.get.shiplist.from.sy
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.shiplist.from.sy.xml
+
+* Fix 1 : Performance increased, one less loop
+
+$trade.array = $sy -> get tradeable ware array from station
+$cnt =  size of array $trade.array
+while $cnt
+dec $cnt =
+$test.ware = $trade.array[$cnt]
+* - Remove Stations
+$transport.class = get transport class of ware $test.ware
+if $transport.class == Station Containers ST
+remove element from array $trade.array at index $cnt
+continue
+end
+* - Quick and Dirty method to check ship class
+$ship =  create ship: type=$test.ware owner=Friendly Race addto=$sy x=0 y=0 z=0
+skip if $ship -> is of class $ship.class
+remove element from array $trade.array at index $cnt
+$ship -> destruct: show no explosion=[TRUE]
+end
+return $trade.array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.ships.fast.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.ships.fast.x3s
@@ -1,0 +1,90 @@
+#name: anarkis.lib.get.ships.fast
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.ships.fast.xml
+
+* ===========================================
+* Find all ships according to the parameters
+* ===========================================
+
+$null = null
+$class.cnt =  size of array $class.array
+if $class.array == null
+$class.cnt = 0
+else if $class.cnt == 0
+$class.array = null
+end
+
+$military.array =  array alloc: size=0
+
+if $jump.range > 0
+$sector.list = $from -> find all sectors within $jump.range jumps: Only known sectors=[FALSE]
+else
+$sector.list =  array alloc: size=0
+append [SECTOR] to array $sector.list
+end
+$cnt =  size of array $sector.list
+
+* For all sectors
+$sl.cnt = 0
+while $cnt
+dec $cnt =
+$sector = $sector.list[$cnt]
+$ship.array = $sector -> get ship array from sector/ship/station
+$cnt.ship =  size of array $ship.array
+* - For each ship in sector
+while $cnt.ship
+inc $sl.cnt =
+if $sl.cnt == 1000
+$sl.cnt = 0
+= wait 25 ms
+end
+dec $cnt.ship =
+$test.ship = $ship.array[$cnt.ship]
+* - - Check Race
+$owner = $test.ship -> get true owner
+if $force.race != null AND $owner != $force.race
+continue
+else if $force.race != null AND $owner == $force.race
+goto label skipracecheck
+end
+* - - Ignore Player
+if $ignore.player == [TRUE] AND $owner == Player
+continue
+end
+* - - Ignore Khaaks and Xenons ?
+if $ignore.aliens == [TRUE] AND ( $owner == Kha'ak OR $owner == Xenon )
+continue
+end
+* - - Ignore Pirates ?
+if $ignore.pirates == [TRUE] AND ( $owner == Pirates OR $owner == Yaki )
+continue
+end
+skipracecheck:
+* - - Ignore invincible
+skip if not $test.ship -> is invincible
+continue
+* - - Ignore civilians
+if $ignore.civilians
+skip if not $test.ship -> is civilian ship
+continue
+skip if $test.ship -> get current laser strength
+continue
+end
+* - - Check Local
+if $checkvar
+skip if $test.ship -> get local variable: name=$checkvar
+continue
+end
+
+* - - Check class
+$ship.class = $test.ship -> get object class
+$found =  find $ship.class in array: $class.array
+if $found == [TRUE] OR $class.array == null
+append $test.ship to array $military.array
+end
+
+end
+end
+
+return $military.array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.ships.from.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.ships.from.x3s
@@ -1,0 +1,11 @@
+#name: anarkis.lib.get.ships.from
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.ships.from.xml
+
+* ===========================================
+* Find all ships according to the parameters
+* ===========================================
+$military.array = [THIS] -> call script anarkis.lib.get.ships.var :  array of class=$class.array  force race=$force.race  jump.range=$jump.range  ignore khaak/xenon?=$ignore.aliens  ignore pirate/yaki?=$ignore.pirates  ignore civilians?=$ignore.civilians  ignore player?=$ignore.player  local.var=$null  from=$from
+
+return $military.array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.ships.var.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.ships.var.x3s
@@ -1,0 +1,90 @@
+#name: anarkis.lib.get.ships.var
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.ships.var.xml
+
+* ===========================================
+* Find all ships according to the parameters
+* ===========================================
+
+$null = null
+$class.cnt =  size of array $class.array
+if $class.array == null
+$class.cnt = 0
+else if $class.cnt == 0
+$class.array = null
+end
+
+$military.array =  array alloc: size=0
+
+if $jump.range > 0
+$sector.list = $from -> find all sectors within $jump.range jumps: Only known sectors=[FALSE]
+else
+$sector.list =  array alloc: size=0
+append [SECTOR] to array $sector.list
+end
+$cnt =  size of array $sector.list
+
+* For all sectors
+$sl.cnt = 0
+while $cnt
+dec $cnt =
+$sector = $sector.list[$cnt]
+$ship.array = $sector -> get ship array from sector/ship/station
+$cnt.ship =  size of array $ship.array
+* - For each ship in sector
+while $cnt.ship
+inc $sl.cnt =
+if $sl.cnt == 75
+$sl.cnt = 0
+= wait 100 ms
+end
+dec $cnt.ship =
+$test.ship = $ship.array[$cnt.ship]
+* - - Check Race
+$owner = $test.ship -> get true owner
+if $force.race != null AND $owner != $force.race
+continue
+else if $force.race != null AND $owner == $force.race
+goto label skipracecheck
+end
+* - - Ignore Player
+if $ignore.player == [TRUE] AND $owner == Player
+continue
+end
+* - - Ignore Khaaks and Xenons ?
+if $ignore.aliens == [TRUE] AND ( $owner == Kha'ak OR $owner == Xenon )
+continue
+end
+* - - Ignore Pirates ?
+if $ignore.pirates == [TRUE] AND ( $owner == Pirates OR $owner == Yaki )
+continue
+end
+skipracecheck:
+* - - Ignore invincible
+skip if not $test.ship -> is invincible
+continue
+* - - Ignore civilians
+if $ignore.civilians
+skip if not $test.ship -> is civilian ship
+continue
+skip if $test.ship -> get current laser strength
+continue
+end
+* - - Check Local
+if $checkvar
+skip if $test.ship -> get local variable: name=$checkvar
+continue
+end
+
+* - - Check class
+$ship.class = $test.ship -> get object class
+$found =  find $ship.class in array: $class.array
+if $found == [TRUE] OR $class.array == null
+append $test.ship to array $military.array
+end
+
+end
+end
+
+return $military.array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.ships.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.ships.x3s
@@ -1,0 +1,11 @@
+#name: anarkis.lib.get.ships
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.ships.xml
+
+* ===========================================
+* Find all ships according to the parameters
+* ===========================================
+$found = [THIS] -> call script anarkis.lib.get.ships.var :  array of class=$class.array  force race=$force.race  jump.range=$jump.range  ignore khaak/xenon?=$ignore.aliens  ignore pirate/yaki?=$ignore.pirates  ignore civilians?=$ignore.civilians  ignore player?=$ignore.player  local.var=null  from=[THIS]
+
+return $found

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.shipyard.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.get.shipyard.x3s
@@ -1,0 +1,29 @@
+#name: anarkis.lib.get.shipyard
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.shipyard.xml
+
+$array =  find station in galaxy: startsector=[SECTOR] class or type=Shipyard race=null flags=[Find.Multiple] refobj=[THIS] serial=null max.jumps=$max.jump num=20
+$cnt =  size of array $array
+
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+
+if $ignore.aliens == [TRUE]
+$race = $select -> get owner race
+if $race == Kha'ak OR $race == Xenon
+remove element from array $array at index $cnt
+continue
+end
+end
+
+end
+
+$cnt =  size of array $array
+skip if $cnt
+return null
+
+$rnd =  = random value from 0 to $cnt - 1
+$select = $array[$rnd]
+return $select

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.guild.changescore.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.guild.changescore.x3s
@@ -1,0 +1,13 @@
+#name: anarkis.lib.guild.changescore
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.guild.changescore.xml
+
+$global.name = sprintf: fmt='anarkis.guild.%s', $plugin.name, null, null, null, null
+$array = get global variable: name=$global.name
+$xp = $array[1]
+$xp = $xp + $value
+$array[1] = $xp
+set global variable: name=$global.name value=$array
+
+return $array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.guild.getscore.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.guild.getscore.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.lib.guild.getscore
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.guild.getscore.xml
+
+$global.name = sprintf: fmt='anarkis.guild.%s', $plugin.name, null, null, null, null
+$array = get global variable: name=$global.name
+$xp = $array[1]
+return $xp

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.guild.isguild.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.guild.isguild.x3s
@@ -1,0 +1,13 @@
+#name: anarkis.lib.guild.isguild
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.guild.isguild.xml
+
+$global.name = sprintf: fmt='anarkis.guild.%s', $plugin.name, null, null, null, null
+$array = get global variable: name=$global.name
+$xp = $array[3]
+if $xp == [TRUE]
+return [TRUE]
+else
+return [FALSE]
+end

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.guild.join.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.guild.join.x3s
@@ -1,0 +1,11 @@
+#name: anarkis.lib.guild.join
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.guild.join.xml
+
+$global.name = sprintf: fmt='anarkis.guild.%s', $plugin.name, null, null, null, null
+$array = get global variable: name=$global.name
+$array[3] = $join
+set global variable: name=$global.name value=$array
+
+return $array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.guild.register.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.guild.register.x3s
@@ -1,0 +1,14 @@
+#name: anarkis.lib.guild.register
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.guild.register.xml
+
+$global.name = sprintf: fmt='anarkis.guild.%s', $plugin.name, null, null, null, null
+$array =  array alloc: size=4
+$array[0] = $page.id
+$array[1] = 0
+$array[2] = 0
+$array[3] = [FALSE]
+set global variable: name=$global.name value=$array
+
+return $array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.guild.remove.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.guild.remove.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.lib.guild.remove
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.guild.remove.xml
+
+$global.name = sprintf: fmt='anarkis.guild.%s', $plugin.name, null, null, null, null
+set global variable: name=$global.name value=null
+
+return $array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.id.to.race.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.id.to.race.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.lib.id.to.race
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.id.to.race.xml
+
+$array = [THIS] -> call script anarkis.lib.get.race.array :
+$test = $array[$id]
+
+return $test

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kcnt.add.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kcnt.add.x3s
@@ -1,0 +1,16 @@
+#name: anarkis.lib.kcnt.add
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.kcnt.add.xml
+
+$global.name = sprintf: fmt='anarkis.kcnt.%s', $plugin.name, null, null, null, null
+$array = get global variable: name=$global.name
+$id = [THIS] -> call script anarkis.lib.race.to.id :  race=$race
+$tmp = $array[$id]
+$tmp = $tmp + $value
+skip if $tmp >= 0
+$tmp = 0
+$array[$id] = $tmp
+set global variable: name=$global.name value=$array
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kcnt.findtop.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kcnt.findtop.x3s
@@ -1,0 +1,23 @@
+#name: anarkis.lib.kcnt.findtop
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.kcnt.findtop.xml
+
+$global.name = sprintf: fmt='anarkis.kcnt.%s', $plugin.name, null, null, null, null
+$array = get global variable: name=$global.name
+$cnt =  size of array $array
+
+$m.id = 0
+$m.val = 0
+while $cnt
+dec $cnt =
+$test = $array[$cnt]
+$x =  = random value from 0 to 2 - 1
+if ( $test > $m.val ) OR ( $test == $m.val AND $x == 1 )
+$m.val = $test
+$m.id = $cnt
+end
+end
+
+$result = [THIS] -> call script anarkis.lib.id.to.race :  ID=$m.id
+return $result

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kcnt.get.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kcnt.get.x3s
@@ -1,0 +1,11 @@
+#name: anarkis.lib.kcnt.get
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.kcnt.get.xml
+
+$global.name = sprintf: fmt='anarkis.kcnt.%s', $plugin.name, null, null, null, null
+$array = get global variable: name=$global.name
+$id = [THIS] -> call script anarkis.lib.race.to.id :  race=$race
+$result = $array[$id]
+
+return $result

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kcnt.init.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kcnt.init.x3s
@@ -1,0 +1,16 @@
+#name: anarkis.lib.kcnt.init
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.kcnt.init.xml
+
+$global.name = sprintf: fmt='anarkis.kcnt.%s', $plugin.name, null, null, null, null
+
+$array = [THIS] -> call script anarkis.lib.get.race.array :
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$array[$cnt] = 0
+end
+set global variable: name=$global.name value=$array
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kcnt.kill.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kcnt.kill.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.lib.kcnt.kill
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.kcnt.kill.xml
+
+$global.name = sprintf: fmt='anarkis.kcnt.%s', $plugin.name, null, null, null, null
+set global variable: name=$global.name value=null
+
+return $result

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kcnt.set.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kcnt.set.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.lib.kcnt.set
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.kcnt.set.xml
+
+$global.name = sprintf: fmt='anarkis.kcnt.%s', $plugin.name, null, null, null, null
+$array = get global variable: name=$global.name
+$id = [THIS] -> call script anarkis.lib.race.to.id :  race=$race
+$array[$id] = $value
+set global variable: name=$global.name value=$array
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kill.civies.sector.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kill.civies.sector.x3s
@@ -1,0 +1,14 @@
+#name: anarkis.lib.kill.civies.sector
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.kill.civies.sector.xml
+
+$ar = $sector -> get ship array from sector/ship/station
+$cnt =  size of array $ar
+while $cnt
+dec $cnt =
+$select = $ar[$cnt]
+skip if not $select -> is civilian ship
+START $select -> call script !ship.cmd.destroy.std :
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kill.civilians.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kill.civilians.x3s
@@ -1,0 +1,23 @@
+#name: anarkis.lib.kill.civilians
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.kill.civilians.xml
+
+$races = [THIS] -> call script anarkis.lib.get.race.array :
+$cnt =  size of array $races
+while $cnt
+dec $cnt =
+$r = $races[$cnt]
+$arr =  get ship array: of race $r class/type=Moveable Ship
+$v1 =  size of array $arr
+while $v1
+dec $v1 =
+$s = $arr[$v1]
+if $s -> is civilian ship
+= $s -> call script anarkis.lib.disable.ai :
+$s -> destruct: show no explosion=[TRUE]
+end
+end
+*= wait 500 ms
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kill.task.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.kill.task.x3s
@@ -1,0 +1,7 @@
+#name: anarkis.lib.kill.task
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.kill.task.xml
+
+$object -> start task $task with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.news.init.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.news.init.x3s
@@ -1,0 +1,14 @@
+#name: anarkis.lib.news.init
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.news.init.xml
+
+$news.list =  array alloc: size=0
+
+$setup =  array alloc: size=4
+$setup[0] = $plugin.id
+$setup[1] = $page.id
+$setup[2] = $max.news
+$setup[3] = $news.list
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.race.to.id.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.race.to.id.x3s
@@ -1,0 +1,17 @@
+#name: anarkis.lib.race.to.id
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.race.to.id.xml
+
+$array = [THIS] -> call script anarkis.lib.get.race.array :
+$cnt =  size of array $array
+
+while $cnt
+dec $cnt =
+$test = $array[$cnt]
+if $test == $race
+return $cnt
+end
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.restore.signals.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.restore.signals.x3s
@@ -1,0 +1,21 @@
+#name: anarkis.lib.restore.signals
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.restore.signals.xml
+
+$curr.time = playing time
+$end.time = $curr.time + $delay
+while $curr.time < $end.time
+$curr.time = playing time
+= wait 1000 ms
+end
+
+[THIS] -> set ship command/signal $sig.a to global default behaviour
+skip if not $sig.b
+[THIS] -> set ship command/signal $sig.b to global default behaviour
+skip if not $sig.c
+[THIS] -> set ship command/signal $sig.c to global default behaviour
+skip if not $sig.d
+[THIS] -> set ship command/signal $sig.d to global default behaviour
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.revealmap.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.revealmap.x3s
@@ -1,0 +1,37 @@
+#name: anarkis.lib.revealmap
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.revealmap.xml
+
+
+$m.x = get max sectors in x direction
+$m.y = get max sectors in y direction
+
+$x = 0
+while $x <= $m.x
+$y = 0
+while $y <= $m.y
+$sector = get sector from universe index: x=$x, y=$y
+if $sector -> exists
+$sector.owner = $sector -> get owner race
+if $sector.owner == $set.race OR $set.race == null
+$sector -> set known status to [TRUE]
+$arr = $sector -> get all stationary objects: include asteroids=[TRUE]
+$ct =  size of array $arr
+while $ct
+dec $ct =
+$select = $arr[$ct]
+$select -> set known status to [TRUE]
+if $scan.roid
+skip if not $select -> is of class Asteroid
+$select -> set asteroid scanned to [TRUE]
+end
+end
+end
+end
+
+inc $y =
+end
+inc $x =
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.roids.destroy.sector.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.roids.destroy.sector.x3s
@@ -1,0 +1,13 @@
+#name: anarkis.lib.roids.destroy.sector
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.roids.destroy.sector.xml
+
+$roids = $sec -> get asteroid array from sector
+$cnt =  size of array $roids
+while $cnt
+dec $cnt =
+$r = $roids[$cnt]
+$r -> destruct: show no explosion=[TRUE]
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.satrelay.clean.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.satrelay.clean.x3s
@@ -1,0 +1,29 @@
+#name: anarkis.lib.satrelay.clean
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.satrelay.clean.xml
+
+$m.x = get max sectors in x direction
+$m.y = get max sectors in y direction
+$x = 0
+while $x <= $m.x
+$y = 0
+while $y <= $m.y
+$sector = get sector from universe index: x=$x, y=$y
+if $sector -> exists
+$s.array =  find ship: sector=$sector class or type=Advanced Satellite race=Player flags=[Find.Multiple] refobj=null maxdist=null maxnum=100 refpos=null
+$s.count =  size of array $s.array
+while $s.count > 1
+dec $s.count =
+$sat = $s.array[$s.count]
+$sat -> destruct: show no explosion=[TRUE]
+end
+$sat = $s.array[0]
+$tmp = '(AIA) Adv.Sat. - ' + $sector
+$sat -> set name to $tmp
+end
+inc $y =
+end
+inc $x =
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.sector.format.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.sector.format.x3s
@@ -1,0 +1,10 @@
+#name: anarkis.lib.sector.format
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.sector.format.xml
+
+$x = $sect -> get universe x index
+$y = $sect -> get universe y index
+$st = sprintf: fmt='%s (%s,%s)', [SECTOR], $x, $y, null, null
+
+return $st

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.sectorrestore.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.sectorrestore.x3s
@@ -1,0 +1,29 @@
+#name: anarkis.lib.sectorrestore
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.sectorrestore.xml
+
+$current.owner = $sector -> get owner race
+
+$arr = $sector -> get station array from sector
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$select.race = $select -> get owner race
+if $select.race == $current.owner
+$old.owner = $select -> get local variable: name='anarkis.sector.oldrace'
+$oldname = $select -> get local variable: name='anarkis.sector.oldname'
+skip if not $old.owner
+$select -> set owner race to $old.owner
+skip if not $oldname
+$select -> set name to $oldname
+$select -> set local variable: name='anarkis.sector.oldrace' value=null
+$select -> set local variable: name='anarkis.sector.oldname' value=null
+end
+end
+
+skip if not $old.owner
+$sector -> set owner race to $old.owner
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.sectortakeover.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.sectortakeover.x3s
@@ -1,0 +1,69 @@
+#name: anarkis.lib.sectortakeover
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.sectortakeover.xml
+
+* ===========================================
+* Sector Takeover  Script
+* ===========================================
+* Takeover Type :
+* - 0 : No Changes
+* - 1 : Change ownership of old race stations
+* - 2 : Destroy Enemy Stations
+* - 3 : Destroy All non new owner stations
+* - 4 : Destroy All
+* ===========================================
+
+$old.owner = $sector -> get owner race
+$sector -> set owner race to $new.owner
+$sector -> set sector to core security $is.core
+$arr = $sector -> get station array from sector
+$cnt =  size of array $arr
+
+if $stationmode == 1
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$select.race = $select -> get owner race
+$name = $select -> get name
+if $select.race == $old.owner
+$select -> set owner race to $new.owner
+$select -> set local variable: name='anarkis.sector.oldrace' value=$old.owner
+$select -> set local variable: name='anarkis.sector.oldname' value=$name
+end
+end
+else if $stationmode == 2
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$select.race = $select -> get owner race
+skip if not $select.race == $old.owner
+$select -> destruct: show no explosion=[TRUE]
+end
+else if $stationmode == 3
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$select.race = $select -> get owner race
+skip if $select.race == $new.owner
+$select -> destruct: show no explosion=[TRUE]
+end
+else if $stationmode == 4
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$select -> destruct: show no explosion=[TRUE]
+end
+end
+
+if $destroy.old.ships == [TRUE]
+$arr = $sector -> get ship array from sector/ship/station
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+skip if not $select.race == $old.owner
+$select -> destruct: show no explosion=[TRUE]
+end
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.set.new.relation.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.set.new.relation.x3s
@@ -1,0 +1,33 @@
+#name: anarkis.lib.set.new.relation
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.set.new.relation.xml
+
+
+set notoriety of $base.race -> $target.race to $new.noto points
+
+if $new.noto >= 10000
+$new.rel = Friend
+else if $new.noto <= -10000
+$new.rel = Foe
+else
+$new.rel = Neutral
+end
+
+$array =  get ship array: of race $base.race class/type=Ship
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$select -> set relation against $target.race to $new.rel
+end
+
+$array =  get station array: of race $base.race class/type=Station
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$select -> set relation against $target.race to $new.rel
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.shipstate.restore.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.shipstate.restore.x3s
@@ -1,0 +1,20 @@
+#name: anarkis.lib.shipstate.restore
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.shipstate.restore.xml
+
+$array = $ref.object -> get local variable: name='anarkis.ship.state'
+$v1 = $array[0]
+$ref.object -> set destination to $v1
+$v1 = $array[1]
+$ref.object -> set command: $v1
+$v1 = $array[2]
+$ref.object -> set command target: $v1
+$v1 = $array[3]
+$ref.object -> set command target2: $v1
+$v1 = $array[4]
+$ref.object -> set name to $v1
+
+$ref.object -> set local variable: name='anarkis.ship.state' value=null
+
+return $array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.shipstate.save.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.shipstate.save.x3s
@@ -1,0 +1,21 @@
+#name: anarkis.lib.shipstate.save
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.shipstate.save.xml
+
+$array =  array alloc: size=0
+
+$v1 = $ref.object -> get destination
+append $v1 to array $array
+$v1 = $ref.object -> get command
+append $v1 to array $array
+$v1 = $ref.object -> get command target
+append $v1 to array $array
+$v1 = $ref.object -> get command target2
+append $v1 to array $array
+$v1 = $ref.object -> get name
+append $v1 to array $array
+
+$ref.object -> set local variable: name='anarkis.ship.state' value=$array
+
+return $array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.shiptype.array.m3m4.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.shiptype.array.m3m4.x3s
@@ -1,0 +1,25 @@
+#name: anarkis.lib.shiptype.array.m3m4
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.shiptype.array.m3m4.xml
+
+$races =  array alloc: size=0
+append Argon to array $races
+append Boron to array $races
+append Split to array $races
+append Paranid to array $races
+append Teladi to array $races
+append Pirates to array $races
+$race.cnt =  size of array $races
+
+$shiptype.array =  array alloc: size=0
+while $race.cnt
+dec $race.cnt =
+$race = $races[$race.cnt]
+$arr1 =  get ship type array: maker race=$race class=M3
+$shiptype.array = [THIS] -> call script anarkis.lib.array.append :  base array=$shiptype.array  append array=$arr1
+$arr1 =  get ship type array: maker race=$race class=M4
+$shiptype.array = [THIS] -> call script anarkis.lib.array.append :  base array=$shiptype.array  append array=$arr1
+end
+
+return $shiptype.array

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.shortcmd.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.shortcmd.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.lib.shortcmd
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.shortcmd.xml
+
+
+$d = sprintf: fmt='%s', $command, null, null, null, null
+$d =  substitute in string $d: pattern 'COMMAND_' with ' '
+return $d

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.shortstring.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.shortstring.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.lib.shortstring
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.shortstring.xml
+
+$length =  get length of string $string
+if $length > $max
+$length = $max - 3
+$string =  get substring of $string offset=0 length=$length
+$string = $string + '..'
+end
+return $string

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.task.autodocking.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.task.autodocking.x3s
@@ -1,0 +1,93 @@
+#name: anarkis.lib.task.autodocking
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.task.autodocking.xml
+
+* ===========================================
+* Securely Dock All Ships to a Carrier / Station
+* ===========================================
+
+
+$owner = [THIS] -> get owner race
+
+while [OWNER] == $owner
+= wait 5000 ms
+$array = [THIS] -> get owned ships: class/type=Moveable Ship
+$cnt =  size of array $array
+while $cnt
+= wait 50 ms
+dec $cnt =
+$ship = $array[$cnt]
+* - - Check existence
+if not $ship -> exists
+remove element from array $array at index $cnt
+continue
+end
+* - - Check environment
+$env = $ship -> get environment
+if not [THIS] -> is docking possible of $ship
+remove element from array $array at index $cnt
+continue
+end
+* - - Check if docked
+if $env == [THIS]
+gosub dodock
+remove element from array $array at index $cnt
+continue
+end
+* - - Ship has return flag or is doing nothing, order to go back
+if $ship -> get local variable: name='anarkis.flag.return'
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+$ship -> set local variable: name='anarkis.flag.return' value=null
+remove element from array $array at index $cnt
+continue
+end
+if not $ship -> is task 0 in use
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+remove element from array $array at index $cnt
+continue
+end
+* - - Ship is moving, skip it
+$speed = $ship -> get current speed
+if $speed > 0
+remove element from array $array at index $cnt
+continue
+end
+* - - Now handling returning stuck ships
+$cmd = $ship -> get command
+$r1 = $ship -> is script !move.returntohomebase on stack of task=0
+$r2 = $ship -> is script !ship.cmd.retreat.std on stack of task=0
+if $cmd == COMMAND_RETURN_HOME OR $r1 == [TRUE] OR $r2 == [TRUE]
+$transport.device = $ship -> get true amount of ware Transporter Device in cargo bay
+$distance = get distance between [THIS] and $ship
+* - - - If transport device teleport
+if $distance <= 5000 AND $transport.device >= 1
+$ship -> put into environment [THIS] ->
+gosub dodock
+remove element from array $array at index $cnt
+continue
+* - - - Else Re issue orders
+else
+START $ship -> call script !ship.cmd.idle.std :
+= wait 1000 ms
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+end
+end
+
+end
+
+end
+
+return null
+
+
+dodock:
+$ship -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$ship -> set command: COMMAND_NONE  target=null target2=null par1=null par2=null
+$ship -> set destination to null
+$v1 = $ship -> get maximum shield strength
+$ship -> set current shield strength to $v1
+endsub
+
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.task.autosupply.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.task.autosupply.x3s
@@ -1,0 +1,35 @@
+#name: anarkis.lib.task.autosupply
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.task.autosupply.xml
+
+
+= wait randomly from 10000 to 30000 ms
+
+while [TRUE]
+
+$array = [THIS] -> get tradeable ware array from station
+$cnt =  size of array $array
+
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$type =  get maintype of ware $select
+skip if not $type == 16
+continue
+$amt.curr = [THIS] -> get amount of ware $select in cargo bay
+$amt.max = [THIS] -> get max amount of ware $select that can be stored in cargo bay
+$rnd =  = random value from 0 to 2 - 1
+if $amt.curr <= ( $amt.max / 2 ) AND $rnd == 1
+$amt.curr = $amt.max / 2 + 1
+$amt.curr =  = random value from 1 to $amt.curr - 1
+= [THIS] -> add $amt.curr units of $select
+= wait randomly from 10000 to 30000 ms
+end
+end
+
+= [THIS] -> call script anarkis.lib.wait :  wait time (in sec)=900  global to check=null
+
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.unknown.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.unknown.x3s
@@ -1,0 +1,7 @@
+#name: anarkis.lib.unknown
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.unknown.xml
+
+$sec -> set known status to [FALSE]
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.vis.blinkname.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.vis.blinkname.x3s
@@ -1,0 +1,10 @@
+#name: anarkis.lib.vis.blinkname
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.vis.blinkname.xml
+
+$target -> set local variable: name='anarkis.isblinking' value=[TRUE]
+skip if $target -> is task 893 in use
+$target -> start task 893 with script anarkis.lib.vis.task.blink and prio 0: arg1=$duration arg2=$stop.oos arg3=$check.local arg4=null arg5=null
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.vis.showtext.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.vis.showtext.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.lib.vis.showtext
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.vis.showtext.xml
+
+skip if $target -> is task 893 in use
+$target -> start task 893 with script anarkis.lib.vis.task.showtext and prio 0: arg1=$message arg2=$duration arg3=$stop.oos arg4=$check.local arg5=null
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.vis.task.blink.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.vis.task.blink.x3s
@@ -1,0 +1,45 @@
+#name: anarkis.lib.vis.task.blink
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.vis.task.blink.xml
+
+$page.id = 8513
+
+$saved.name = [THIS] -> get name
+$save.owner = [THIS] -> get owner race
+
+$blink1 = sprintf: pageid=$page.id textid=150, [THIS], null, null, null, null
+$blink2 = sprintf: pageid=$page.id textid=151, [THIS], null, null, null, null
+$cnt = 0
+while [TRUE]
+if $check.local
+skip if [THIS] -> get local variable: name=$check.local
+break
+end
+if $stop.oos
+$pl.sector = [PLAYERSHIP] -> get sector
+skip if [SECTOR] == $pl.sector
+break
+end
+
+$curr.owner = [THIS] -> get owner race
+if $curr.owner != $save.owner
+break
+end
+
+[THIS] -> set name to $blink1
+= wait 1000 ms
+[THIS] -> set name to $blink2
+= wait 1000 ms
+if $duration
+inc $cnt =
+inc $cnt =
+skip if $cnt <= $duration
+break
+end
+end
+
+[THIS] -> set name to $saved.name
+[THIS] -> set local variable: name='anarkis.isblinking' value=null
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.vis.task.showtext.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.vis.task.showtext.x3s
@@ -1,0 +1,34 @@
+#name: anarkis.lib.vis.task.showtext
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.vis.task.showtext.xml
+
+$page.id = 8513
+
+$saved.name = [THIS] -> get name
+$new.name = sprintf: pageid=$page.id textid=143, $message, null, null, null, null
+$new.name = sprintf: fmt='%s %s', $saved.name, $new.name, null, null, null
+$cnt = 0
+while [TRUE]
+if $check.local
+skip if [THIS] -> get local variable: name=$check.local
+break
+end
+if $stop.oos
+$pl.sector = [PLAYERSHIP] -> get sector
+skip if [SECTOR] == $pl.sector
+break
+end
+[THIS] -> set name to $new.name
+= wait 1000 ms
+[THIS] -> set name to $saved.name
+= wait 1000 ms
+if $duration
+inc $cnt =
+inc $cnt =
+skip if $cnt <= $duration
+break
+end
+end
+[THIS] -> set name to $saved.name
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wait.not.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wait.not.x3s
@@ -1,0 +1,18 @@
+#name: anarkis.lib.wait.not
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.wait.not.xml
+
+$curr.time = playing time
+$end.time = $curr.time + $delay
+
+while $curr.time < $end.time
+= wait 2000 ms
+$curr.time = playing time
+
+if $global
+skip if get global variable: name=$global
+return null
+end
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wait.random.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wait.random.x3s
@@ -1,0 +1,22 @@
+#name: anarkis.lib.wait.random
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.wait.random.xml
+
+$curr.time = playing time
+
+$delay =  = random value from $minwait to $maxwait - 1
+$end.time = $curr.time + $delay
+
+while $curr.time < $end.time
+= wait 2000 ms
+$curr.time = playing time
+
+if $global
+$exit = get global variable: name=$global
+skip if not $exit == [TRUE]
+return null
+end
+
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wait.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wait.x3s
@@ -1,0 +1,19 @@
+#name: anarkis.lib.wait
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.wait.xml
+
+$curr.time = playing time
+$end.time = $curr.time + $delay
+
+while $curr.time < $end.time
+= wait 2000 ms
+$curr.time = playing time
+
+if $global
+$exit = get global variable: name=$global
+skip if not $exit == [TRUE]
+return null
+end
+end
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wing.changeleader.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wing.changeleader.x3s
@@ -1,0 +1,22 @@
+#name: anarkis.lib.wing.changeleader
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.wing.changeleader.xml
+
+* ===========================================
+* Wing : Set a new leader and apply to formation
+* (must be used on wing leader)
+* ===========================================
+
+if [THIS] -> has formation ships
+$new.leader = [THIS] -> select new formation leader by: ship class=[TRUE] strength=[TRUE] min.speed=[FALSE]
+[THIS] -> give formation leadership to $new.leader
+$cmd.name = [THIS] -> get command
+$arg1 = [THIS] -> get command target
+$arg2 = [THIS] -> get command target2
+$arg3 = [THIS] -> get destination
+START $new.leader -> command $cmd.name : arg1=$arg1, arg2=$arg2, arg3=$arg3, arg4=null
+
+end
+
+return $new.leader

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wing.getall.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wing.getall.x3s
@@ -1,0 +1,26 @@
+#name: anarkis.lib.wing.getall
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.wing.getall.xml
+
+* ===========================================
+* select a ship and it will return all ships in is formation with the leader
+* as the first item of the array. If no formation for the selected ship
+* it will give back a single item array with the ship itself
+* ===========================================
+
+$result =  array alloc: size=0
+
+$leader = $ship -> get formation leader
+skip if $leader -> exists
+$leader = $ship
+append $leader to array $result
+
+$follower = $leader -> get formation follower ships
+$cnt =  size of array $follower
+while $cnt
+dec $cnt =
+$t = $follower[$cnt]
+append $t to array $result
+end
+return $result

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wing.join.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wing.join.x3s
@@ -1,0 +1,22 @@
+#name: anarkis.lib.wing.join
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.wing.join.xml
+
+* ===========================================
+* Merge 2 wings in one
+* ===========================================
+
+$wing2 = [THIS] -> call script anarkis.lib.wing.getall :  ship=$leader.b
+$cnt =  size of array $wing2
+
+while $cnt
+dec $cnt =
+$ship = $wing2[$cnt]
+$ship -> remove from any formation
+$ship -> add to formation with leader $leader.a
+START $ship -> call script !ship.cmd.attacksame.std :  the target=$leader.a  stop if leader is docked=[TRUE]
+end
+
+
+return $leader.a

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wing.peace.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wing.peace.x3s
@@ -1,0 +1,22 @@
+#name: anarkis.lib.wing.peace
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.wing.peace.xml
+
+* ===========================================
+* Orders all ships in a wing to make peace with selected race
+* Input : any ship of the wing
+* ===========================================
+
+$wing = [THIS] -> call script anarkis.lib.wing.getall :  ship=$ship
+$cnt =  size of array $wing
+
+while $cnt
+dec $cnt =
+$select = $wing[$cnt]
+$select -> set relation against $race to Neutral
+$select -> set attack target to null
+$select -> set attacker to null
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wing.split.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wing.split.x3s
@@ -1,0 +1,33 @@
+#name: anarkis.lib.wing.split
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.wing.split.xml
+
+* ===========================================
+* Split a wing in two and returns secondary leader
+* Input : any ship of the wing + size of new wing
+* Output : New leader
+* ===========================================
+
+$old.wing = [THIS] -> call script anarkis.lib.wing.getall :  ship=$wing.leader
+$old.wing.size =  size of array $old.wing
+
+$cnt =  = random value from 1 to $old.wing.size - 1
+$new.leader = $old.wing[$cnt]
+$new.leader -> remove from any formation
+remove element from array $old.wing at index $cnt
+
+$cnt = $new.size
+$old.wing.size =  size of array $old.wing
+
+while $cnt
+dec $cnt =
+dec $old.wing.size =
+$ship = $old.wing[$old.wing.size]
+$ship -> remove from any formation
+$ship -> add to formation with leader $new.leader
+START $ship -> call script !ship.cmd.attacksame.std :  the target=$new.leader  stop if leader is docked=[TRUE]
+end
+
+
+return $new.leader

--- a/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wing.war.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/anarkis.lib.wing.war.x3s
@@ -1,0 +1,23 @@
+#name: anarkis.lib.wing.war
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.wing.war.xml
+
+* ===========================================
+* All ships in the wing will turn red and will attack the selected object
+* Input : any ship of the wing, the target.
+* ===========================================
+
+$wing = [THIS] -> call script anarkis.lib.wing.getall :  ship=$ship
+$cnt =  size of array $wing
+
+while $cnt
+dec $cnt =
+$select = $wing[$cnt]
+$select -> set relation against $target to Foe
+$select -> set attack target to $target
+$select -> set attacker to $target
+$select -> send signal SIGNAL_ATTACKED : arg1=$target, arg2=[ACTION_KILL_ALL_ENEMIES], arg3=null, arg4=null
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.al.init.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.al.init.x3s
@@ -1,0 +1,29 @@
+#name: plugin.sk.ecs.al.init
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.al.init.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+if  is datatyp[ $ecs.setup ] == DATATYP_ARRAY
+$ecs.setup[3] = [TRUE]
+else
+$ecs.setup =  array alloc: size=6
+$ecs.installed =  array alloc: size=0
+$ecs.configs =  array alloc: size=0
+$ecs.news =  array alloc: size=0
+$ecs.guilds =  array alloc: size=0
+$ecs.setup[0] = 250
+$ecs.setup[1] = $ecs.installed
+$ecs.setup[2] = $ecs.configs
+$ecs.setup[3] = [TRUE]
+$ecs.setup[4] = null
+$ecs.setup[5] = $ecs.news
+$ecs.setup[6] = $ecs.guilds
+end
+set global variable: name='plugin.ecs.setup' value=$ecs.setup
+= [THIS] -> call script plugin.sk.ecs.hotkey.install :
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.al.register.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.al.register.x3s
@@ -1,0 +1,48 @@
+#name: plugin.sk.ecs.al.register
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.al.register.xml
+
+$text.id = 8511
+
+$plugin.Vars = get global variable: name=$plugin.ID
+
+* setup new data structure and init it
+if not $plugin.Vars
+$plugin.Vars =  array alloc: size=2
+set global variable: name=$plugin.ID value=$plugin.Vars
+$plugin.Vars[0] = 0
+$plugin.Vars[1] = [TRUE]
+end
+
+* init and reinit are run every time the game loads
+if $plugin.Event == 'init' OR $plugin.Event == 'reinit'
+$desc = sprintf: pageid=$text.id textid=100, null, null, null, null, null
+al engine: set plugin $plugin.ID description to $desc
+$interval = 30 * 60
+al engine: set plugin $plugin.ID timer interval to $interval s
+skip if get global variable: name='plugin.ecs.setup'
+= [THIS] -> call script plugin.sk.ecs.al.init :
+
+else if $plugin.Event == 'isenabled'
+$desc = sprintf: pageid=$text.id textid=100, null, null, null, null, null
+al engine: set plugin $plugin.ID description to $desc
+$enabled = $plugin.Vars[1]
+return $enabled
+
+* Use this area to process special instructions when the plugin is toggled on
+else if $plugin.Event == 'start'
+$plugin.Vars[1] = [TRUE]
+= [THIS] -> call script plugin.sk.ecs.al.init :
+= [THIS] -> call script plugin.sk.ecs.manager :
+* Use this area to process special instructions when the plugin is toggled off
+else if $plugin.Event == 'stop'
+$plugin.Vars[1] = [FALSE]
+= [THIS] -> call script plugin.sk.ecs.al.stop :
+
+* The event script is called every interval
+else if $plugin.Event == 'timer'
+$enabled = $plugin.Vars[1]
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.al.stop.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.al.stop.x3s
@@ -1,0 +1,15 @@
+#name: plugin.sk.ecs.al.stop
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.al.stop.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+$ecs.setup[3] = [FALSE]
+set global variable: name='plugin.ecs.setup' value=$ecs.setup
+START [THIS] -> call script plugin.sk.ecs.manager :
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.call.script.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.call.script.x3s
@@ -1,0 +1,53 @@
+#name: plugin.sk.ecs.call.script
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.call.script.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* This script is started each time the ECS hotkey is pressed.
+* It gets the player's current targeti and check every ECS plugin to see if the
+* object is handled by such plugin. If found, it will run the plugin's comm.script
+* ===========================================
+
+$target =  get player tracking aim
+skip if $target -> exists
+return null
+$setup = get global variable: name='plugin.ecs.setup'
+skip if  is datatyp[ $setup ] == DATATYP_ARRAY
+return null
+
+$setup.installed = $setup[1]
+$setup.configs = $setup[2]
+
+$plugin.count =  size of array $setup.installed
+while $plugin.count
+dec $plugin.count =
+$plugin.name = $setup.installed[$plugin.count]
+if get global variable: name=$plugin.name
+$index =  get index of $plugin.name in array $setup.installed offset=-1 + 1
+$plugin.config = $setup.configs[$index]
+$plugin.config.global = $plugin.config[0]
+$plugin.config.script = $plugin.config[1]
+$plugin.config.local = $plugin.config[2]
+$plugin.config.race = $plugin.config[3]
+$plugin.config.class = $plugin.config[4]
+$target.local = $target -> get local variable: name=$plugin.config.local
+if $plugin.config.local != null AND $target.local == null
+continue
+end
+$target.race = $target -> get owner race
+if $plugin.config.race != null AND $target.race != $plugin.config.race
+continue
+end
+if $plugin.config.class != null
+skip if $target -> is of class $plugin.config.class
+continue
+end
+= [THIS] -> call named script: script=$plugin.config.script, $target, null, null, null, null
+break
+end
+end
+
+return [TRUE]

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dialog.menu.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dialog.menu.x3s
@@ -1,0 +1,35 @@
+#name: plugin.sk.ecs.dialog.menu
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dialog.menu.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* You can make your own menu using the new X3TC custom menu commands
+* And use this script to display it through ECS
+* ===========================================
+* Script Settings:
+* $ship : object sending the message (ship/station/roid/...)
+* $sound : Sound ID to be player with 'send audio message..' command (can be null)
+* $dialog.title : window's title
+* $dialog.menu : custom menu array
+* ===========================================
+* Script Returns:
+* -1 : Player closed the window pressing ESC
+* other : menu result
+* ===========================================
+
+$page.id = 8511
+
+$pilot.name = $ship -> get pilot name
+skip if $pilot.name
+$pilot.name = $ship
+
+skip if not $sound
+$ship -> send audio message $sound to player
+
+$from = sprintf: pageid=$page.id textid=217, $ship, null, null, null, null
+$menu.result =  open custom menu: title=$dialog.title description=$from option array=$dialog.menu
+
+return $menu.result

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dialog.ok.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dialog.ok.x3s
@@ -1,0 +1,47 @@
+#name: plugin.sk.ecs.dialog.ok
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dialog.ok.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* Call this script when you want to show a simple message windows with a single
+* ok button
+* ===========================================
+* Script Settings:
+* $ship : object sending the message (ship/station/roid/...)
+* $sound : Sound ID to be player with 'send audio message..' command (can be null)
+* $dialog.title : window's title
+* $dialog.content : window's main text
+* $dialog.ok : button ok caption
+* ===========================================
+* Script Returns: -1
+* ===========================================
+
+$page.id = 8511
+
+if $ship -> is of class Station
+$pilot.name = $ship -> get name
+else
+$pilot.name = $ship -> get pilot name
+skip if $pilot.name
+$pilot.name = $ship
+end
+
+skip if not $sound
+$ship -> send audio message $sound to player
+
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=224
+add custom menu heading to array $menu: title=$st
+add custom menu item to array $menu: text=$dialog.ok returnvalue=-1
+
+$st = sprintf: pageid=$page.id textid=225, $dialog.content, $pilot.name, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$from = sprintf: pageid=$page.id textid=217, $ship, null, null, null, null
+$menu.result =  open custom menu: title=$dialog.title description=$from option array=$menu
+
+return $menu.result

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dialog.yesno.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dialog.yesno.x3s
@@ -1,0 +1,53 @@
+#name: plugin.sk.ecs.dialog.yesno
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dialog.yesno.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* Call this script when you want to show a dialog window with 2 possible
+* answers.
+* ===========================================
+* Script Settings:
+* $ship : object sending the message (ship/station/roid/...)
+* $sound : Sound ID to be player with 'send audio message..' command (can be null)
+* $dialog.title : window's title
+* $dialog.content : window's main text
+* $dialog.yes : option 1 caption
+* $dialog.no : option 2 caption
+* ===========================================
+* Script Returns:
+* -1 : Player closed the window pressing ESC
+* 1 : Player choosed the first answer
+* 2 : Player choosed the second answer
+* ===========================================
+
+$page.id = 8511
+
+if $ship -> is of class Station
+$pilot.name = $ship -> get name
+else
+$pilot.name = $ship -> get pilot name
+skip if $pilot.name
+$pilot.name = $ship
+end
+
+skip if not $sound
+$ship -> send audio message $sound to player
+
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=224
+add custom menu heading to array $menu: title=$st
+add custom menu item to array $menu: text=$dialog.yes returnvalue=1
+add custom menu item to array $menu: text=$dialog.no returnvalue=2
+
+$st = sprintf: pageid=$page.id textid=225, $dialog.content, $pilot.name, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$from = sprintf: pageid=$page.id textid=217, $ship, null, null, null, null
+$menu.result =  open custom menu: title=$dialog.title description=$from option array=$menu
+
+
+return $menu.result

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dummy.commscript.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dummy.commscript.x3s
@@ -1,0 +1,22 @@
+#name: plugin.sk.ecs.dummy.commscript
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dummy.commscript.xml
+
+* Here, each time the player 'spot' / ecs-comm a ship, it willl add a report
+* to the ECS Newsfeed. Notice that a true plugin should aim for a specific target
+* with local variable on the targeted object, or a specific class, etc.
+
+$pl.sector = [PLAYERSHIP] -> get sector
+$sector = $target -> get sector
+
+
+$title = sprintf: fmt='%s located here : %s', $target, $sector, null, null, null
+$content = sprintf: fmt='%s has been spotted in sector %s', $target, $sector, null, null, null
+= [THIS] -> call script plugin.sk.ecs.news.add :  Plugin ID='plugin.ecs.dummy'  News Title=$title  News Content=$content  from=[PLAYERSHIP]
+
+* And then, show the newsfeed (with the 10 last scanned roids):
+= [THIS] -> call script plugin.sk.ecs.news.display :  Plugin ID='plugin.ecs.dummy'
+
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dummy.register.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dummy.register.x3s
@@ -1,0 +1,25 @@
+#name: plugin.sk.ecs.dummy.register
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dummy.register.xml
+
+* We create an array with this example script's ECS setup
+* Read the documentation included in plugin.sk.ecs.register for details
+$setup =  array alloc: size=7
+* Default value: script to call when hotkey is pressed, local var to check on
+* selected object, race and class check of selected object.
+$setup[0] = 'plugin.ecs.dummy'
+$setup[1] = 'plugin.ecs.dummy.commscript'
+$setup[2] = null
+$setup[3] = null
+$setup[4] = Ship
+* ECS Newsfeed setup (can be null if not used)
+* Index 5 is max amount of news to store, 6 is the newsfeed window's title.
+$setup[5] = 10
+$setup[6] = 'ECS Spy Ship'
+
+* We call register to add the script to the ECS plugin list
+skip if [THIS] -> call script plugin.sk.ecs.register :  Setup Array=$setup
+send incoming message 'Error registering dummy script' to player: display it=[TRUE]
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dummy.remove.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dummy.remove.x3s
@@ -1,0 +1,10 @@
+#name: plugin.sk.ecs.dummy.remove
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dummy.remove.xml
+
+
+skip if [THIS] -> call script plugin.sk.ecs.unregister :  Plugin ID='plugin.ecs.dummy'
+send incoming message 'Error removing dummy from ECS' to player: display it=[TRUE]
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dummy.setup.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dummy.setup.x3s
@@ -1,0 +1,26 @@
+#name: plugin.sk.ecs.dummy.setup
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dummy.setup.xml
+
+* ===========================================
+* ECS 2.5 Demo Script - Spy Ship
+* ===========================================
+* This example script allows the player to keep track of the 10 last
+* ships he has spotted, with current location info
+* ===========================================
+* This script should be renamed/copied as setup.ecs.dummy to be
+* run when game starts.
+* ===========================================
+
+* We set a global to easily check if the script is installed
+set global variable: name='plugin.ecs.dummy' value=[TRUE]
+
+* Then we call the script used to register to ECS
+= [THIS] -> call script plugin.sk.ecs.dummy.register :
+
+* ... here comes whatever you need to add in your setup script ...
+
+* ...
+
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dummy.uninstall.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.dummy.uninstall.x3s
@@ -1,0 +1,20 @@
+#name: plugin.sk.ecs.dummy.uninstall
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dummy.uninstall.xml
+
+* ===========================================
+* Usually, ECS plugins should be released as AL plugins and this script should be
+* called in the AL 'stop' event. Anyway, it's used here to unregister to  ECS.
+* ===========================================
+
+* We disable the scipt's global variable
+set global variable: name='plugin.ecs.dummy' value=null
+
+* Function used to remove all messages in the ECS Newsfeed, not mendatory here.
+= [THIS] -> call script plugin.sk.ecs.news.clear :  Plugin ID='plugin.ecs.dummy'
+* I cleany unregister to ECS here. AL plugin can also only alter the plugin's
+* global variable here.
+skip if [THIS] -> call script plugin.sk.ecs.unregister :  Plugin ID='plugin.ecs.dummy'
+send incoming message 'Unable to unregister dummy script : Script not registered to ECS' to player: display it=[TRUE]
+return null

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.hotkey.install.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.hotkey.install.x3s
@@ -1,0 +1,16 @@
+#name: plugin.sk.ecs.hotkey.install
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.hotkey.install.xml
+
+$setup = get global variable: name='plugin.ecs.setup'
+skip if  is datatyp[ $setup ] == DATATYP_ARRAY
+return null
+$hotkey.id = $setup[4]
+skip if not $hotkey.id
+return null
+$msg = sprintf: pageid=8511 textid=103, null, null, null, null, null
+$hotkey.id =  register hotkey $msg to call script plugin.sk.ecs.call.script
+$setup[4] = $hotkey.id
+set global variable: name='anarkis.ecs.setup' value=$setup
+return [TRUE]

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.hotkey.remove.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.hotkey.remove.x3s
@@ -1,0 +1,15 @@
+#name: plugin.sk.ecs.hotkey.remove
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.hotkey.remove.xml
+
+$setup = get global variable: name='plugin.ecs.setup'
+skip if  is datatyp[ $setup ] == DATATYP_ARRAY
+return null
+$hotkey.id = $setup[4]
+skip if $hotkey.id
+return null
+unregister hotkey $hotkey.id
+$setup[4] = null
+set global variable: name='anarkis.ecs.setup' value=$setup
+return [TRUE]

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.manager.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.manager.x3s
@@ -1,0 +1,112 @@
+#name: plugin.sk.ecs.manager
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.manager.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+
+* Retrieve ECS configuration
+$page.id = 8511
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+$ecs.installed = $ecs.setup[1]
+$ecs.configs = $ecs.setup[2]
+$status = $ecs.setup[3]
+$ecs.news = $ecs.setup[5]
+
+$res = 0
+$selected = 0
+while $res != -1
+$menu =  create custom menu array
+$st = sprintf: pageid=$page.id textid=211, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=213, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=-1
+if not $status
+$st = sprintf: pageid=$page.id textid=212, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=3
+end
+
+$st = sprintf: pageid=$page.id textid=202, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$cnt =  size of array $ecs.configs
+while $cnt
+dec $cnt =
+$cfg = $ecs.configs[$cnt]
+$v1 = $cfg[0]
+$v2 = get global variable: name=$v1
+if $v2
+$v2 =  read text: page=$page.id id=303
+else
+$v2 =  read text: page=$page.id id=302
+end
+$st = sprintf: pageid=$page.id textid=203, $v1, $v2, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=$v1
+end
+
+if  find $selected in array: $ecs.installed
+
+$st = sprintf: pageid=$page.id textid=204, $res, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$v2 =  read text: page=$page.id id=206
+add custom menu item to array $menu: text=$v2 returnvalue=2
+
+$st =  read text: page=$page.id id=205
+add custom menu heading to array $menu: title=$st
+
+$index =  get index of $res in array $ecs.installed offset=-1 + 1
+$mycfg = $ecs.configs[$index]
+$v1 = $mycfg[1]
+$st = sprintf: pageid=$page.id textid=207, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=0
+$v1 = $mycfg[2]
+$st = sprintf: pageid=$page.id textid=208, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=0
+$v1 = $mycfg[3]
+$st = sprintf: pageid=$page.id textid=209, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=0
+$v1 = $mycfg[4]
+$st = sprintf: pageid=$page.id textid=210, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=0
+$v1 = $mycfg[5]
+$st = sprintf: pageid=$page.id textid=226, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=0
+$v1 = $mycfg[6]
+$st = sprintf: pageid=$page.id textid=227, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=0
+
+end
+
+if $status
+$v2 =  read text: page=$page.id id=300
+else
+$v2 =  read text: page=$page.id id=301
+end
+$st = sprintf: pageid=$page.id textid=201, $v2, null, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=200
+$v2 =  read text: page=$page.id id=104
+$res =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+if $res == 2
+= [THIS] -> call script plugin.sk.ecs.unregister :  Plugin ID=$selected
+$selected = null
+else if $res == 3
+= [THIS] -> call script plugin.sk.ecs.hotkey.remove :
+$ecs.configs =  array alloc: size=0
+$ecs.installed =  array alloc: size=0
+$ecs.setup =  array alloc: size=0
+$ecs.news =  array alloc: size=0
+$selected = null
+set global variable: name='plugin.ecs.setup' value=null
+$st =  read text: page=$page.id id=214
+send incoming message $st to player: display it=[TRUE]
+return [TRUE]
+else if  is datatyp[ $res ] == DATATYP_STRING
+$selected = $res
+end
+
+end
+return [TRUE]

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.news.add.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.news.add.x3s
@@ -1,0 +1,51 @@
+#name: plugin.sk.ecs.news.add
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.news.add.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* Use this function to add a news/message to the list.
+* ===========================================
+* Parameter :
+* - plugin.id : The global variable you used to register (string)
+* - news.title : News Title
+* - news.content : Main text of the news
+* - news.from : Who is sending this message (optional)
+* ===========================================
+
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+$ecs.installed = $ecs.setup[1]
+$ecs.configs = $ecs.setup[2]
+$ecs.news = $ecs.setup[5]
+
+skip if  find $plugin.id in array: $ecs.installed
+return null
+$index =  get index of $plugin.id in array $ecs.installed offset=-1 + 1
+
+$my.config = $ecs.configs[$index]
+$max.news.count = $my.config[5]
+$news.list = $ecs.news[$index]
+
+
+$my.news =  array alloc: size=4
+$my.news[0] = $news.title
+$my.news[1] = $news.content
+$my.news[2] = $news.from
+$pl.time = playing time
+$my.news[3] = $pl.time
+if $news.list
+insert $my.news into array $news.list at index 0
+else
+$news.list =  array alloc: size=1
+$news.list[0] = $my.news
+end
+
+$news.count =  size of array $news.list
+if $news.count > $max.news.count
+resize array $news.list to $max.news.count
+end
+
+
+return [TRUE]

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.news.clear.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.news.clear.x3s
@@ -1,0 +1,26 @@
+#name: plugin.sk.ecs.news.clear
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.news.clear.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* Use this function to remove all news from the current list
+* ===========================================
+* Parameter :
+* - plugin.id : The global variable you used to register (string)
+* ===========================================
+
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+$ecs.installed = $ecs.setup[1]
+$ecs.configs = $ecs.setup[2]
+$ecs.news = $ecs.setup[5]
+
+skip if  find $plugin.id in array: $ecs.installed
+return null
+
+$my.news =  array alloc: size=0
+$ecs.news[$index] = $my.news
+
+return [TRUE]

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.news.display.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.news.display.x3s
@@ -1,0 +1,86 @@
+#name: plugin.sk.ecs.news.display
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.news.display.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* Use this script to show the News List GUI. It will show a menu allowing the
+* player to browse the latest messages posted to news list.
+* ===========================================
+* Parameter :
+* - plugin.id : The global variable you used to register (string)
+* ===========================================
+
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+load text: id=8511
+$ecs.installed = $ecs.setup[1]
+$ecs.configs = $ecs.setup[2]
+$ecs.news = $ecs.setup[5]
+
+skip if  find $plugin.id in array: $ecs.installed
+return null
+$index =  get index of $plugin.id in array $ecs.installed offset=-1 + 1
+
+$my.config = $ecs.configs[$index]
+$max.news.count = $my.config[5]
+$bbs.title = $my.config[6]
+
+$news.list = $ecs.news[$index]
+$news.count =  size of array $news.list
+$menu.result = 0
+$selected = -1
+while $menu.result != -1
+$menu =  create custom menu array
+$string = sprintf: pageid=8511 textid=221, null, null, null, null, null
+add custom menu heading to array $menu: title=$string
+if $news.count
+$x = 0
+while $x < $news.count
+$c.news = $news.list[$x]
+$c.news.title = $c.news[0]
+$ago = $c.news[3]
+$pl.time = playing time
+$ago = $pl.time - $ago
+$ago =  format time: $ago
+$string = sprintf: pageid=8511 textid=216, $ago, $c.news.title, null, null, null
+$res = $x + 10
+add custom menu item to array $menu: text=$string returnvalue=$res
+inc $x =
+end
+else
+$string = sprintf: pageid=8511 textid=222, null, null, null, null, null
+add custom menu item to array $menu: text=$string returnvalue=-1
+end
+
+if $selected >= 0
+$c.news = $news.list[$selected]
+$c.title = $c.news[0]
+$c.content = $c.news[1]
+$c.from = $c.news[2]
+$ago = $c.news[3]
+$pl.time = playing time
+$ago = $pl.time - $ago
+$ago =  format time: $ago
+$string = sprintf: pageid=8511 textid=220, $c.title, null, null, null, null
+add custom menu info line to array $menu: text=$string
+$string = sprintf: pageid=8511 textid=218, $c.content, $ago, null, null, null
+add custom menu info line to array $menu: text=$string
+if $c.from -> exists
+$string = sprintf: pageid=8511 textid=217, $c.from, null, null, null, null
+else
+$string = null
+end
+else
+$string = sprintf: pageid=8511 textid=223, null, null, null, null, null
+add custom menu info line to array $menu: text=$string
+end
+$menu.result =  open custom menu: title=$bbs.title description=$string option array=$menu
+if $menu.result != -1
+$menu.result = $menu.result - 10
+$selected = $menu.result
+end
+end
+
+return [TRUE]

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.news.getrandom.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.news.getrandom.x3s
@@ -1,0 +1,41 @@
+#name: plugin.sk.ecs.news.getrandom
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.news.getrandom.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* Use this function to get a random message from the list
+* ===========================================
+* Parameter :
+* - plugin.id : The global variable you used to register (string)
+* ===========================================
+* Output : Array
+* - 0 : Title
+* - 1 : Main text of the news
+* - 2 : Who is sending this message (optional)
+* - 3 : Date of publication
+* ===========================================
+
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+$ecs.installed = $ecs.setup[1]
+$ecs.configs = $ecs.setup[2]
+$ecs.news = $ecs.setup[5]
+
+skip if  find $plugin.id in array: $ecs.installed
+return null
+$index =  get index of $plugin.id in array $ecs.installed offset=-1 + 1
+
+$my.config = $ecs.configs[$index]
+$max.news.count = $my.config[5]
+$news.list = $ecs.news[$index]
+
+$mycount =  size of array $news.list
+skip if not $mycount == 0
+return null
+
+$mycount =  = random value from 0 to $mycount - 1
+$result = $news.list[$mycount]
+
+return $result

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.register.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.register.x3s
@@ -1,0 +1,69 @@
+#name: plugin.sk.ecs.register
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.register.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* Use this function to register your plugin or script to ECS, allowing you
+* to use the ECS hotkey
+* ===========================================
+* Parameter : SETUP -> Array
+* - 00 : Global variable to check to see if your plugin is enabled (string)
+* - 01 : Script to call when the ECS key is pressed (string)
+* - 02 : Restrict ECS to objects with this local variable set to TRUE (string)
+* - 03 : Restrict ECS to this RACE (var/race)
+* - 04 : Restrict ECS to this Object Class (var/class)
+* - 05 : News Channel (null=off, else max amount of news to store)
+* - 06 : News System Name (string, can be null if not used)
+* Indexes 02, 03, 04, 05 can be null
+* As an example Pirate Guild use the following SETUP array :
+* - 00 : anarkis.pirate.plugin (will check this global)
+* - 01 : anarkis.pirate.comm (if found, it will call this script only...)
+* - 02 : anarkis.pirate (... if this local var is found)
+* - 03 : Pirates (and this is pirate owned object)
+* - 04 : null (we dont care about object class)
+* - 05 : 12 (we want to store 12 most recent news)
+* - 06 : "Pirate Guild BBS"
+* ===========================================
+* Output :
+* - null : Script registration failed
+* - TRUE : Your script has be registered to ECS
+* ===========================================
+* If a same script is re registered, previous config will be overwritten.
+* ===========================================
+
+* Check the parameter, quit if error
+skip if  is datatyp[ $setup ] == DATATYP_ARRAY
+return null
+$setup.width =  size of array $setup
+if $setup.width != 7
+resize array $setup to 7
+end
+$setup.width =  size of array $setup
+* ---
+
+$global = $setup[0]
+
+* Retrieve ECS configuration
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+$ecs.installed = $ecs.setup[1]
+$ecs.configs = $ecs.setup[2]
+$ecs.news = $ecs.setup[5]
+if  find $global in array: $ecs.installed
+* - Update if setup already found in list
+$index =  get index of $global in array $ecs.installed offset=-1 + 1
+$config.to.update = $ecs.configs[$index]
+copy array $setup index 0 ... 6 into array $config.to.update at index 0
+* - ---
+else
+* - We add the new plugin (todo: conflict check)
+append $global to array $ecs.installed
+append $setup to array $ecs.configs
+$my.news =  array alloc: size=0
+append $my.news to array $ecs.news
+* - ---
+end
+* ---
+return [TRUE]

--- a/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.unregister.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/plugin.sk.ecs.unregister.x3s
@@ -1,0 +1,32 @@
+#name: plugin.sk.ecs.unregister
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.unregister.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* Use this function to remove your plugin or script from ECS
+* ===========================================
+* Parameter :
+* - plugin.id : The global variable you used to register (string)
+* ===========================================
+* Output :
+* - null : Script isn't registered
+* - TRUE : Script removed succesfully
+* ===========================================
+
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+$ecs.installed = $ecs.setup[1]
+$ecs.configs = $ecs.setup[2]
+$ecs.news = $ecs.setup[5]
+
+skip if  find $plugin.id in array: $ecs.installed
+return null
+
+$index =  get index of $plugin.id in array $ecs.installed offset=-1 + 1
+remove element from array $ecs.installed at index $index
+remove element from array $ecs.configs at index $index
+remove element from array $ecs.news at index $index
+
+return [TRUE]

--- a/tools/fixtures/known_good/ADS/src/scripts/setup.anarkis.acc.x3s
+++ b/tools/fixtures/known_good/ADS/src/scripts/setup.anarkis.acc.x3s
@@ -1,0 +1,108 @@
+#name: setup.anarkis.acc
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/setup.anarkis.acc.xml
+
+$PageID = 8510
+load text: id=$PageID
+
+$ver =  read text: page=$PageID id=101
+$ver =  string $ver to integer
+$c.ver = get global variable: name='anarkis.acc.plugin'
+$update = [FALSE]
+set global variable: name='anarkis.ads.manager.open' value=null
+
+* New install, add hotkeys
+if $c.ver == null
+= [THIS] -> call script anarkis.acc.hotkey.install :
+$gl.setup = [THIS] -> call script anarkis.ads.setup.init :
+$msg = sprintf: pageid=$PageID textid=103, $ver, null, null, null, null
+send incoming message $msg to player: display it=[TRUE]
+set global variable: name='anarkis.acc.plugin' value=$ver
+START [THIS] -> call script anarkis.acc.ecs.register :
+* Upgrade Needed
+else if $ver > $c.ver
+$update = [TRUE]
+if $ver == 255
+= [THIS] -> call script anarkis.acc.hotkey.uninstall :
+end
+= [THIS] -> call script anarkis.acc.ecs.remove :
+
+skip if get global variable: name='anarkis.ads.setup'
+$gl.setup = [THIS] -> call script anarkis.ads.setup.init :
+
+= [THIS] -> call script anarkis.acc.upgrade.disable :
+
+
+end
+= wait 1000 ms
+
+set script command upgrade: command=ANARKIS_DOCKALL  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_DOCKALL, class=M1, race=Player, script=anarkis.acc.cmd.dock.all.pl, prio=0
+global script map: set: key=ANARKIS_DOCKALL, class=M7, race=Player, script=anarkis.acc.cmd.dock.all.pl, prio=0
+global script map: set: key=ANARKIS_DOCKALL, class=TL, race=Player, script=anarkis.acc.cmd.dock.all.pl, prio=0
+global script map: set: key=ANARKIS_DOCKALL, class=TM, race=Player, script=anarkis.acc.cmd.dock.all.pl, prio=0
+
+
+set script command upgrade: command=ANARKIS_BUYWARES  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_BUYWARES, class=M1, race=Player, script=anarkis.acc.cmd.buywares.pl, prio=0
+global script map: set: key=ANARKIS_BUYWARES, class=M7, race=Player, script=anarkis.acc.cmd.buywares.pl, prio=0
+global script map: set: key=ANARKIS_BUYWARES, class=TL, race=Player, script=anarkis.acc.cmd.buywares.pl, prio=0
+global script map: set: key=ANARKIS_BUYWARES, class=TM, race=Player, script=anarkis.acc.cmd.buywares.pl, prio=0
+
+set script command upgrade: command=ANARKIS_SELLWARES  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_SELLWARES, class=M1, race=Player, script=anarkis.acc.cmd.sellwares.pl, prio=0
+global script map: set: key=ANARKIS_SELLWARES, class=M7, race=Player, script=anarkis.acc.cmd.sellwares.pl, prio=0
+global script map: set: key=ANARKIS_SELLWARES, class=TL, race=Player, script=anarkis.acc.cmd.sellwares.pl, prio=0
+global script map: set: key=ANARKIS_SELLWARES, class=TM, race=Player, script=anarkis.acc.cmd.sellwares.pl, prio=0
+
+set script command upgrade: command=ANARKIS_STATIONDEFENSE  upgrade=[TRUE]
+global script map: set: key=ANARKIS_STATIONDEFENSE, class=Dock, race=Player, script=anarkis.acc.cmd.call.autostation, prio=0
+
+set script command upgrade: command=ANARKIS_SETUPSTATION  upgrade=[TRUE]
+global script map: set: key=ANARKIS_SETUPSTATION, class=Dock, race=Player, script=anarkis.acc.setup, prio=0
+
+set script command upgrade: command=ANARKIS_AUTOCARRIER  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_AUTOCARRIER, class=M1, race=Player, script=anarkis.acc.cmd.call.autocarrier, prio=0
+global script map: set: key=ANARKIS_AUTOCARRIER, class=M7, race=Player, script=anarkis.acc.cmd.call.autocarrier, prio=0
+global script map: set: key=ANARKIS_AUTOCARRIER, class=TL, race=Player, script=anarkis.acc.cmd.call.autocarrier, prio=0
+global script map: set: key=ANARKIS_AUTOCARRIER, class=TM, race=Player, script=anarkis.acc.cmd.call.autocarrier, prio=0
+
+set script command upgrade: command=ANARKIS_SETTACTICS  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_SETTACTICS, class=M1, race=Player, script=anarkis.acc.setup, prio=0
+global script map: set: key=ANARKIS_SETTACTICS, class=M7, race=Player, script=anarkis.acc.setup, prio=0
+global script map: set: key=ANARKIS_SETTACTICS, class=TL, race=Player, script=anarkis.acc.setup, prio=0
+global script map: set: key=ANARKIS_SETTACTICS, class=TM, race=Player, script=anarkis.acc.setup, prio=0
+
+set script command upgrade: command=ANARKIS_ATTACKWING  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_ATTACKWING, class=M1, race=Player, script=anarkis.ads.wing.attack.pl, prio=0
+global script map: set: key=ANARKIS_ATTACKWING, class=M7, race=Player, script=anarkis.ads.wing.attack.pl, prio=0
+global script map: set: key=ANARKIS_ATTACKWING, class=TL, race=Player, script=anarkis.ads.wing.attack.pl, prio=0
+global script map: set: key=ANARKIS_ATTACKWING, class=TM, race=Player, script=anarkis.ads.wing.attack.pl, prio=0
+
+set script command upgrade: command=ANARKIS_DEFENSIVEWING  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_DEFENSIVEWING, class=M1, race=Player, script=anarkis.ads.wing.defense.pl, prio=0
+global script map: set: key=ANARKIS_DEFENSIVEWING, class=M7, race=Player, script=anarkis.ads.wing.defense.pl, prio=0
+global script map: set: key=ANARKIS_DEFENSIVEWING, class=TL, race=Player, script=anarkis.ads.wing.defense.pl, prio=0
+global script map: set: key=ANARKIS_DEFENSIVEWING, class=TM, race=Player, script=anarkis.ads.wing.defense.pl, prio=0
+
+set script command upgrade: command=ANARKIS_CLEANSECTOR  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_CLEANSECTOR, class=M1, race=Player, script=anarkis.acc.wing.clearsector.pl, prio=0
+global script map: set: key=ANARKIS_CLEANSECTOR, class=M7, race=Player, script=anarkis.acc.wing.clearsector.pl, prio=0
+global script map: set: key=ANARKIS_CLEANSECTOR, class=TL, race=Player, script=anarkis.acc.wing.clearsector.pl, prio=0
+global script map: set: key=ANARKIS_CLEANSECTOR, class=TM, race=Player, script=anarkis.acc.wing.clearsector.pl, prio=0
+
+* Restore cmds if doing update
+if $update == [TRUE]
+= [THIS] -> call script anarkis.acc.upgrade.enable :
+= [THIS] -> call script anarkis.acc.ecs.register :
+if $ver == 255
+= [THIS] -> call script anarkis.acc.hotkey.install :
+end
+
+set global variable: name='anarkis.acc.plugin' value=$ver
+$msg = sprintf: pageid=$PageID textid=104, $ver, null, null, null, null
+send incoming message $msg to player: display it=[TRUE]
+end
+
+return null

--- a/tools/fixtures/known_good/ADS/t/8510-L033.xml
+++ b/tools/fixtures/known_good/ADS/t/8510-L033.xml
@@ -1,0 +1,465 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<language id="33">
+
+<page id="2008" title="Script Object Commands" descr="0">
+ <t id="830">ANARKIS_SETDOCKED</t>
+ <t id="831">ANARKIS_SELLWARES</t>
+ <t id="832">ANARKIS_BUYWARES</t>
+ <t id="833">ANARKIS_DEFENSIVEWING</t>
+ <t id="834">ANARKIS_ATTACKWING</t>
+ <t id="835">ANARKIS_CLEANSECTOR</t>
+ <t id="836">ANARKIS_DOCKALL</t>
+ <t id="1231">ANARKIS_SETTACTICS</t>
+ <t id="1232">ANARKIS_AUTOCARRIER</t>
+ <t id="1131">ANARKIS_SETUPSTATION</t>
+ <t id="1132">ANARKIS_STATIONDEFENSE</t>
+</page>
+
+<page id="2010" title="Script Cmd Names" descr="Long version of commandos. These are the commandos assigned to ships using the commandconsole. Page 2010 and 2011 belong together and hold short and long versions of the same commands"> 
+ <t id="830">\033RADS:\033X Reglages de Base</t>
+ <t id="831">\033RADS:\033X Vendre marchandises...</t>
+ <t id="832">\033RADS:\033X Acheter marchandises...</t>
+ <t id="833">\033RADS:\033X Défendre...</t>
+ <t id="834">\033RADS:\033X Attaquer...</t>
+ <t id="835">\033RADS:\033X Nettoyer Secteur</t>
+ <t id="836">\033RADS:\033X Amarrer Chasseurs</t>
+ <t id="1231">\033RADS:\033X Configuration</t>
+ <t id="1232">\033RADS:\033X Mode Automatique</t>
+ <t id="1131">\033RADS:\033X Configuration</t>
+ <t id="1132">\033RADS:\033X Défendre Secteur</t>
+</page> 
+
+<page id="2011" title="Script Cmd Shorts" descr="Short version of commandos. These are the commandos assigned to ships using the commandconsole. Page 2010 and 2011 belong together and hold short and long versions of the same commands"> 
+ <t id="830">set.homebase</t>  
+ <t id="831">sell.ware</t>
+ <t id="832">buy.ware</t>
+ <t id="833">defense.wing</t>
+ <t id="834">attack.wing</t>
+ <t id="835">clean.sector</t>
+ <t id="836">dock.ships</t>
+ <t id="1131">set.defense</t>
+ <t id="1132">auto.station</t>
+ <t id="1231">set.tactics</t>
+ <t id="1232">auto.carrier</t>
+</page> 
+
+<page id="2022"> 
+ <t id="830">Permet de changer la base et le nom des vaisseaux amarrés au navire porteur.</t>  
+ <t id="831">Envoie les vaisseaux vendre les marchandises de ce porteur</t>
+ <t id="832">Envoie les vaisseaux acheter des marchandises pour ce porteur</t>
+ <t id="833">Envoie un groupe de navires défendre le porteur ou un autre navire</t>
+ <t id="834">Envoie un groupe de navires attaquer une cible</t>
+ <t id="835">Nettoie le secteur de toute activité adverse</t>
+ <t id="836">Rappelle tous les navires vers ce porteur, ils utiliseront le moteur de saut si besoin est.</t>
+ <t id="1131">Configurer le système de défense sur cette station.</t>
+ <t id="1132">Active le mode automatique pour cette station. Elle protègera le secteur contre les activités hostiles.</t>
+ <t id="1231">Permet de regler tous les paramêtres du porteur et de ses navires amarrés.</t>
+ <t id="1232">Active le mode automatique. Le porteur se défendra automatiquement contre tout hostile à portée.</t>
+</page> 
+
+<page id="2022"> 
+ <t id="830">Permet de changer la base et le nom des vaisseaux amarrés au navire porteur.</t>  
+ <t id="831">Envoie les vaisseaux vendre les marchandises de ce porteur</t>
+ <t id="832">Envoie les vaisseaux acheter des marchandises pour ce porteur</t>
+ <t id="833">Envoie un groupe de navires défendre le porteur ou un autre navire</t>
+ <t id="834">Envoie un groupe de navires attaquer une cible</t>
+ <t id="835">Nettoie le secteur de toute activité adverse</t>
+ <t id="836">Rappelle tous les navires vers ce porteur, ils utiliseront le moteur de saut si besoin est.</t>
+ <t id="1131">Configurer le système de défense sur cette station.</t>
+ <t id="1132">Active le mode automatique pour cette station. Elle protègera le secteur contre les activités hostiles.</t>
+ <t id="1231">Permet de regler tous les paramêtres du porteur et de ses navires amarrés.</t>
+ <t id="1232">Active le mode automatique. Le porteur se défendra automatiquement contre tout hostile à portée.</t>
+</page> 
+
+<page id="8510" title="ACC" descr="Anarkis Command Carrier">
+ <t id="100">\033RADS:\033X Anarkis Defense System</t>
+ <t id="101">260</t>
+ <t id="102">Anarkis Federation</t>
+ <t id="103">[author][b]Anarkis Federation[/b][/author][b]Anarkis Defense System[/b] v%s installé avec succés !</t>
+ <t id="104">[author][b]Anarkis Federation[/b][/author][b]Anarkis Defense System[/b] mis à jour vers la version %s !</t>
+ <t id="105">[author][b]ADS - %s[/b][/author] Vous ne pouvez pas utiliser cette commande sur votre vaisseau personnel.</t>
+ <t id="106">[author][b]Anarkis Federation[/b][/author][b]Anarkis Defense System[/b] a été supprimé.\nVeuillez maintenant sauvegarder la partie, quitter X3 et lancer le fichier 'uninstall acc.bat' situé dans le dossier de X3TC.</t>
+ 
+ <t id="200">Menu ADS</t>
+
+ <t id="210">General</t>
+ <t id="211">Hangars ...</t>
+ <t id="212">Rapports d'activité ADS</t>
+ <t id="213">Utilisation des Missiles  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="214">Saut d'urgence  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X - Limite du Bouclier  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="215">Saut automatique  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X - Distance minimale  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="216">Réapprovision d'énergie \(nb de sauts\)  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="217">Configurer les navires amarrés</t>
+
+ <t id="220">Configuration du Mode Automatique</t>
+ <t id="221">\033WNiveau de Menace Minimal\033X</t>
+ <t id="222">\033WMessage d'avertissement\033X</t>
+ <t id="223">\033WForcer les chasseurs endommagés à fuire\033X</t>
+ <t id="224">\033WMode d'attaque\033X</t>
+ <t id="225">\033WNombre de chasseurs défensifs\033X</t>
+ <t id="226">\033WPortée Radar\033X</t>
+ <t id="227">Ignorer Factions  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="228">Affichage</t>
+ <t id="229">\033WType d'avertissement\033X</t>
+  
+ <t id="230">Configuration du plugin ADS</t>
+ <t id="231">Appliquer réglages à \033Ytous\033X les navires amarrés</t>
+ <t id="232">Restaurer les réglages par défaut</t>
+ <t id="233">Sous-Titres</t>
+ <t id="234">Audio</t>
+ <t id="235">Message Popup</t>
+ <t id="236">Mode Debug  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="237">Appliquer réglages aux navires \033Yactifs\033X seulement</t>
+
+ <t id="238">\033WTemps d'attente avant d'amarrer les chasseurs\033X</t>
+
+ 
+ <t id="240">Réglages du Navire Porteur</t>
+ <t id="241">Mode Automatique...</t>
+ <t id="242">Zone de Réparation ...</t>
+ <t id="243">Transfert d'équipement ...</t>
+ <t id="244">Reglage des tourelles : \033Y%s\033X</t>
+ <t id="245">Protéger Vaisseau</t>
+ <t id="246">Attaquer Ennemis</t>
+ <t id="247">Défense anti-missile</t>
+ <t id="248">\033RMARS:\033X Offense</t>
+ <t id="249">\033RMARS:\033X Defense</t>
+ 
+ <t id="201">Activé</t>
+ <t id="202">Désactivé</t>
+ <t id="203">Oui</t>
+ <t id="204">Non</t>
+ <t id="205">Defaut</t>
+ <t id="206">Sélection Automatique</t>
+ <t id="207">Plus fort en premier</t>
+ <t id="208">Plus proche en premier</t>
+ <t id="209">Aucun</t>
+ 
+ <t id="250">Porteur : \033Y%s\033X [%s]</t>
+ <t id="251">Location : \033Y%s\033X</t>
+ <t id="252">Amarré : %s/%s - Détenu : %s</t>
+ <t id="260">© Serial Kicked / [\033YAnarkis Federation\033X]</t>
+ 
+ <t id="300">Choisissez le nombre de navires utilisés pour la défense</t>
+ <t id="301">Choix du mode de sélection de cible</t>
+ <t id="302">Choisissez comment les vaisseaux de combat vont choisir leur cible.</t>
+ <t id="303">Forcer les navires endommagés à retourner s'amarrer au porteur?</t>
+ <t id="304">Afficher un message d'avertissement quand le porteur est en danger?</t>
+ <t id="305">Ce menu permet de choisir quel quantité d'hostile est nécessaire pour declencher le lancement des chasseurs actifs. Pour comprendre comment ce système fonctionne vous devez connaitre le niveau d'alerte correspondant à chaque classe de vaisseau, ce qui est expliqué ci dessous, et savoir que le porteur deploiera toujours ses vaisseaux s'il rencontre un M1 ou un M2. Les drones sont ignorés.</t>
+ <t id="306">M5: 1 - M4: 2  - M3: 5 - M8: 10 - M6: 14 - M7: 35\nTL: 15 - TM: 8 - TP/TS: 2\n\n\n\n</t>
+ <t id="307">Niveau de Menace Minimal</t>
+ <t id="308">Choisissez combien de carburant les vaisseaux emporteront avec eux en mission. Indiquez la distance de saut voulue.</t>
+ <t id="309">Voulez vous activer l'utilisation automatique du moteur de saut pour les vaisseaux du porteur?</t>
+ <t id="310">Choisissez la distance minimale pour effectuer un saut automatique</t>
+ <t id="311">Voulez vous activer le saut d'urgence sur les navires de ce porteur?</t>
+ <t id="312">Niveau minimal du bouclier pour déclencher le saut d'urgence, en pourcentage.</t>
+ <t id="313">Utilisation des missiles en pourcentage</t>
+ <t id="314">Choisissez la portée du radar en mètres pour ce porteur</t>
+ <t id="315">Choisissez le nouveau délai, en secondes</t>
+ 
+ <t id="400">Mécanos</t>
+ <t id="401">Vous pouvez utiliser des mécanos pour réparer les navires endommagés et le porteur. Vous pouvez les embaucher, moyennant finances dans tout secteur amical disposant d'une station commerciale. Chaque mécano vous coutera 1.000 crédits-heure quand il n'a rien à faire, et 15.000 crédits-heure quand il a du travail. Plus vous avez de mécanos et plus ils travailleront vite.\n\nCout actuel quand inactifs : \033Y%s crédits par heure\033X\nCout actuel quand actifs : \033Y%s crédits par heure\033X\n\n\n\n</t>
+ <t id="402">Vous avez : \033Y%s\033X mécanos (cout inactif : \033Y%s\033X crédits par heure)</t>
+ <t id="403">Réglages</t>
+ <t id="404">Permettre de réparer les navires amarrés  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="405">Permettre de réparer le porteur  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="406">Personnel : \033Y%s mechanics\033X</t>
+ <t id="407">Embaucher un nouveau mécano</t>
+ <t id="408">Virer un mécano</t>
+ <t id="409">Vaisseaux endommagés</t>
+ <t id="410">  [%s] \033Y%s\033X - coque : %s/100</t>
+ <t id="411">Vous dépenserez 50.000 crédits pour embaucher un mécano. Etes-vous certain?</t>
+ <t id="412">Vous n'avez pas assez d'argent pour embaucher un mécano.</t>
+ <t id="413">Il n'y a pas de station commerciale dans ce secteur!</t>
+
+ <t id="420">Gestion des Hangars</t>
+ <t id="421">Choisissez les vaisseaux qui seront utilisés par ADS</t>
+ <t id="422">Liste des vaisseaux amarrés</t>
+ <t id="423">Commandes Générales</t>
+ <t id="424">Appliquer les paramêtres de base à tous les navires amarrés</t>
+ <t id="425">Réglages</t>
+ <t id="426">Ajouter tous les vaisseaux</t>
+ <t id="427">Ajouter les M3 et M4 seulement</t>
+ <t id="428">Ajouter les M3 seulement</t>
+ <t id="429">Retirer tous les vaisseaux</t>
+ <t id="430">  [%s] \033Y%s\033X - %s</t>
+ <t id="431">\033GActif\033X</t>
+ <t id="432">\033RInactif\033X</t>
+ <t id="433">\033YEn Réparation\033X</t>
+ <t id="434">Renommer les navires amarrés</t>
+ <t id="435">Appliquer les paramêtres de base à tous les navires actifs</t>
+
+ <t id="440">Equipement de Navires</t>
+ <t id="441">C'est ici que vous pouvez deplacer du cargo et des armes entre les vaisseaux amarrés et le porteur.\n\n\n</t>
+ <t id="442">Actions de Base</t>
+ <t id="443">Deplacer des marchandises du porteur vers les vaisseaux amarrés</t>
+ <t id="444">Décharger les marchandises des vaisseaux dans le porteur</t>
+ <t id="445">Avancé</t>
+ <t id="446">Permettre au porteur de racheter les vaisseaux detruits  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="447">Permettre au porteur de chercher des réparations dans un chantier spatial  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="448">Permettre au porteur de maintenir les stocks de missiles et munitions \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="449">Ce menu permet de deplacer des marchandises de vos chasseurs vers ce porteur.</t>
+ <t id="450">\033YDécharger :\033X %s</t>
+ <t id="451">Marchandises de commerce seulement [sauf photopiles]</t>
+ <t id="452">Marchandises de commerce seulement [avec photopiles]</t>
+ <t id="453">Missiles</t>
+ <t id="454">Tout ce qui n'est pas equippé</t>
+ <t id="455">\033YDe :\033X %s</t>
+ <t id="456">Vaisseaux actifs seulement</t>
+ <t id="457">Tous les vaisseaux amarrés</t>
+ <t id="458">\033YValider\033X</t>
+ <t id="459">Confirmer Action</t>
+ 
+ <t id="460">Ignored Factions</t>
+ <t id="461">Manage</t>
+ <t id="462">Clear whole list</t>
+ <t id="463">Add a faction to the list</t>
+ <t id="464">\033Y%s\033X - remove</t>
+ <t id="465">Select a faction to ignore</t>
+
+ <t id="480">Renommer Navires</t>
+ <t id="481">Type Classe - Numéro</t>
+ <t id="482">Porteur - Type - Numéro</t>
+ <t id="483">RaceConstructeur Classe - Numéro</t>
+ <t id="484">Permet de renommer en masse les vaisseaux amarrés.</t>
+ <t id="485">Configurer</t>
+ <t id="486">Appliquer à tous les navires amarrés</t>
+ <t id="487">Appliquer à tous les navires actifs</t>
+ <t id="488">\033YSélectionné : \033X%s</t>
+ <t id="489">\033YExemple : \033X%s</t>
+
+ 
+ <t id="500">[author][b]Anarkis Defense System[/b][/author] [b]Attention:[/b] Votre [b]%s[/b] dans [b]%s[/b] est en danger et requière votre attention.</t>
+ <t id="501">[author][b]Anarkis Defense System[/b][/author] [b]Annulé:[/b] Vous n'avez pas assez de navires dans %s pour cette commande.</t>
+ <t id="502">[author][b]Anarkis Defense System[/b][/author] [b]Annulé:[/b] Vous n'avez pas assez de vaisseaux dans %s pour nettoyer le secteur. 5 sont nécessaires.</t>
+ <t id="503">[author][b]Anarkis Defense System[/b][/author] [b]Erreur:[/b] Pas assez de marchandises pour équipper le moindre navire.</t>
+ <t id="504">[author][b]Anarkis Defense System[/b][/author] [b]Succés:[/b] %s a équippé %s/%s navires avec %s %s.</t>
+ <t id="505">[author][b]Anarkis Defense System[/b][/author] [b]Annulé:[/b] %s - Aucune station à portée a assez de %s.</t>
+ <t id="506">\033RALERTE:\033X \033W%s dans %s a besoin d'aide!\033X</t>
+ 
+ <t id="520">Equipper Navires</t>
+ <t id="521">\033YMarchandises\033X</t>
+ <t id="522">&lt; \033Yajouter une marchandise\033X &gt;</t>
+ <t id="523">\033W%s\033X [quantité: %s]  &lt;\033Rretirer\033X&gt;</t>
+ <t id="524">\033YMode :\033X %s</t>
+ <t id="525">Même quantité dans chaque navire [$quantité = valeur maximale]</t>
+ <t id="526">Au moins $quantité de marchandise dans chaque vaisseau</t>
+ <t id="527">\033YDestination :\033X %s</t>
+ <t id="528">Vaisseaux amarrés</t>
+ <t id="529">Vaisseaux actifs</t>
+ <t id="530">\033YValider\033X</t>
+ <t id="531">Confirmer Action</t>
+ <t id="532">Choisissez la quantité de marchandise à deplacer</t>
+ <t id="533">Choisissez la quantité</t>
+
+ <t id="540">Rapport de Transfert</t>
+ <t id="541">Marchandises transférées</t>
+ <t id="542">\033W%s %s\033X transférés vers \033Y%s\033X</t>
+ <t id="543">\033W%s %s\033X dechargés depuis \033Y%s\033X</t>
+ 
+ <t id="600">\033RADS:\033X Nettoyer Secteur</t>
+ <t id="601">\033RADS:\033X Amarrer tous mes navires</t>
+ <t id="602">\033RADS:\033X Attaquer ma cible</t>
+ <t id="603">\033RADS:\033X Manager</t>
+
+ <t id="640">\033RADS:\033X Vendre Marchandises</t>
+ <t id="641">Choisissez Marchandises</t>
+ <t id="642">Sélection Rapide</t>
+ <t id="643">Vider la liste</t>
+ <t id="644">Ajouter toutes les marchandises de commerce</t>
+ <t id="645">Lancer le transfert</t>
+ <t id="646">&lt; \033Yajouter une marchandise\033X &gt;</t>
+ <t id="647">Reglages</t>
+ <t id="648">Distance maximale \033R&lt;\033X \033Y%s secteurs\033X \033R&gt;\033X</t>
+ <t id="649">Cette commande permet à votre porteur de vendre ses marchandises aux stations proches en utilisant ses navires amarrés. Il n'y a pas de vérification sur les secteurs ennemis, donc choisissez votre distance avec attention.\n\n\n\n</t>
+ <t id="650">\033W%s\033X - Quantité: \033W%s\033X  &lt;\033Yretiré\033X&gt;</t>
+ <t id="651">Choisissez une nouvelle distance de saut</t>
+ <t id="652">Choisissez une marchandise à ajouter</t>
+ <t id="653">\033R[ADS]\033X \033Y%s\033X vend \033Y%s\033X à \033Y%s\033X</t> 
+ <t id="654">\033R[ADS]\033X Aucune station n'achète de \033Y%s\033X</t> 
+ <t id="655">\033R[ADS]\033X Aucune navire capable de charger les \033Y%s\033X</t>
+ <t id="656">\033R[ADS]\033X Aucune station à portée de vend de \033Y%s\033X</t> 
+ <t id="657">\033RADS:\033X Acheter Marchandises</t>
+ <t id="658">Cette commande permet à votre porteur d'acheter des marchandises dans les stations aux alentours en utilisant ses navires amarrés. Il n'y a pas de vérification sur les secteurs ennemis, donc choisissez votre distance avec attention.\n\n\n\n</t>
+ <t id="659">Procéder</t>
+ <t id="660">\033W%s\033X - Quantité: \033W%s\033X  &lt;\033Yretirer\033X&gt;</t>
+ <t id="661">\033R[ADS]\033X \033Y%s\033X achète \033Y%s %s\033X à \033Y%s\033X</t> 
+ <t id="662">Choisissez la quantité désirée</t>
+ <t id="663">Ajouter tous les types de missiles</t>
+ 
+
+ <t id="700">\033R[ADS]\033X \033WGroupe %s: \033X %s &lt;%s&gt;</t> 
+ <t id="702">\033R[ADS]\033X %s - \033WRetraite...\033X</t>
+ <t id="703">\033R[ADS]\033X %s</t>
+ <t id="710">\033YLeader\033X</t>
+ <t id="711">Wingmate</t>
+ <t id="712">\033GEscorte\033X</t>
+ <t id="713">\033WPas de cible\033X</t>
+ <t id="714">\033R%s\033X</t>
+ <t id="715">\033B%s\033X</t>
+ 
+  
+ <t id="800">Rapport de ADS</t>
+ <t id="801">\033WSelectionné : \033X %s [%s]</t>
+ <t id="802">\033WOrdres : \033X %s - \033WAutomatique :\033X %s</t>
+ <t id="803">Sélection</t>
+ <t id="804">\033Y%s\033X [\033Y%s\033X] - Secteur : \033Y%s\033X</t>
+ <t id="805">\033WLocation : \033X %s [%s]</t>
+ <t id="806">Actions</t>
+ <t id="807">Configurer le porteur sélectionné</t>
+ <t id="808">Appliquer les parametres actuels à tous les porteurs</t>
+
+
+ <t id="820">\033GOui\033X</t>
+ <t id="821">\033RNon\033X</t>
+
+<t id="1000">ADS Setup Menu</t>
+ <t id="1001">\033YSélection :\033X %s</t>
+ <t id="1002">Gérer Stations</t>
+ <t id="1003">Gérer Navires</t>
+ <t id="1004">\033YMenu\033X</t>
+ <t id="1005">Lister %ss ADS</t>
+ <t id="1006">Evènements Récents</t>
+ <t id="1007">\033RDésinstaller ADS\033X</t>
+ <t id="1008">Appliquer les réglages par défauts à tous les %ss</t>
+ <t id="1009">\033Y[\033X\033G%s\033X\033Y]\033X \033W%s\033X | auto: \033W%s\033X | Chasseurs: \033W%s\033X</t>
+ 
+ <t id="1010">\033RADS Manager\033X</t>
+ <t id="1011">Ce menu vous donne accés à tous les navires et stations compatibles avec \033YADS\033X</t>
+ <t id="1012">\033Y[\033X\033G%s\033X\033Y]\033X \033W%s\033X</t>
+ <t id="1013">- \033GIntegrité:\033X Coque \033Y%s/100\033X - Bouclier \033Y%s/100\033X</t>
+ <t id="1014">- \033GStatus:\033X \033W%s\033X - \033Y%s\033X</t>
+ <t id="1015">- \033GCombat:\033X danger \033Y%s\033X - attacké \033Y%s\033X - deployé \033Y%s\033X</t>
+ <t id="1016">- \033GChasseurs:\033X  total \033Y%s\033X - à quai \033Y%s\033X - ADS \033Y%s\033X</t>
+ <t id="1017">\033YListe %s\033X</t>
+ <t id="1018">Mode Automatique ADS  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1019">Configurer ce(tte) %s</t>
+
+ <t id="1020">\033Y[\033X\033G%s\033X\033Y]\033X \033G%s\033X | auto: \033W%s\033X | Chasseurs: \033W%s\033X</t>
+ <t id="1021">\033Y[\033X\033G%s\033X\033Y]\033X \033Y%s\033X | auto: \033W%s\033X | Chasseurs: \033W%s\033X</t>
+ <t id="1022">\033Y[\033X\033G%s\033X\033Y]\033X \033R%s\033X | auto: \033W%s\033X | Chasseurs: \033W%s\033X</t>
+
+ <t id="1023">\033G   Sauter vers Moi</t>
+ <t id="1024">\033G   Sauter vers Secteur ...\033X</t>
+ <t id="1025">\033G   Attaquer Cible ...\033X</t>
+ <t id="1026">Sélectionner un Destination</t>
+ <t id="1027">Sélectionner une Cible</t>
+ <t id="1028">\033G   Patrouiller Secteurs\033X</t>
+ <t id="1029">\033G   Attaquer tous les ennemis\033X</t>
+ <t id="1030">Sélectionner au curseur et fermer ce menu</t>
+ <t id="1031">%s chasseurs déployés dans %s</t>
+ <t id="1032">\033WRapport De :\033X %s | \033WClasse :\033X %s\n\033WLocation :\033X %s | \033WDanger :\033X %s\n\n\033WAction :\033X Chasseurs Mobilisés</t>
+ <t id="1033">\033G   S'amarrer à ...\033X</t>
+ <t id="1034">\033WCommandes\033X  \033Y&lt;\033G+\033X\033Y&gt;\033X</t>
+ <t id="1035">Voir les navires à quai</t>
+ <t id="1036">\033G   Protéger ...\033X</t>
+ <t id="1037">\033G   En Attente\033X</t>
+ <t id="1038">\033WCommandes\033X  \033Y&lt;\033G-\033X\033Y&gt;\033X</t>
+ <t id="1039">\033G   %s\033G</t>
+ <t id="1040">\033RADS:\033X \033WManager\033X</t>
+ <t id="1041">\033W%s\033X  \033G[\033X%s\033G]\033X  \033G[\033X \033Wcoque\033X %s%% \033G|\033X \033Wbouclier\033X %s%% \033G]\033X</t>
+ <t id="1042">En Vol</t>
+ <t id="1043">A Quai</t>
+
+ <t id="001">** COMMENT ** v2.60 Begins Here</t>
+ 
+ <t id="1044">Grille Defensive</t>
+ <t id="1045">Réglages</t>
+ <t id="1046">Voir Secteurs</t>
+ <t id="1047">Afficher Vaisseaux  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1048">ADS Satellite (%s)</t>
+ <t id="1049">\033YGrille Défensive\033X</t>
+ 
+ <t id="1050">\033YListe des Secteurs\033X</t>
+ <t id="1051">[\033G%s,%s\033X] \033W%s\033X | Stations: \033G%s\033X | Threat Level: \033Y%s\033X</t>
+ <t id="1052">Filtre : %s</t>
+ <t id="1053">Tous les secteurs</t>
+ <t id="1054">Secteurs protégés par ADS</t>
+ <t id="1055">Secteurs attaqués</t>
+
+ <t id="1056">\033YListe des Vaisseaux\033X</t>
+ <t id="1057">[\033G%s\033X] \033W%s\033X - \033W%s\033X | Defense Grid : \033Y%s\033X</t>
+ <t id="1058">Grille Défensive  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1059">Utilisé par la Grille Défensive  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ 
+ <t id="1060">[\033G%s\033X] [%s]  \033W%s\033X</t>
+ <t id="1061">\033WPanneau de Commande\033X</t>
+ <t id="1062">\033GLancer Vaisseaux\033X</t>
+ <t id="1063">Changer de Cible  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1064">Nombre de vaisseaux</t>
+ <t id="1065">\033WSélection manuelle\033X</t>
+ <t id="1066">\033G%s\033X</t>
+ <t id="1067">\033Y%s\033X</t>
+ <t id="1068">\033R%s\033X</t>
+ 
+ <t id="1069">Lancer</t>
+ <t id="1070">%s%%</t>
+ <t id="1071">Reste à Quai</t>
+ <t id="1072">sélection manuelle</t>
+ <t id="1073">auto</t>
+ <t id="1074">Classe: %s | Faction: %s | Relation: %s</t>
+ 
+ 
+ <t id="001">** COMMENT ** v2.65 Begins Here</t> 
+ 
+ <t id="1075">Centre d'Entrainement</t>
+ <t id="1076">Repos</t>
+ <t id="1077">Entrainement Standard</t>
+ <t id="1078">Entrainement Combat</t>
+
+ <t id="001">** COMMENT ** Marine Statistics</t> 
+ <t id="1079">  \033Y[\033X Fight: \033W%s\033X - Mech: \033W%s\033X - Hack: \033W%s\033X - Engineer: \033W%s\033X\033Y ]\033X</t>
+ 
+ <t id="001">** COMMENT ** Marine Name - Overall Skill</t> 
+ <t id="1080">\033G%s\033X - \033WTotal:\033X \033G%s\033X</t>
+
+ <t id="1081">Nom</t>
+ <t id="1082">Combat</t>
+ <t id="1083">Mécanique</t>
+ <t id="1084">Piratage</t>
+ <t id="1085">Ingénieur</t>
+ <t id="1086">Caserne ...</t>
+ <t id="1087">\033GSauvegarder et Fermer\033X</t>
+ <t id="1088">\n\033RPressez [Echap] pour fermer sans sauvegarder\033X</t>
+ 
+ <t id="1089">\033WOptions Générales\033X</t>
+ <t id="1090">\033YReglages par Défaut\033X</t>
+ <t id="1091">\033WEditer les réglages par défaut des Porteurs\033W</t>
+ <t id="1092">\033WEditer les réglages par défaut des Stations\033W</t>
+ <t id="1093">\033YConfiguration de la Grille Défensive\033X</t>
+ <t id="1094">\033WDistance de saut maximale\033X</t>
+ <t id="1095">\033WSeuil de danger pour declencher une alerte\033X</t>
+ <t id="1096">\033WAfficher un message d'avertissement\033X</t>
+ <t id="1097">\033YIgnorer Factions\033X</t>
+ <t id="1098">\033YRéglages Généraux\033X</t>
+ <t id="1099">\033WRenommage dynamique des vaisseaux\033X</t>
+ <t id="1100">\033RRemettre les réglages par défaut\033X</t>
+ <t id="1101">Auto</t>
+ <t id="1102">Manuel</t>
+ <t id="1103">Commerce</t>
+ <t id="1104">Ignorer</t>
+
+<t id="1105">\033W- Entrainement :\033X \033Y%s\033X \033Wcrédits par heure\033X</t>
+<t id="1106">\033GAppliquer Reglages\033X</t>
+<t id="1107">Caserne</t>
+<t id="1108">\033W- Il y a %s soldats qui s'entrainent à bord\033X</t>
+<t id="1109">\033W- Place :\033X \033Y%s/%s\033X</t>
+<t id="1110">Passager</t>
+<t id="1111">Asservir</t>
+<t id="1112">Entrainer</t>
+<t id="1113">\033RADS:\033X \033Y%s\033X \033West attaqué [menace :\033X \033Y%s\033X\033W]\033X</t>
+<t id="1114">[\033G%s,%s\033X] \033W%s:\033X \033G%s</t>
+<t id="1115">%s\033X \033W%s\033X [\033Gauto\033X|\033W%s\033X]</t>
+<t id="1116">%s\033X \033W%s\033X [\033Wmanuel\033X|\033W%s\033X]</t>
+<t id="1117">%s\033X \033W%s\033X</t>
+<t id="1118">\033YMembres de la Grille Défensive\033X</t>
+<t id="1119">\033YNon Assignés\033X</t>
+<t id="1120">%s\033X \033W%s\033X [\033Ycombat\033X|\033W%s\033X]</t>
+<t id="1121">[\033G%s,%s\033X] \033W%s:\033X \033Y%s</t>
+<t id="1122">[\033G%s,%s\033X] \033W%s:\033X %s</t>
+<t id="1123">\033Y%s\033X  \033G[\033X%s\033G]\033X  \033G[\033X \033Wcoque\033X %s%% \033G|\033X \033Wbouclier\033X %s%% \033G]\033X</t>
+ 
+ </page>
+
+</language>
+

--- a/tools/fixtures/known_good/ADS/t/8510-L039.xml
+++ b/tools/fixtures/known_good/ADS/t/8510-L039.xml
@@ -1,0 +1,452 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<language id="39">
+
+<page id="2008" title="Script Object Commands" descr="0">
+ <t id="830">ANARKIS_SETDOCKED</t>
+ <t id="831">ANARKIS_SELLWARES</t>
+ <t id="832">ANARKIS_BUYWARES</t>
+ <t id="833">ANARKIS_DEFENSIVEWING</t>
+ <t id="834">ANARKIS_ATTACKWING</t>
+ <t id="835">ANARKIS_CLEANSECTOR</t>
+ <t id="836">ANARKIS_DOCKALL</t>
+ <t id="1231">ANARKIS_SETTACTICS</t>
+ <t id="1232">ANARKIS_AUTOCARRIER</t>
+ <t id="1131">ANARKIS_SETUPSTATION</t>
+ <t id="1132">ANARKIS_STATIONDEFENSE</t>
+</page>
+
+<page id="2010" title="Script Cmd Names" descr="Versione estesa dei comandi. Questi sono i comandi assegnati alle navi utilizzando la console di comando. Le pagine 2010 e 2011 contengono assieme le versioni estese e compatte degli stessi comandi"> 
+ <t id="830">\033RADS:\033X Impostazioni Base</t>
+ <t id="831">\033RADS:\033X Vendi merci...</t>
+ <t id="832">\033RADS:\033X Compra merci per la carrier...</t>
+ <t id="833">\033RADS:\033X Invia Wing Difensiva</t>
+ <t id="834">\033RADS:\033X Wing d'attacco contro...</t>
+ <t id="835">\033RADS:\033X Pulisci Settore</t>
+ <t id="836">\033RADS:\033X Attracca tutte le navi</t>
+ <t id="1231">\033RADS:\033X Impostazioni Carrier</t>
+ <t id="1232">\033RADS:\033X Carrier Automatizzata</t>
+ <t id="1131">\033RADS:\033X Imposta Sistema Difesa</t>
+ <t id="1132">\033RADS:\033X Difesa Settore</t>
+</page> 
+
+<page id="2011" title="Script Cmd Shorts" descr="Versione compatta dei comandi. Questi sono i comandi assegnati alle navi utilizzando la console di comando. Le pagine 2010 e 2011 contengono assieme le versioni estese e compatte degli stessi comandi"> 
+ <t id="830">imposta.homebase</t>  
+ <t id="831">vendi.merci</t>
+ <t id="832">compra.merci</t>
+ <t id="833">wing.difensiva</t>
+ <t id="834">wing.attacco</t>
+ <t id="835">clean.sector</t>
+ <t id="836">attracca.navi</t>
+ <t id="1131">imposta.difese</t>
+ <t id="1132">stazione.auto</t>
+ <t id="1231">imposta.tattiche</t>
+ <t id="1232">carrier.auto</t>
+</page> 
+
+<page id="2022"> 
+ <t id="830">Permette di selezionare le impostazioni della base per le navi attraccate a questa carrier. Le navi verranno rinominate e le impostazioni dei missili applicate.</t>  
+ <t id="831">Invia molteplici navi a vendere le tue merci dalla Carrier</t>
+ <t id="832">Invia molteplici navi a comprare un dato ammontare di merci alla stazione più vicina</t>
+ <t id="833">Invia uno squadrone a difendere la tua carrier o un'altra nave</t>
+ <t id="834">Invia uno squadrone all'attacco di una nave o una stazione</t>
+ <t id="835">Ripulisci il settore da tutta l'attività nemica</t>
+ <t id="836">Tutte le navi assegnate a questa base attraccheranno qui. Le navi distanti equipaggiate con il jumpdrive proveranno ad attraccare alla carrier.</t>
+ <t id="1131">Imposta Anarkis Defense Station in questa stazione.</t>
+ <t id="1132">Abilità il sistema difensivo della stazione, inviera le navi contro i nemici in arrivo e gradualmente riparerà le navi attraccate</t>
+ <t id="1231">Questo comando ti permette di impostare sia le navi attraccate sia le carrier in modalità automatica.</t>
+ <t id="1232">Modalità automatica. La carrier difenderà se stessa e invierà le navi quando necessario.</t>
+</page> 
+
+<page id="8510" title="ACC" descr="Comandi Carrier Anarkis">
+ <t id="100">\033RADS:\033X Anarkis Defense System</t>
+ <t id="101">265</t>
+ <t id="102">Anarkis Federation</t>
+ <t id="103">[author][b]Anarkis Federation[/b][/author][b]Anarkis Defense System[/b] v%s installato con successo ! </t>
+ <t id="104">[author][b]Anarkis Federation[/b][/author][b]Anarkis Defense System[/b] aggiornato con successo alla versione v%s !</t>
+ <t id="105">[author][b]ADS - %s[/b][/author] Non puoi utilizzare questo comando sulla nave che attualmente piloti.</t>
+ <t id="106">[author][b]Anarkis Federation[/b][/author][b]Anarkis Defense System[/b] è stato rimosso dal gioco.\nSi prega di salvare il gioco ora, esci e avvia il file 'Uninstall ADS.bat' nella tua cartella di X3.</t>
+ 
+ <t id="200">Menu Carrier Anarkis</t>
+
+ <t id="210">Generale</t>
+ <t id="211">Hangars ...</t>
+ <t id="212">Report Automatizzati Carriers</t>
+ <t id="213">Utilizzo Missili  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="214">Salto di Emergenza  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X - Limite Scuto  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="215">Salto Automatico  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X - Raggio Minimo  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="216">Rifornimento Automatico Celle \(Salti\)  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="217">Impostazione navi attraccate</t>
+
+ <t id="220">Impostazioni Automatizzate Carrier</t>
+ <t id="221">\033WLivello minimo minaccia\033X</t>
+ <t id="222">\033WMostra Avviso Messaggi\033X</t>
+ <t id="223">\033WObbliga Navi Danneggiate alla Ritirata\033X</t>
+ <t id="224">\033WModalita Attacco\033X</t>
+ <t id="225">\033WConteggio Navi Difesa\033X</t>
+ <t id="226">\033WRaggio Radar\033X</t>
+ <t id="227">Ignora Fazioni  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="228">Dettagliato</t>
+ <t id="229">\033WTipo Pericolo\033X</t>
+  
+ <t id="230">Impostazioni Plugin ADS</t>
+ <t id="231">Applica Impostazioni a \033Ytutte\033X le navi attraccate</t>
+ <t id="232">Imposta configurazione ai valori di Default</t>
+ <t id="233">Sottotitoli</t>
+ <t id="234">Audio</t>
+ <t id="235">Popup</t>
+ <t id="236">Debug Logfile Output  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="237">Applica impostazioni solamente alle navi attraccate \033Yattive\033X</t>
+
+ <t id="238">Ritardo prima dello schieramento dei caccia attraccati  \033R&lt;\033X \033Y%s sec\033X \033R&gt;\033X</t>
+
+ 
+ <t id="240">Gestione Carrier</t>
+ <t id="241">Carrier Automatizzata ...</t>
+ <t id="242">Ripara attracchi ...</t>
+ <t id="243">Rifornimenti Nave ...</t>
+ <t id="244">Impostazioni Torrette : \033Y%s\033X</t>
+ <t id="245">Proteggi Nave</t>
+ <t id="246">Attacca Nemici</t>
+ <t id="247">Difesa Missili</t>
+ <t id="248">\033RMARS:\033X Attacco</t>
+ <t id="249">\033RMARS:\033X Difesa</t>
+ 
+ <t id="201">Abilitato</t>
+ <t id="202">Disabilitato</t>
+ <t id="203">Si</t>
+ <t id="204">No</t>
+ <t id="205">Default</t>
+ <t id="206">Selezione Automatica</t>
+ <t id="207">Il più forte prima</t>
+ <t id="208">Il più vicino prima</t>
+ <t id="209">Niente</t>
+ 
+ <t id="250">Carrier : \033Y%s\033X [%s]</t>
+ <t id="251">Posizione : \033Y%s\033X</t>
+ <t id="252">Attraccate : %s/%s - Possedute : %s</t>
+ <t id="260">© Serial Kicked / [\033YAnarkis Federation\033X]</t>
+ 
+ <t id="300">Seleziona l'ammontare di navi utilizzate a scopo difensivo</t>
+ <t id="301">Impostazione acquisizione bersaglio</t>
+ <t id="302">Seleziona come la forza offensiva selezionerà i bersagli nemici</t>
+ <t id="303">Obbliga le navi danneggiate alla ritirata ?</t>
+ <t id="304">Mostra un messaggio di avviso quando la carrier è in pericolo ?</t>
+ <t id="305">Questo menù ti permette di scegliere il livello minimo di minaccia che aziona il lancio dei caccia. Per capire come il sistema funziona, devi conoscere il valore di "minaccia" utilizzato per ogni tipo di nave e devi anche sapere che la carrier invierà sempre navi se il nemico avvistato è una nave di classe M1/M2. I Droni da Combattimento vengono ignorati.</t>
+ <t id="306">M5: 1 - M4: 2  - M3: 5 - M8: 10 - M6: 14 - M7: 35\nTL: 15 - TM: 8 - TP/TS: 2\n\n\n\n</t>
+ <t id="307">Livello Minimo Minaccia</t>
+ <t id="308">Seleziona la quantità di celle da rifornire in Salti</t>
+ <t id="309">Vuoi abilitare la funzione di Salto Automatico per le navi attraccate ?</t>
+ <t id="310">Imposta il raggio minimo per il Salto Automatico</t>
+ <t id="311">Vuoi abilitare la funzione di Salto di Emergenza per le navi attraccate ?</t>
+ <t id="312">Imposta la soglia di emergenza dello scudo in percentuale</t>
+ <t id="313">Imposta l'utilizzo dei missili in percentuale</t>
+ <t id="314">Seleziona il nuovo raggio del radar in metri</t>
+ <t id="315">Seleziona il nuovo ritardo in secondi</t>
+ 
+ <t id="400">Meccanici</t>
+ <t id="401">Puoi utilizzare i meccanici per riparare le navi danneggiate nelle carrier. Puoi assumere meccanici ad un dato prezzo in qualunque settore amico. Quando sono fuori servizio ti costeranno circa 1000 crediti l'ora per meccanico, e molto di più quando stanno riparando una nave. Più meccanici possiedi, più velocemente ripareranno la nave danneggiata.\n\nAttuale costo fuori servizio : \033Y%s crediti per ora\033X\nAttuale costo in servizio : \033Y%s crediti per ora\033X\n\n\n\n</t>
+ <t id="402">Attualmente hai : \033Y%s\033X meccanici (costo fuori turno : \033Y%s\033X crediti per ora)</t>
+ <t id="403">Impostazioni</t>
+ <t id="404">Permetti di riparare le navi attraccate  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="405">Permetti la riparazione della carrier  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="406">Gestione : \033Y%s meccanici\033X</t>
+ <t id="407">Assumi nuovi meccanici</t>
+ <t id="408">Licenzia meccanici</t>
+ <t id="409">Navi Danneggiate</t>
+ <t id="410">  [%s] \033Y%s\033X - scafo : %s/100</t>
+ <t id="411">Assumere un nuovo meccanico ti costerà 50.000 crediti. Sei sicuro ?</t>
+ <t id="412">Non possiedi abbastanza crediti per assumere un novo meccanico.</t>
+ <t id="413">Hai bisogno di una Stazione amichevole nel settore in cui si trova attualmente la carrier.</t>
+
+ <t id="420">Gestione Hangar</t>
+ <t id="421">Seleziona quali navi vuoi utilizzino vengano utilizzate dai comandi ADS</t>
+ <t id="422">Lista Navi Attraccate</t>
+ <t id="423">Comandi Generali</t>
+ <t id="424">Applica base a tutte le navi attraccate</t>
+ <t id="425">Gestione</t>
+ <t id="426">Aggiungi tutte le navi</t>
+ <t id="427">Aggiungi solamente le navi M3 e M4</t>
+ <t id="428">Aggiungi solamente le navi M3</t>
+ <t id="429">Rimuovi tutte le navi</t>
+ <t id="430">  [%s] \033Y%s\033X - %s</t>
+ <t id="431">\033GAttivo\033X</t>
+ <t id="432">\033RInattivo\033X</t>
+ <t id="433">\033YIn Riparazione\033X</t>
+ <t id="434">Rinomina le navi attraccate</t>
+ <t id="435">Assegna la base solamente alle navi attive</t>
+
+ <t id="440">Rifornimenti Nave</t>
+ <t id="441">Questo menù permette di muovere il carico tra la carrier e le navi attraccate\n\n\n</t>
+ <t id="442">Azioni Standard</t>
+ <t id="443">Muovi merci dalla carrier alle navi attraccate</t>
+ <t id="444">Scarica le merci nella carrier</t>
+ <t id="445">Avanzato</t>
+ <t id="446">Permetti alla carrier di ricomprare i caccia distrutti  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="447">Permetti alla carrier di ripararsi al Cantiere  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="448">Permetti alla carrier di mantenere le navi rifornite \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="449">Questo menù permette di muovere le merci dalle navi attraccate alla carrier.</t>
+ <t id="450">\033YScarica :\033X %s</t>
+ <t id="451">Commercia solamente le merci [eccetto le Celle d'Energia]</t>
+ <t id="452">Commercia solamente le merci [incluse le Celle d'Energia]</t>
+ <t id="453">Missili</t>
+ <t id="454">Qualunque cosa non equipaggiata</t>
+ <t id="455">\033YDa :\033X %s</t>
+ <t id="456">Solamente navi Attive</t>
+ <t id="457">Tutte le navi attraccate</t>
+ <t id="458">\033YConvalida\033X</t>
+ <t id="459">Conferma Azione</t>
+ 
+ <t id="460">Fazioni Ignorate</t>
+ <t id="461">Gestione</t>
+ <t id="462">Cancella intera lista</t>
+ <t id="463">Aggiungi una fazione alla lista</t>
+ <t id="464">\033Y%s\033X - rimuovi</t>
+ <t id="465">Seleziona fazione da ignorare</t>
+
+ <t id="480">Rinomina Navi</t>
+ <t id="481">Tipo Classe - Numero</t>
+ <t id="482">Nome Carrier- Tipo - Numero</t>
+ <t id="483">Razza Costruttrice Classe - Numero</t>
+ <t id="484">Abilita rinominazione di massa alle navi attraccate.</t>
+ <t id="485">Impostazioni</t>
+ <t id="486">Applica a tutte le navi attraccate</t>
+ <t id="487">Applica a tutte le navi attive</t>
+ <t id="488">\033YSelezionate : \033X%s</t>
+ <t id="489">\033YEsempio : \033X%s</t>
+
+ 
+ <t id="500">[author][b]Comandi Carrier Anarkis[/b][/author] [b]Pericolo:[/b] Il tuo [b]%s[/b] nel settore [b]%s[/b] è in pericolo e richiede la tua attenzione.</t>
+ <t id="501">[author][b]Comandi Carrier Anarkis[/b][/author] [b]Cancellato:[/b] Non possiedi abbastanza navi a %s per questo comando</t>
+ <t id="502">[author][b]Comandi Carrier Anarkis[/b][/author] [b]Cancellato:[/b] Non possiedi abbastanza navi a %s per ripulire il settore. Sono necessarie almeno 5.</t>
+ <t id="503">[author][b]Comandi Carrier Anarkis[/b][/author] [b]Errorr:[/b] Not enough wares in cargo bay to equip any ship.</t>
+ <t id="504">[author][b]Comandi Carrier Anarkis[/b][/author] [b]Successo:[/b] %s ha equipaggiato le navi %s/%s con %s %s.</t>
+ <t id="505">[author][b]Comandi Carrier Anarkis[/b][/author] [b]Cancellato:[/b] %s - Nessuna stazione nelle vicinanza possiede abbastanza %s.</t>
+ <t id="506">\033RALLERTA:\033X \033W%s nel settore %s necessita aiuto !\033X</t>
+ 
+ <t id="520">Equipaggia navi</t>
+ <t id="521">\033YMerci\033X</t>
+ <t id="522">&lt; \033Yaggiungi una nuova merce\033X &gt;</t>
+ <t id="523">\033W%s\033X [quantita: %s]  &lt;\033Rrimuovi\033X&gt;</t>
+ <t id="524">\033YModalità :\033X %s</t>
+ <t id="525">Stessa quantita a tutte le navi [$quantita = valore massimo]</t>
+ <t id="526">Almeno $quantity merci per ogni nave</t>
+ <t id="527">\033YDestinazione :\033X %s</t>
+ <t id="528">Navi Attraccate</t>
+ <t id="529">Navi Attive</t>
+ <t id="530">\033YConvalida\033X</t>
+ <t id="531">Conferma Azione</t>
+ <t id="532">Seleziona le merci che vuoi muovere</t>
+ <t id="533">Select the quantity</t>
+
+ <t id="540">Rapporti Trasferimenti</t>
+ <t id="541">Merci trasferite</t>
+ <t id="542">\033W%s %s\033X trasferite a \033Y%s\033X</t>
+ <t id="543">\033W%s %s\033X scaricate da \033Y%s\033X</t>
+ 
+ <t id="600">\033RADS:\033X Ripulisci Settore</t>
+ <t id="601">\033RADS:\033X Attracca tutte le mie navi</t>
+ <t id="602">\033RADS:\033X Attacca il mio bersaglio</t>
+ <t id="603">\033RADS\033X \033WManager\033W</t>
+
+ <t id="640">\033RADS:\033X Vendi Merci</t>
+ <t id="641">Merci Selezionate</t>
+ <t id="642">Selezione Rapida</t>
+ <t id="643">Cancella la Lista</t>
+ <t id="644">Aggiungi tutte le merci commerciabili</t>
+ <t id="645">Inizia trasferimento</t>
+ <t id="646">&lt; \033Yaggiungi una nuva merce\033X &gt;</t>
+ <t id="647">Impostazioni</t>
+ <t id="648">Distanza Massima \033R&lt;\033X \033Y%s settori\033X \033R&gt;\033X</t>
+ <t id="649">Questo comando permette alle tue carrier di vendere le merci alle stazioni vicine utilizzando le navi attraccate. Non viene effettuato nessu controllo per settori nemici pertanto imposta il raggio con attenzione.\n\n\n\n</t>
+ <t id="650">\033W%s\033X - Quantità: \033W%s\033X  &lt;\033Yrimuovi\033X&gt;</t>
+ <t id="651">Seleziona raggio di salto</t>
+ <t id="652">Seleziona la merce da aggiungere</t>
+ <t id="653">\033R[ADS]\033X \033Y%s\033X vende \033Y%s\033X a \033Y%s\033X</t> 
+ <t id="654">\033R[ADS]\033X Nessuna stazione sta comprando \033Y%s\033X</t> 
+ <t id="655">\033R[ADS]\033X Nessuna nave abilitata a caricare \033Y%s\033X</t>
+ <t id="656">\033R[ADS]\033X Nessuna stazione nel raggio sta vendendo \033Y%s\033X</t> 
+ <t id="657">\033RADS:\033X Compra Merci</t>
+ <t id="658">Questo comando permette alle tue carrier di comprare merci dalle stazioni vicine utilizzando le navi attraccate. Non viene effettuato nessu controllo per settori nemici pertanto imposta il raggio con attenzione.\n\n\n\n</t>
+ <t id="659">Procedi</t>
+ <t id="660">\033W%s\033X - Quantità: \033W%s\033X  &lt;\033Yrimuovi\033X&gt;</t>
+ <t id="661">\033R[ADS]\033X \033Y%s\033X compra \033Y%s %s\033X a \033Y%s\033X</t> 
+ <t id="662">Seleziona l'ammontare ricercato</t>
+ <t id="663">Aggiungi tutti i tipi di missili</t>
+ 
+
+ <t id="700">\033R[ADS]\033X \033WWing %s: \033X %s &lt;%s&gt;</t> 
+ <t id="702">\033R[ADS]\033X %s - \033WRitirata...\033X</t>
+ <t id="703">\033R[ADS]\033X %s</t>
+ <t id="710">\033YLeader\033X</t>
+ <t id="711">Wingmate</t>
+ <t id="712">\033GScorta\033X</t>
+ <t id="713">\033WNessun Bersaglio\033X</t>
+ <t id="714">\033R%s\033X</t>
+ <t id="715">\033B%s\033X</t>
+ 
+  
+ <t id="800">Report Carrier Automatizzati</t>
+ <t id="801">\033WSeleziona : \033X %s [%s]</t>
+ <t id="802">\033WOrdini : \033X %s - \033WAutomatizzato :\033X %s</t>
+ <t id="803">Seleziona</t>
+ <t id="804">\033Y%s\033X [\033Y%s\033X] - Settore : \033Y%s\033X</t>
+ <t id="805">\033WPosizione : \033X %s [%s]</t>
+ <t id="806">Azioni</t>
+ <t id="807">Impostazione carrier selezionata</t>
+ <t id="808">Applica le attuali impostazioni a tutte le carrier</t>
+
+
+ <t id="820">\033GSi\033X</t>
+ <t id="821">\033RNo\033X</t>
+  
+  <t id="001">** COMMENT ** v2.55 Begins Here</t>
+  
+ <t id="1000">ADS Setup Menu</t>
+ <t id="1001">\033YSelected :\033X %s</t>
+ <t id="1002">Manage Stations</t>
+ <t id="1003">Manage Carriers</t>
+ <t id="1004">\033YMenu\033X</t>
+ <t id="1005">List ADS %ss</t>
+ <t id="1006">Recent Events</t>
+ <t id="1007">\033RUninstall ADS\033X</t>
+ <t id="1008">Apply default settings to all %ss</t>
+ <t id="1009">\033Y[\033X\033G%s\033X\033Y]\033X \033W%s\033X | auto: \033W%s\033X | ADS figthers: \033W%s\033X</t>
+ 
+ <t id="1010">\033RADS Manager\033X</t>
+ <t id="1011">This menu gives you access to all \033YADS compatible\033X assets</t>
+ <t id="1012">\033Y[\033X\033G%s\033X\033Y]\033X \033W%s\033X</t>
+ <t id="1013">- \033GIntegrity:\033X Hull \033Y%s/100\033X - Shields \033Y%s/100\033X</t>
+ <t id="1014">- \033GStatus:\033X \033W%s\033X - \033Y%s\033X</t>
+ <t id="1015">- \033GCombat:\033X threat level \033Y%s\033X - attacked \033Y%s\033X - deployed \033Y%s\033X</t>
+ <t id="1016">- \033GFighters:\033X  owned \033Y%s\033X - docked \033Y%s\033X - ADS \033Y%s\033X</t>
+ <t id="1017">\033Y%s List\033X</t>
+ <t id="1018">ADS Automated Mode  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1019">Open Setup Menu for this %s</t>
+
+ <t id="1020">\033Y[\033X\033G%s\033X\033Y]\033X \033G%s\033X | auto: \033W%s\033X | ADS figthers: \033W%s\033X</t>
+ <t id="1021">\033Y[\033X\033G%s\033X\033Y]\033X \033Y%s\033X | auto: \033W%s\033X | ADS figthers: \033W%s\033X</t>
+ <t id="1022">\033Y[\033X\033G%s\033X\033Y]\033X \033R%s\033X | auto: \033W%s\033X | ADS figthers: \033W%s\033X</t>
+
+ <t id="1023">\033G   Jump to Me</t>
+ <t id="1024">\033G   Jump to Sector ...\033X</t>
+ <t id="1025">\033G   Attack Target ...\033X</t>
+ <t id="1026">Select Destination</t>
+ <t id="1027">Select Target</t>
+ <t id="1028">\033G   Patrol Sectors\033X</t>
+ <t id="1029">\033G   Attack All\033X</t>
+ <t id="1030">Select in crosshair and close</t>
+ <t id="1031">%s deployed fighters in %s</t>
+ <t id="1032">\033WReport From :\033X %s | \033WClass :\033X %s\n\033WLocation :\033X %s | \033WThreat Level :\033X %s\n\n\033WAction :\033X Fighters Launched</t>
+ <t id="1033">\033G   Dock at ...\033X</t>
+ <t id="1034">\033WCommand Panel\033X  \033Y&lt;\033G+\033X\033Y&gt;\033X</t>
+ <t id="1035">View owned ships</t>
+ <t id="1036">\033G   Protect ...\033X</t>
+ <t id="1037">\033G   Standby\033X</t>
+ <t id="1038">\033WCommand Panel\033X  \033Y&lt;\033G-\033X\033Y&gt;\033X</t>
+ <t id="1039">\033G   %s\033G</t>
+ <t id="1040">\033RADS:\033X \033WManager\033X</t>
+ <t id="1041">\033W%s\033X  \033G[\033X%s\033G]\033X  \033G[\033X \033Whull\033X %s%% \033G|\033X \033Wshield\033X %s%% \033G]\033X</t>
+ <t id="1042">Flying</t>
+ <t id="1043">Docked</t>
+ 
+ <t id="001">** COMMENT ** v2.60 Begins Here</t>
+ 
+ <t id="1044">Defense Grid</t>
+ <t id="1045">General Settings</t>
+ <t id="1046">Manage Sectors</t>
+ <t id="1047">View Ships  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1048">ADS Satellite (%s)</t>
+ <t id="1049">\033YDefense Grid\033X</t>
+ 
+ <t id="1050">\033YSector List\033X</t>
+ <t id="1051">[\033G%s,%s\033X] \033W%s\033X | Stations: \033G%s\033X | Threat Level: \033Y%s\033X</t>
+ <t id="1052">Filter : %s</t>
+ <t id="1053">All Sectors</t>
+ <t id="1054">Sectors protected by ADS</t>
+ <t id="1055">Threatened sectors</t>
+
+ <t id="1056">\033YShip List\033X</t>
+ <t id="1057">[\033G%s\033X] \033W%s\033X - \033W%s\033X | Defense Grid : \033Y%s\033X</t>
+ <t id="1058">Defense Grid  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1059">Used by the Defense Grid  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ 
+ <t id="1060">[\033G%s\033X] [%s]  \033W%s\033X</t>
+ <t id="1061">\033WCommand Panel\033X</t>
+ <t id="1062">\033GLaunch Wing\033X</t>
+ <t id="1063">Change Target  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1064">Ship Count</t>
+ <t id="1065">\033WManual Selection\033X</t>
+ <t id="1066">\033G%s\033X</t>
+ <t id="1067">\033Y%s\033X</t>
+ <t id="1068">\033R%s\033X</t>
+ 
+ <t id="1069">Launch</t>
+ <t id="1070">%s%%</t>
+ <t id="1071">Stay Docked</t>
+ <t id="1072">manual selection</t>
+ <t id="1073">auto</t>
+ <t id="1074">Class: %s | Owner: %s | Relation: %s</t>
+ 
+ <t id="001">** COMMENT ** v2.65 Begins Here</t> 
+ 
+ <t id="1075">Marine Training Center</t>
+ <t id="1076">Crew Quarters</t>
+ <t id="1077">Standard Training</t>
+ <t id="1078">Combat Training</t>
+
+<t id="001">** COMMENT ** Marine Statistics</t> 
+ <t id="1079">  \033Y[\033X Fight: \033W%s\033X - Mech: \033W%s\033X - Hack: \033W%s\033X - Engineer: \033W%s\033X\033Y ]\033X</t>
+ 
+ <t id="001">** COMMENT ** Marine Name - Overall Skill</t> 
+ <t id="1080">\033G%s\033X - \033WOverall:\033X \033G%s\033X</t>
+
+<t id="1081">Name</t>
+ <t id="1082">Fightskill</t>
+ <t id="1083">Mechanical</t>
+ <t id="1084">Hacking</t>
+ <t id="1085">Engineering</t>
+ <t id="1086">Barracks ...</t>
+ <t id="1087">\033GSave and close\033X</t>
+ <t id="1088">\n\033RPress [Esc] to close without saving\033X</t>
+ 
+ <t id="1089">\033WGeneral Settings\033X</t>
+ <t id="1090">\033YDefault Setup\033X</t>
+ <t id="1091">\033WEdit Default Carrier Setup\033W</t>
+ <t id="1092">\033WEdit Default Station Setup\033W</t>
+ <t id="1093">\033YDefense Grid Settings\033X</t>
+ <t id="1094">\033WMaximum Jump Distance\033X</t>
+ <t id="1095">\033WMinimum Threat to trigger an alert\033X</t>
+ <t id="1096">\033WDisplay Warning Message\033X</t>
+ <t id="1097">\033YIgnore Factions\033X</t>
+ <t id="1098">\033YGeneral Settings\033X</t>
+ <t id="1099">\033WDynamic Renaming System\033X</t>
+ <t id="1100">\033RReset All Settings to default values\033X</t>
+ <t id="1101">Auto</t>
+ <t id="1102">Manual</t>
+ <t id="1103">Trade Only</t>
+ <t id="1104">Ignore</t>
+
+<t id="1105">\033W- Training Cost :\033X \033Y%s\033X \033Wcredits per hour\033X</t>
+<t id="1106">\033GApply Settings\033X</t>
+<t id="1107">Barracks</t>
+<t id="1108">\033W- There is %s marines training onboard\033X</t>
+<t id="1109">\033W- Room :\033X \033Y%s/%s\033X</t>
+<t id="1110">Passengers</t>
+<t id="1111">Enslave</t>
+<t id="1112">Train</t>
+<t id="1113">\033RADS:\033X \033Y%s\033X \033Wis under attack [threat :\033X \033Y%s\033X\033W]\033X</t>
+<t id="1114">[\033G%s,%s\033X] \033W%s:\033X \033G%s</t>
+<t id="1115">%s\033X \033W%s\033X [\033Gauto\033X|\033W%s\033X]</t>
+<t id="1116">%s\033X \033W%s\033X [\033Wmanual\033X|\033W%s\033X]</t>
+<t id="1117">%s\033X \033W%s\033X</t>
+<t id="1118">\033YGrid Members\033X</t>
+<t id="1119">\033YUnassigned\033X</t>
+<t id="1120">%s\033X \033W%s\033X [\033Ybattle\033X|\033W%s\033X]</t>
+<t id="1121">[\033G%s,%s\033X] \033W%s:\033X \033Y%s</t>
+<t id="1122">[\033G%s,%s\033X] \033W%s:\033X %s</t>
+<t id="1123">\033Y%s\033X  \033G[\033X%s\033G]\033X  \033G[\033X \033Whull\033X %s%% \033G|\033X \033Wshield\033X %s%% \033G]\033X</t>
+
+ </page>
+
+</language>
+

--- a/tools/fixtures/known_good/ADS/t/8510-L044.xml
+++ b/tools/fixtures/known_good/ADS/t/8510-L044.xml
@@ -1,0 +1,451 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<language id="44">
+
+<page id="2008" title="Script Object Commands" descr="0">
+ <t id="830">ANARKIS_SETDOCKED</t>
+ <t id="831">ANARKIS_SELLWARES</t>
+ <t id="832">ANARKIS_BUYWARES</t>
+ <t id="833">ANARKIS_DEFENSIVEWING</t>
+ <t id="834">ANARKIS_ATTACKWING</t>
+ <t id="835">ANARKIS_CLEANSECTOR</t>
+ <t id="836">ANARKIS_DOCKALL</t>
+ <t id="1231">ANARKIS_SETTACTICS</t>
+ <t id="1232">ANARKIS_AUTOCARRIER</t>
+ <t id="1131">ANARKIS_SETUPSTATION</t>
+ <t id="1132">ANARKIS_STATIONDEFENSE</t>
+</page>
+
+<page id="2010" title="Script Cmd Names" descr="Long version of commandos. These are the commandos assigned to ships using the commandconsole. Page 2010 and 2011 belong together and hold short and long versions of the same commands"> 
+ <t id="830">\033RADS:\033X Homebase Settings</t>
+ <t id="831">\033RADS:\033X Sell wares...</t>
+ <t id="832">\033RADS:\033X Buy ware for carrier...</t>
+ <t id="833">\033RADS:\033X Send Defensive Wing</t>
+ <t id="834">\033RADS:\033X Attack Wing against...</t>
+ <t id="835">\033RADS:\033X Clear Sector</t>
+ <t id="836">\033RADS:\033X Dock all ships</t>
+ <t id="1231">\033RADS:\033X Carrier Setup</t>
+ <t id="1232">\033RADS:\033X Automated Carrier</t>
+ <t id="1131">\033RADS:\033X Setup Defense System</t>
+ <t id="1132">\033RADS:\033X Sector Defense</t>
+</page> 
+
+<page id="2011" title="Script Cmd Shorts" descr="Short version of commandos. These are the commandos assigned to ships using the commandconsole. Page 2010 and 2011 belong together and hold short and long versions of the same commands"> 
+ <t id="830">set.homebase</t>  
+ <t id="831">sell.ware</t>
+ <t id="832">buy.ware</t>
+ <t id="833">defense.wing</t>
+ <t id="834">attack.wing</t>
+ <t id="835">clean.sector</t>
+ <t id="836">dock.ships</t>
+ <t id="1131">set.defense</t>
+ <t id="1132">auto.station</t>
+ <t id="1231">set.tactics</t>
+ <t id="1232">auto.carrier</t>
+</page> 
+
+<page id="2022"> 
+ <t id="830">Allow to selected homebase settings for the docked ships at this carrier. Ships will be renamed and missile settings applied.</t>  
+ <t id="831">Send multiple ships to sell wares from the carrier</t>
+ <t id="832">Send multiple ships to buy a given amount of a ware to the nearest factory</t>
+ <t id="833">Send a squadron to defend your carrier or another ship</t>
+ <t id="834">Send a squadron to attack a ship or a factory</t>
+ <t id="835">Clean the sector from all enemy activity</t>
+ <t id="836">All ships with this homebase assigned will dock here. Distant jumpdrive equipped ships will try to jump to the carrier.</t>
+ <t id="1131">Setup Anarkis Defense Station on this station.</t>
+ <t id="1132">Enable a defensive mode for the station, it will send ships against incomings and repair its docked ships over time</t>
+ <t id="1231">This command will allow you to setup both your docked ships and the carrier in automated mode.</t>
+ <t id="1232">Automated Mode. The carrier will defend itself and send ships when needed.</t>
+</page> 
+
+<page id="8510" title="ACC" descr="Anarkis Command Carrier">
+ <t id="100">\033RADS:\033X Anarkis Defense System</t>
+ <t id="101">265</t>
+ <t id="102">Anarkis Federation</t>
+ <t id="103">[author][b]Anarkis Federation[/b][/author][b]Anarkis Defense System[/b] v%s succesfully installed ! </t>
+ <t id="104">[author][b]Anarkis Federation[/b][/author][b]Anarkis Defense System[/b] succesfully upgraded to v%s !</t>
+ <t id="105">[author][b]ADS - %s[/b][/author] You cannot use this command on your playership.</t>
+ <t id="106">[author][b]Anarkis Federation[/b][/author][b]Anarkis Defense System[/b] has been removed from the game.\nPlease save your game now, exit and run the 'uninstall acc.bat' file in your X3 folder.</t>
+ 
+ <t id="200">Anarkis Carrier Menu</t>
+
+ <t id="210">General</t>
+ <t id="211">Hangars ...</t>
+ <t id="212">Automated Carriers Report</t>
+ <t id="213">Missile Usage  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="214">Emergency Jump  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X - Shield Limit  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="215">Autojump  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X - Minimum Range  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="216">Fuel Resupply Quantity \(jumps\)  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="217">Setup docked ships</t>
+
+ <t id="220">Automated Carrier Setup</t>
+ <t id="221">\033WMinimal Threat Level\033X</t>
+ <t id="222">\033WDisplay Warning Message\033X</t>
+ <t id="223">\033WForce Damaged Ships to Retreat\033X</t>
+ <t id="224">\033WAttack Mode\033X</t>
+ <t id="225">\033WDefensive Wing Size\033X</t>
+ <t id="226">\033WRadar Range\033X</t>
+ <t id="227">Ignore Factions  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="228">Display</t>
+ <t id="229">\033WWarning Type\033X</t>
+  
+ <t id="230">ADS Plugin Settings</t>
+ <t id="231">Apply settings on \033Yall\033X docked ships</t>
+ <t id="232">Reset Settings to Default Values</t>
+ <t id="233">Subtitles</t>
+ <t id="234">Audio</t>
+ <t id="235">Popup</t>
+ <t id="236">Debug Logfile Output  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="237">Apply settings on \033Yactive\033X docked ships only</t>
+
+ <t id="238">\033WDelay before docking fighters in seconds\033X</t>
+
+ 
+ <t id="240">Carrier Management</t>
+ <t id="241">Automated Carrier ...</t>
+ <t id="242">Repair Bays ...</t>
+ <t id="243">Ship Supplies ...</t>
+ <t id="244">Turret Settings : \033Y%s\033X</t>
+ <t id="245">Protect Ship</t>
+ <t id="246">Attack Enemies</t>
+ <t id="247">Missile Defence</t>
+ <t id="248">\033RMARS:\033X Offense</t>
+ <t id="249">\033RMARS:\033X Defense</t>
+ 
+ <t id="201">Enabled</t>
+ <t id="202">Disabled</t>
+ <t id="203">Yes</t>
+ <t id="204">No</t>
+ <t id="205">Default</t>
+ <t id="206">Auto Select</t>
+ <t id="207">Strongest First</t>
+ <t id="208">Nearest First</t>
+ <t id="209">None</t>
+ 
+ <t id="250">Carrier : \033Y%s\033X [%s]</t>
+ <t id="251">Location : \033Y%s\033X</t>
+ <t id="252">Docked : %s/%s - Owned : %s</t>
+ <t id="260">© Serial Kicked / [\033YAnarkis Federation\033X]</t>
+ 
+ <t id="300">Select the amount of ship used for defence purpose</t>
+ <t id="301">Targeting Setup</t>
+ <t id="302">Select how attack ships will target enemy ships</t>
+ <t id="303">Force damaged ships to retreat ?</t>
+ <t id="304">Display a warning message when the carrier is in danger ?</t>
+ <t id="305">This menu allow you to choose what is the minimum threat level that trigger a launch of fighters. To understand how the level system work, you'll need to know the "threat" values used for each kind of ship and you should also know that the carrier will always send ships if an enemy M1/M2 ship is spotted. Fighter drones are ignored.</t>
+ <t id="306">M5: 1 - M4: 2  - M3: 5 - M8: 10 - M6: 14 - M7: 35\nTL: 15 - TM: 8 - TP/TS: 2\n\n\n\n</t>
+ <t id="307">Minimum Threat Level</t>
+ <t id="308">Select the fuel resupply quantity in jumps</t>
+ <t id="309">Do you want to enabled the autojump feature on docked ships ?</t>
+ <t id="310">Set the autojump minimum range</t>
+ <t id="311">Do you want to enabled the emergency jump feature on docked ships ?</t>
+ <t id="312">Set the emergency shield threshold in percent</t>
+ <t id="313">Set the missile usage in percent</t>
+ <t id="314">Select a new radar range in meters</t>
+ <t id="315">Select the new delay in seconds</t>
+ 
+ <t id="400">Mechanics</t>
+ <t id="401">You can use mechanics to repair damaged fighters in the carrier. You can hire mechanics for a cost in any friendly sector. When off duty they will cost you about 1000 credits per hour and per mechanic, and much more when repairing a ship. The more mechanics you have, they faster your ships will be repaired.\n\nCurrent off-duty cost : \033Y%s credits per hour\033X\nCurrent on-duty cost : \033Y%s credits per hour\033X\n\n\n\n</t>
+ <t id="402">You currently have : \033Y%s\033X mechanics (off duty cost : \033Y%s\033X credits per hour)</t>
+ <t id="403">Settings</t>
+ <t id="404">Allow to repair docked ships  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="405">Allow to repair the carrier  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="406">Management : \033Y%s mechanics\033X</t>
+ <t id="407">Hire new mechanics</t>
+ <t id="408">Fire mechanics</t>
+ <t id="409">Damaged Ships</t>
+ <t id="410">  [%s] \033Y%s\033X - hull : %s/100</t>
+ <t id="411">To hire a new mechanic will cost you 50.000 credits. Are you sure ?</t>
+ <t id="412">You do not have enough money to hire a new mechanic.</t>
+ <t id="413">You need a friendly Trading Station in the carrier current sector.</t>
+
+ <t id="420">Hangar Management</t>
+ <t id="421">Select the ships you want to be used by ACC commands</t>
+ <t id="422">Docked Ship List</t>
+ <t id="423">General Commands</t>
+ <t id="424">Apply homebase to all docked ships</t>
+ <t id="425">Management</t>
+ <t id="426">Add all ships</t>
+ <t id="427">Add M3 and M4 ships only</t>
+ <t id="428">Add M3 ships only</t>
+ <t id="429">Remove all ships</t>
+ <t id="430">  [%s] \033Y%s\033X - %s</t>
+ <t id="431">\033GActive\033X</t>
+ <t id="432">\033RInactive\033X</t>
+ <t id="433">\033YUnder Repairs\033X</t>
+ <t id="434">Rename docked ships</t>
+ <t id="435">Apply homebase to active ships only</t>
+
+ <t id="440">Ship Supplies</t>
+ <t id="441">This is where you can move cargo between your carrier and its docked ships\n\n\n</t>
+ <t id="442">Standard Actions</t>
+ <t id="443">Move wares from the carrier to docked ships</t>
+ <t id="444">Unload wares to the carrier</t>
+ <t id="445">Advanced</t>
+ <t id="446">Allow carrier to buy back destroyed fighters  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="447">Allow carrier to repair at SY  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="448">Allow carrier to keep ships supplied \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="449">This menu allows to move wares from your docked ships to the carrier.</t>
+ <t id="450">\033YUnload :\033X %s</t>
+ <t id="451">Trade wares only [except energy cells]</t>
+ <t id="452">Trade wares only [including energy cells]</t>
+ <t id="453">Missiles</t>
+ <t id="454">Everything not equipped</t>
+ <t id="455">\033YFrom :\033X %s</t>
+ <t id="456">Active ships only</t>
+ <t id="457">All docked ships</t>
+ <t id="458">\033YValidate\033X</t>
+ <t id="459">Confirm Action</t>
+ 
+ <t id="460">Ignored Factions</t>
+ <t id="461">Manage</t>
+ <t id="462">Clear whole list</t>
+ <t id="463">Add a faction to the list</t>
+ <t id="464">\033Y%s\033X - remove</t>
+ <t id="465">Select a faction to ignore</t>
+
+ <t id="480">Rename Ships</t>
+ <t id="481">ShipType Class - Number</t>
+ <t id="482">CarrierName - ShipType - Number</t>
+ <t id="483">BuilderRace Class - Number</t>
+ <t id="484">Allows to mass rename your docked ships.</t>
+ <t id="485">Setup</t>
+ <t id="486">Apply to all docked ships</t>
+ <t id="487">Apply to all active ships</t>
+ <t id="488">\033YSelected : \033X%s</t>
+ <t id="489">\033YExample : \033X%s</t>
+
+ 
+ <t id="500">[author][b]Anarkis Carrier Commands[/b][/author] [b]Warning:[/b] Your [b]%s[/b] in sector [b]%s[/b] is in danger and could request your attention.</t>
+ <t id="501">[author][b]Anarkis Carrier Commands[/b][/author] [b]Canceled:[/b] You don't have enough ships in %s for this command</t>
+ <t id="502">[author][b]Anarkis Carrier Commands[/b][/author] [b]Canceled:[/b] You don't have enough ships in %s to clean a sector. At least 5 are needed.</t>
+ <t id="503">[author][b]Anarkis Carrier Commands[/b][/author] [b]Error:[/b] Not enough wares in cargo bay to equip any ship.</t>
+ <t id="504">[author][b]Anarkis Carrier Commands[/b][/author] [b]Success:[/b] %s has equiped %s/%s ships with %s %s.</t>
+ <t id="505">[author][b]Anarkis Carrier Commands[/b][/author] [b]Canceled:[/b] %s - No station in range has enough %s.</t>
+ <t id="506">\033RALERT:\033X \033W%s in sector %s needs help !\033X</t>
+ 
+ <t id="520">Equip Ships</t>
+ <t id="521">\033YWares\033X</t>
+ <t id="522">&lt; \033Yadd a new ware\033X &gt;</t>
+ <t id="523">\033W%s\033X [quantity: %s]  &lt;\033Rremove\033X&gt;</t>
+ <t id="524">\033YMode :\033X %s</t>
+ <t id="525">Same quantity to all ships [$quantity = max value]</t>
+ <t id="526">At least $quantity wares to each ship</t>
+ <t id="527">\033YDestination :\033X %s</t>
+ <t id="528">Docked ships</t>
+ <t id="529">Active ships</t>
+ <t id="530">\033YValidate\033X</t>
+ <t id="531">Confirm Action</t>
+ <t id="532">Select the ware you want to move</t>
+ <t id="533">Select the quantity</t>
+
+ <t id="540">Transfert Report</t>
+ <t id="541">Wares transfered</t>
+ <t id="542">\033W%s %s\033X transfered to \033Y%s\033X</t>
+ <t id="543">\033W%s %s\033X unloaded from \033Y%s\033X</t>
+ 
+ <t id="600">\033RADS:\033X Clear Sector</t>
+ <t id="601">\033RADS:\033X Dock all my ships</t>
+ <t id="602">\033RADS:\033X Attack My Target</t>
+ <t id="603">\033RADS\033X \033WManager\033W</t>
+
+ <t id="640">\033RADS:\033X Sell Wares</t>
+ <t id="641">Selected Wares</t>
+ <t id="642">Quick Select</t>
+ <t id="643">Clear the List</t>
+ <t id="644">Add all trading wares</t>
+ <t id="645">Begin Transfert</t>
+ <t id="646">&lt; \033Yadd a new ware\033X &gt;</t>
+ <t id="647">Settings</t>
+ <t id="648">Maximum Distance \033R&lt;\033X \033Y%s sectors\033X \033R&gt;\033X</t>
+ <t id="649">This command allows your carrier to sell its wares to the stations around using its docked ships. There is no check for enemy sectors so set your range carefully.\n\n\n\n</t>
+ <t id="650">\033W%s\033X - Amount: \033W%s\033X  &lt;\033Yremove\033X&gt;</t>
+ <t id="651">Select new jump range</t>
+ <t id="652">Select a ware to be added</t>
+ <t id="653">\033R[ADS]\033X \033Y%s\033X sells \033Y%s\033X to \033Y%s\033X</t> 
+ <t id="654">\033R[ADS]\033X No station buying \033Y%s\033X</t> 
+ <t id="655">\033R[ADS]\033X No ship able to load \033Y%s\033X</t>
+ <t id="656">\033R[ADS]\033X No station selling \033Y%s\033X in range</t> 
+ <t id="657">\033RADS:\033X Buy Wares</t>
+ <t id="658">This command allows your carrier to buy wares from the stations around using its docked ships. There is no check for enemy sectors so set your range carefully.\n\n\n\n</t>
+ <t id="659">Proceed</t>
+ <t id="660">\033W%s\033X - Quantity: \033W%s\033X  &lt;\033Yremove\033X&gt;</t>
+ <t id="661">\033R[ADS]\033X \033Y%s\033X buy \033Y%s %s\033X at \033Y%s\033X</t> 
+ <t id="662">Select the wanted amount</t>
+ <t id="663">Add all missile types</t>
+ 
+
+ <t id="700">\033R[ADS]\033X \033WWing %s: \033X %s &lt;%s&gt;</t> 
+ <t id="702">\033R[ADS]\033X %s - \033WRetreating...\033X</t>
+ <t id="703">\033R[ADS]\033X %s</t>
+ <t id="710">\033YLeader\033X</t>
+ <t id="711">Wingmate</t>
+ <t id="712">\033GEscort\033X</t>
+ <t id="713">\033WNo Target\033X</t>
+ <t id="714">\033R%s\033X</t>
+ <t id="715">\033B%s\033X</t>
+ 
+	
+ <t id="800">Automated Carriers Report</t>
+ <t id="801">\033WSelected : \033X %s [%s]</t>
+ <t id="802">\033WOrders : \033X %s - \033WAutomated :\033X %s</t>
+ <t id="803">Selection</t>
+ <t id="804">\033Y%s\033X [\033Y%s\033X] - Sector : \033Y%s\033X</t>
+ <t id="805">\033WLocation : \033X %s [%s]</t>
+ <t id="806">Actions</t>
+ <t id="807">Setup selected carrier</t>
+ <t id="808">Apply current settings to all carriers</t>
+
+
+ <t id="820">\033GYes\033X</t>
+ <t id="821">\033RNo\033X</t>
+
+<t id="001">** COMMENT ** v2.55 Begins Here</t>
+ 
+ <t id="1000">ADS Setup Menu</t>
+ <t id="1001">\033YSelected :\033X %s</t>
+ <t id="1002">Manage Stations</t>
+ <t id="1003">Manage Carriers</t>
+ <t id="1004">\033YMenu\033X</t>
+ <t id="1005">List ADS %ss</t>
+ <t id="1006">Recent Events</t>
+ <t id="1007">\033RUninstall ADS\033X</t>
+ <t id="1008">Apply default settings to all %ss</t>
+ <t id="1009">\033Y[\033X\033G%s\033X\033Y]\033X \033W%s\033X | auto: \033W%s\033X | Ships: \033W%s\033X</t>
+ 
+ <t id="1010">\033RADS Manager\033X</t>
+ <t id="1011">This menu gives you access to all \033YADS compatible\033X assets</t>
+ <t id="1012">\033Y[\033X\033G%s\033X\033Y]\033X \033W%s\033X</t>
+ <t id="1013">- \033GIntegrity:\033X Hull \033Y%s/100\033X - Shields \033Y%s/100\033X</t>
+ <t id="1014">- \033GStatus:\033X \033W%s\033X - \033Y%s\033X</t>
+ <t id="1015">- \033GCombat:\033X threat level \033Y%s\033X - attacked \033Y%s\033X - deployed \033Y%s\033X</t>
+ <t id="1016">- \033GFighters:\033X  owned \033Y%s\033X - docked \033Y%s\033X - ADS \033Y%s\033X</t>
+ <t id="1017">\033Y%s List\033X</t>
+ <t id="1018">ADS Automated Mode  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1019">Open ADS %s setup menu</t>
+
+ <t id="1020">\033Y[\033X\033G%s\033X\033Y]\033X \033G%s\033X | auto: \033W%s\033X | Ships: \033W%s\033X</t>
+ <t id="1021">\033Y[\033X\033G%s\033X\033Y]\033X \033Y%s\033X | auto: \033W%s\033X | Ships: \033W%s\033X</t>
+ <t id="1022">\033Y[\033X\033G%s\033X\033Y]\033X \033R%s\033X | auto: \033W%s\033X | Ships: \033W%s\033X</t>
+ <t id="1023">\033G   Jump to Me</t>
+ <t id="1024">\033G   Jump to Sector ...\033X</t>
+ <t id="1025">\033G   Attack Target ...\033X</t>
+ <t id="1026">Select Destination</t>
+ <t id="1027">Select Target</t>
+ <t id="1028">\033G   Patrol Sectors\033X</t>
+ <t id="1029">\033G   Attack All\033X</t>
+
+ <t id="1030">Select in crosshair and close</t>
+ <t id="1031">%s deployed fighters in %s</t>
+ <t id="1032">\033WReport From :\033X %s | \033WClass :\033X %s\n\033WLocation :\033X %s | \033WThreat Level :\033X %s\n\n\033WAction :\033X Fighters Launched</t>
+ <t id="1033">\033G   Dock at ...\033X</t>
+ <t id="1034">\033WCommand Panel\033X  \033Y&lt;\033G+\033X\033Y&gt;\033X</t>
+ <t id="1035">View owned ships</t>
+ <t id="1036">\033G   Protect ...\033X</t>
+ <t id="1037">\033G   Standby\033X</t>
+ <t id="1038">\033WCommand Panel\033X  \033Y&lt;\033G-\033X\033Y&gt;\033X</t>
+ <t id="1039">\033G   %s\033G</t>
+ 
+ <t id="1040">\033RADS:\033X \033WManager\033X</t>
+ <t id="1041">\033W%s\033X  \033G[\033X%s\033G]\033X  \033G[\033X \033Whull\033X %s%% \033G|\033X \033Wshield\033X %s%% \033G]\033X</t>
+ <t id="1042">Flying</t>
+ <t id="1043">Docked</t>
+ 
+<t id="001">** COMMENT ** v2.60 Begins Here</t>
+ 
+ <t id="1044">Defense Grid</t>
+ <t id="1045">General Settings</t>
+ <t id="1046">Manage Sectors</t>
+ <t id="1047">View Ships  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1048">ADS Satellite (%s)</t>
+ <t id="1049">\033YDefense Grid\033X</t>
+ 
+ <t id="1050">\033YSector List\033X</t>
+ <t id="1051">[\033G%s,%s\033X] \033W%s\033X | Stations: \033G%s\033X | Threat Level: \033Y%s\033X</t>
+ <t id="1052">Filter : %s</t>
+ <t id="1053">All Sectors</t>
+ <t id="1054">Sectors protected by ADS</t>
+ <t id="1055">Threatened sectors</t>
+ <t id="1056">\033YShip List\033X</t>
+ <t id="1057">[\033G%s\033X] \033W%s\033X - \033W%s\033X | Defense Grid : \033Y%s\033X</t>
+ <t id="1058">Defense Grid  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1059">Used by the Defense Grid  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ 
+ <t id="1060">[\033G%s\033X] [%s]  \033W%s\033X</t>
+ <t id="1061">\033WCommand Panel\033X</t>
+ <t id="1062">\033GLaunch Wing\033X</t>
+ <t id="1063">Change Target  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1064">Ship Count</t>
+ <t id="1065">\033WManual Selection\033X</t>
+ <t id="1066">\033G%s\033X</t>
+ <t id="1067">\033Y%s\033X</t>
+ <t id="1068">\033R%s\033X</t> 
+ <t id="1069">Launch</t>
+ 
+ <t id="1070">%s%%</t>
+ <t id="1071">Stay Docked</t>
+ <t id="1072">manual</t>
+ <t id="1073">auto</t>
+ <t id="1074">Class: %s | Owner: %s | Relation: %s</t>
+
+ <t id="001">** COMMENT ** v2.65 Begins Here</t> 
+ 
+ <t id="1075">Marine Training Center</t>
+ <t id="1076">Crew Quarters</t>
+ <t id="1077">Standard Training</t>
+ <t id="1078">Combat Training</t>
+
+<t id="001">** COMMENT ** Marine Statistics</t> 
+ <t id="1079">  \033Y[\033X Fight: \033W%s\033X - Mech: \033W%s\033X - Hack: \033W%s\033X - Engineer: \033W%s\033X\033Y ]\033X</t>
+ 
+ <t id="001">** COMMENT ** Marine Name - Overall Skill</t> 
+ <t id="1080">\033G%s\033X - \033WOverall:\033X \033G%s\033X</t>
+
+<t id="1081">Name</t>
+ <t id="1082">Fightskill</t>
+ <t id="1083">Mechanical</t>
+ <t id="1084">Hacking</t>
+ <t id="1085">Engineering</t>
+ <t id="1086">Barracks ...</t>
+ <t id="1087">\033GSave and close\033X</t>
+ <t id="1088">\n\033RPress [Esc] to close without saving\033X</t>
+ 
+ <t id="1089">\033WGeneral Settings\033X</t>
+ <t id="1090">\033YDefault Setup\033X</t>
+ <t id="1091">\033WEdit Default Carrier Setup\033W</t>
+ <t id="1092">\033WEdit Default Station Setup\033W</t>
+ <t id="1093">\033YDefense Grid Settings\033X</t>
+ <t id="1094">\033WMaximum Jump Distance\033X</t>
+ <t id="1095">\033WMinimum Threat to trigger an alert\033X</t>
+ <t id="1096">\033WDisplay Warning Message\033X</t>
+ <t id="1097">\033YIgnore Factions\033X</t>
+ <t id="1098">\033YGeneral Settings\033X</t>
+ <t id="1099">\033WDynamic Renaming System\033X</t>
+ <t id="1100">\033RReset All Settings to default values\033X</t>
+ <t id="1101">Auto</t>
+ <t id="1102">Manual</t>
+ <t id="1103">Trade Only</t>
+ <t id="1104">Ignore</t>
+
+<t id="1105">\033W- Training Cost :\033X \033Y%s\033X \033Wcredits per hour\033X</t>
+<t id="1106">\033GApply Settings\033X</t>
+<t id="1107">Barracks</t>
+<t id="1108">\033W- There is %s marines training onboard\033X</t>
+<t id="1109">\033W- Room :\033X \033Y%s/%s\033X</t>
+<t id="1110">Passengers</t>
+<t id="1111">Enslave</t>
+<t id="1112">Train</t>
+<t id="1113">\033RADS:\033X \033Y%s\033X \033Wis under attack [threat :\033X \033Y%s\033X\033W]\033X</t>
+<t id="1114">[\033G%s,%s\033X] \033W%s:\033X \033G%s</t>
+<t id="1115">%s\033X \033W%s\033X [\033Gauto\033X|\033W%s\033X]</t>
+<t id="1116">%s\033X \033W%s\033X [\033Wmanual\033X|\033W%s\033X]</t>
+<t id="1117">%s\033X \033W%s\033X</t>
+<t id="1118">\033YGrid Members\033X</t>
+<t id="1119">\033YUnassigned\033X</t>
+<t id="1120">%s\033X \033W%s\033X [\033Ybattle\033X|\033W%s\033X]</t>
+<t id="1121">[\033G%s,%s\033X] \033W%s:\033X \033Y%s</t>
+<t id="1122">[\033G%s,%s\033X] \033W%s:\033X %s</t>
+<t id="1123">\033Y%s\033X  \033G[\033X%s\033G]\033X  \033G[\033X \033Whull\033X %s%% \033G|\033X \033Wshield\033X %s%% \033G]\033X</t>
+ 
+</page>
+
+</language>

--- a/tools/fixtures/known_good/ADS/t/8510-L048.xml
+++ b/tools/fixtures/known_good/ADS/t/8510-L048.xml
@@ -1,0 +1,452 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<language id="48">
+
+<page id="2008" title="Script Object Commands" descr="0">
+ <t id="830">ANARKIS_SETDOCKED</t>
+ <t id="831">ANARKIS_SELLWARES</t>
+ <t id="832">ANARKIS_BUYWARES</t>
+ <t id="833">ANARKIS_DEFENSIVEWING</t>
+ <t id="834">ANARKIS_ATTACKWING</t>
+ <t id="835">ANARKIS_CLEANSECTOR</t>
+ <t id="836">ANARKIS_DOCKALL</t>
+ <t id="1231">ANARKIS_SETTACTICS</t>
+ <t id="1232">ANARKIS_AUTOCARRIER</t>
+ <t id="1131">ANARKIS_SETUPSTATION</t>
+ <t id="1132">ANARKIS_STATIONDEFENSE</t>
+</page>
+
+<page id="2010" title="Script Cmd Names" descr="Long version of commandos. These are the commandos assigned to ships using the commandconsole. Page 2010 and 2011 belong together and hold short and long versions of the same commands"> 
+ <t id="830">\033RADS:\033X Ustawienia Bazy macierzystej</t>
+ <t id="831">\033RADS:\033X Sprzedaj towary...</t>
+ <t id="832">\033RADS:\033X Kup towary dla lotniskowca...</t>
+ <t id="833">\033RADS:\033X Wyślij szwadron myśliwców</t>
+ <t id="834">\033RADS:\033X Atak szwadronów przeciwko...</t>
+ <t id="835">\033RADS:\033X Wyczyść Sektor</t>
+ <t id="836">\033RADS:\033X Zadokuj wszystkie statki</t>
+ <t id="1231">\033RADS:\033X Ustawienia Lotniskowca</t>
+ <t id="1232">\033RADS:\033X Zautomatyzowany Lotniskowiec</t>
+ <t id="1131">\033RADS:\033X Ustawienia Systemu Obrony</t>
+ <t id="1132">\033RADS:\033X Obrona Sektora</t>
+</page> 
+
+<page id="2011" title="Script Cmd Shorts" descr="Short version of commandos. These are the commandos assigned to ships using the commandconsole. Page 2010 and 2011 belong together and hold short and long versions of the same commands"> 
+ <t id="830">set.homebase</t>  
+ <t id="831">sell.ware</t>
+ <t id="832">buy.ware</t>
+ <t id="833">defense.wing</t>
+ <t id="834">attack.wing</t>
+ <t id="835">clean.sector</t>
+ <t id="836">dock.ships</t>
+ <t id="1131">set.defense</t>
+ <t id="1132">auto.station</t>
+ <t id="1231">set.tactics</t>
+ <t id="1232">auto.carrier</t>
+</page> 
+
+<page id="2022"> 
+ <t id="830">Zezwala na przypisanie bazy macierzystej dla zadokowanych statków na tym lotniskowcu. Statki zostaną uzbrojone w rakiety, a ich nazewnictwo ulegnie zmianie.</t>  
+ <t id="831">Wyślij wielozadaniowe statki, aby  sprzedały towary z tego lotniskowca</t>
+ <t id="832">Wyślij wielozadaniowe statki, żeby kupiły towary z pobliskich fabryk</t>
+ <t id="833">Wyślij szwadron do obrony lotniskowca lub innego statku</t>
+ <t id="834">Wyślij szwadron do ataku na wskazany statek lub fabrykę</t>
+ <t id="835">Wyczyść sektor z jakiejkolwiek aktywności wroga</t>
+ <t id="836">Wszystkim statkom z tej bazy macierzystej zostanie przypisana komenda zadokowania tutaj. Przy większych dystansach statki wyposażone w napęd skokowy będą z niego korzystały by dostać się do lotniskowca.</t>
+ <t id="1131">Ustawienia Systemu Obronnego Anarkis.</t>
+ <t id="1132">Włączenie trybu obronnego dla stacji oznacza to iż szwadrony myśliwców będą starały się przechwycić najeźdźców, a statki naprawcze będą dokonywały naprawę.</t>
+ <t id="1231">Ten rozkaz umożliwia tobie na ustawienie twojego lotniskowca jak i zadokowanych do niego statków w tryb zautomatyzowany.</t>
+ <t id="1232">Tryb automatyczny. Lotniskowiec będzie sam się bronił i wysyłał statki o ile zajdzie taka potrzeba.</t>
+</page> 
+
+<page id="8510" title="ACC" descr="Anarkis Command Carrier">
+ <t id="100">\033RADS:\033X System Obronny Anarkis</t>
+ <t id="101">265</t>
+ <t id="102">Federacja Anarkis</t>
+ <t id="103">[author][b]Federacja Anarkis[/b][/author][b]System Obronny Anarkis[/b] v%s prawidłowo zainstalowany ! </t>
+ <t id="104">[author][b]Federacja Anarkis[/b][/author][b]System Obronny Anarkis[/b] prawidłowo zaktualizowany do v%s !</t>
+ <t id="105">[author][b]ADS - %s[/b][/author] Nie możesz używać tego polecenia na statku dowodzonym przez ciebie.</t>
+ <t id="106">[author][b]Federacja Anarkis[/b][/author][b]System Obronny Anarkis[/b] został usuniety z gry.\nPrzed zapisem gry przejdź do folderu z grą X3 TC i uruchom program 'uninstall acc.bat. Po czym powróć do gry a następnie ją zapisz.</t>
+ 
+ <t id="200">Anarkis Menu Lotniskowca</t>
+
+ <t id="210">Główne</t>
+ <t id="211">Hangary...</t>
+ <t id="212">Automatyczny Raport Lotniskowca</t>
+ <t id="213">Używane Rakiety  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="214">Awaryjny Skok  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X - Próg Tarcz  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="215">Auto skok \033R&lt;\033X \033Y%s\033X \033R&gt;\033X - Minimalny Zasięg  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="216">Ilość Uzupełnianego Paliwa\(skoki\)  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="217">Zarządzanie Zadokowanymi Statkami</t>
+
+ <t id="220">Zautomatyzowane Zarządzanie Lotniskowcem</t>
+ <t id="221">\033WMinimalny Poziom Zagrożenia\033X</t>
+ <t id="222">\033WPokaż Komunikat Ostrzegawczy\033X</t>
+ <t id="223">\033WZmuś Uszkodzone Statki do Odwrotu\033X</t>
+ <t id="224">\033WTryb Ataku\033X</t>
+ <t id="225">\033WLiczba Statków W Obronie\033X</t>
+ <t id="226">\033WZasięg Radaru\033X</t>
+ <t id="227">Zignoruj Rasę  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="228">Pokaż</t>
+ <t id="229">\033WRodzaj Ostrzeżeń\033X</t>
+  
+ <t id="230">Wtyczka Ustawień SUA</t>
+ <t id="231">Zastosować ustawienia dla \033Ywszystkich\033X zadokowanych statków</t>
+ <t id="232">Resetowanie Ustawień do Wartości Domyślnych</t>
+ <t id="233">Napisy</t>
+ <t id="234">Dźwięk</t>
+ <t id="235">Wyskakujące Menu</t>
+ <t id="236">Zdebugować dziennik danych wyjściowych  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="237">Zastosować ustawienia tylko dla \033Yaktywnych\033X zadokowanych statków</t>
+
+ <t id="238">\033WOpóźnienie wysłania zadokowanych myśliwców w sekundach\033X</t>
+
+ 
+ <t id="240">Zarządzanie Lotniskowcem</t>
+ <t id="241">Zautomatyzowany Lotniskowiec...</t>
+ <t id="242">Naprawy w hangarach...</t>
+ <t id="243">Zaopatrzenie Statku...</t>
+ <t id="244">Ustawienia Wieżyczek: \033Y%s\033X</t>
+ <t id="245">Ochraniaj Statek</t>
+ <t id="246">Atakuj Wrogów</t>
+ <t id="247">Obrona Przeciwrakietowa</t>
+ <t id="248">\033RMARS:\033X Ofensywny</t>
+ <t id="249">\033RMARS:\033X Defensywny</t>
+ 
+ <t id="201">Włączony</t>
+ <t id="202">Wyłączony</t>
+ <t id="203">Tak</t>
+ <t id="204">Nie</t>
+ <t id="205">Domyślny</t>
+ <t id="206">Automatyczny Wybór</t>
+ <t id="207">Najpierw Silniejsze</t>
+ <t id="208">Najpierw Pobliskie</t>
+ <t id="209">Żadne</t>
+ 
+ <t id="250">Lotniskowiec: \033Y%s\033X [%s]</t>
+ <t id="251">Lokalizacja: \033Y%s\033X</t>
+ <t id="252">Zadokowany: %s/%s - Posiada: %s</t>
+ <t id="260">© Serial Kicked / [\033Y Federacja Anarkis\033X]</t>
+ 
+ <t id="300">Wybierz liczbę statków używaną do obrony celu</t>
+ <t id="301">Ustawienia Celowania</t>
+ <t id="302">Wybierz jakie statki mają atakować wrogie cele</t>
+ <t id="303">Zmusić uszkodzone statki do odwrotu?</t>
+ <t id="304">Wyświetlać wiadomość ostrzegawczą kiedy lotniskowiec jest w niebezpieczeństwie?</t>
+ <t id="305">Ta opcja pozwala Ci ustawić minimalne zagrożenie, które zapoczątkuje wysłanie myśliwców. Aby zrozumieć działanie opcji "Minimalny Poziom Zagrożenia", musisz wiedzieć że należy przypisać wartość dla każdego rodzaju statku. Powinieneś również wiedzieć że lotniskowiec zawsze wyśle myśliwce gdy tylko wykryje obecność M1 lub M2. Roboty bojowe są ignorowane.</t>
+ <t id="306">M5: 1 - M4: 2  - M3: 5 - M8: 10 - M6: 14 - M7: 35\nTL: 15 - TM: 8 - TP/TS: 2\n\n\n\n</t>
+ <t id="307">Minimalny Poziom Zagrożenia</t>
+ <t id="308">Wybierz sumę uzupełnianego paliwa do skoków</t>
+ <t id="309">Czy chcesz włączyć auto skok dla zadokowanych statków?</t>
+ <t id="310">Ustawienie minimalnego zasięgu dla auto skoku</t>
+ <t id="311">Czy chcesz włączyć awaryjny skok dla zadokowanych statków?</t>
+ <t id="312">Ustawienie awaryjnego progu tarcz w procentach</t>
+ <t id="313">Prawdopodobieństwo zastosowania rakiet w procentach</t>
+ <t id="314">Wybór zasięgu radaru w metrach</t>
+ <t id="315">Wybór opóźnienia w sekundach</t>
+ 
+ <t id="400">Mechanik</t>
+ <t id="401">Możesz użyć mechanika do naprawy uszkodzonych myśliwców w stacjonujących na lotniskowcu. Możesz zatrudnić mechanika za odpowiednią sumę w przyjaznych sektorach. Stawka godzinowa nieprzypisanych mechaników wynosi 1000 kredytów na każdego mechanika, lecz jego stawka znacznie wzrasta gdy dokonuje on napraw uszkodzonych myśliwców. Im więcej posiadasz mechaników tym szybciej naprawią i uzbroją twoje myśliwce.\n\nObecnie wydatki nieprzypisanego personelu to : \033Y%s kredytów na na godzinę\033X\nObecnie wydatki przypisanego personelu to: \033Y%s kredytów na na godzinę\033X\n\n\n\n</t>
+ <t id="402">Obecnie posiadasz : \033Y%s\033X Mechaników (wydatki nieprzypisanego personelu: \033Y%s\033X kredytów na na godzinę)</t>
+ <t id="403">Ustawienia</t>
+ <t id="404">Zezwól na reperowanie zadokowanych statków  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="405">Zezwól na reperowanie lotniskowca  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="406">Zarządzanie : \033Y%s Mechaników\033X</t>
+ <t id="407">Zatrudnij nowego mechanika</t>
+ <t id="408">Zwolnij mechanika</t>
+ <t id="409">Uszkodzone statki</t>
+ <t id="410">  [%s] \033Y%s\033X - kadłub: %s/100</t>
+ <t id="411">Zatrudnienie nowego mechanika będzie Cię kosztowało 50.000 kredytów. Czy jesteś tego pewien?</t>
+ <t id="412">Nie posiadasz wystarczającej ilości pieniędzy by móc zatrudnić nowego mechanika.</t>
+ <t id="413">W obecnym sektorze musi znajdować się Stacja Handlowa.</t>
+
+ <t id="420">Zarządzanie Hangarami</t>
+ <t id="421">Wybór statku który będzie używał poleceń ACC</t>
+ <t id="422">Lista Zadokowanych Statków.</t>
+ <t id="423">Główne polecenia</t>
+ <t id="424">Dodaj wszystkie zadokowane statki do bazy macierzystej</t>
+ <t id="425">Zarządzanie</t>
+ <t id="426">Dodaj wszystkie statki</t>
+ <t id="427">Dodaj tylko statki klasy M3 i M4</t>
+ <t id="428">Dodaj tylko statki klasy M3</t>
+ <t id="429">Usuń wszystkie statki</t>
+ <t id="430">  [%s] \033Y%s\033X - %s</t>
+ <t id="431">\033GAktywne\033X</t>
+ <t id="432">\033RNieaktywne\033X</t>
+ <t id="433">\033YW Trakcie Naprawy\033X</t>
+ <t id="434">Zmiana nazewnictwa zadokowanych statków</t>
+ <t id="435">Dodaj tylko aktywne statki do bazy macierzystej</t>
+
+ <t id="440">Zaopatrzenie Statku</t>
+ <t id="441">Możliwość przenoszenia ładunku pomiędzy lotniskowcem i zadokowanymi na nim statkami\n\n\n</t>
+ <t id="442">Działania Standardowe</t>
+ <t id="443">Przenieś towary z lotniskowca do zadokowanych statków</t>
+ <t id="444">Rozładuj towary do ładowni lotniskowca</t>
+ <t id="445">Zaawansowany</t>
+ <t id="446">Zezwala naszemu lotniskowcowi na zakupienie myśliwców w trakcie walk  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="447">Zezwala naszemu lotniskowcowi na podejmowanie napraw w stoczniach  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="448">Zezwala naszemu lotniskowcowi na utrzymywanie zaopatrzenia \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="449">Dzięki tej opcji możesz przenieść towary z zadokowanych statków do ładowni swojego lotniskowca.</t>
+ <t id="450">\033YRozładunek:\033X %s</t>
+ <t id="451">Handel tylko towarami [tylko ogniwa energetyczne]</t>
+ <t id="452">Handel tylko towarami [wliczając ogniwa energetyczne]</t>
+ <t id="453">Rakiety</t>
+ <t id="454">Niczego nie wyposażono</t>
+ <t id="455">\033YZ :\033X %s</t>
+ <t id="456">Aktywować tylko statki</t>
+ <t id="457">Wszystkie zadokowane statki</t>
+ <t id="458">\033YZatwierdź\033X</t>
+ <t id="459">Zatwierdź Działanie</t>
+ 
+ <t id="460">Ignorowane Rasy</t>
+ <t id="461">Zarządzanie</t>
+ <t id="462">Czysta lista</t>
+ <t id="463">Dodaj rasę do listy</t>
+ <t id="464">\033Y%s\033X - Usuń</t>
+ <t id="465">Wybierz rasę do Ignorowanych</t>
+
+ <t id="480">Zmień nazwę statku</t>
+ <t id="481">Typ i Klasa Statku - Numer</t>
+ <t id="482">Nazwa Lotniskowca - Typ Statku - Numer</t>
+ <t id="483">Klasa Rasy - Numer</t>
+ <t id="484">Umożliwia na masowe nazewnictwo zadokowanych statków.</t>
+ <t id="485">Ustawienia</t>
+ <t id="486">Dodaj do wszystkich zadokowanych statków</t>
+ <t id="487">Dodaj do wszystkich aktywnych statków</t>
+ <t id="488">\033YWybrano: \033X%s</t>
+ <t id="489">\033YPrzykład: \033X%s</t>
+
+ 
+ <t id="500">[author][b]Anarkis Carrier Commands[/b][/author] [b]Uwaga:[/b] Twój [b]%s[/b] w sektorze [b]%s[/b] jest w niebezpieczeństwie i moze wymagać twojego zainteresowania.</t>
+ <t id="501">[author][b]Anarkis Carrier Commands[/b][/author] [b]Anulowano:[/b] Nie posiadasz wystarczającej ilości statków w %s dla tego polecenia</t>
+ <t id="502">[author][b]Anarkis Carrier Commands[/b][/author] [b]Anulowano:[/b] Nie posiadasz wystarczającej ilości statków w  %s by móc oczyścić sektor. Wymaganych  jest co najmniej 5 statków.</t>
+ <t id="503">[author][b]Anarkis Carrier Commands[/b][/author] [b]Błąd:[/b] Brak wystarczającej ilości towarów by móc wyposażyć jakikolwiek statek.</t>
+ <t id="504">[author][b]Anarkis Carrier Commands[/b][/author] [b]Wykonano:[/b] %s został wyposażony %s/%s statek w %s %s.</t>
+ <t id="505">[author][b]Anarkis Carrier Commands[/b][/author] [b]Anulowano:[/b] %s - Stacja nie znajduje się w zasięgu %s.</t>
+ <t id="506">\033RAlarm:\033X \033W%s w sektorze %s potrzebuje pomocy !\033X</t>
+ 
+ <t id="520">Ekwipunek Statków</t>
+ <t id="521">\033YTowary\033X</t>
+ <t id="522">&lt; \033Ydodaj nowy towar\033X &gt;</t>
+ <t id="523">\033W%s\033X [ilość: %s]  &lt;\033Usunięto\033X&gt;</t>
+ <t id="524">\033YTryb:\033X %s</t>
+ <t id="525">Taka sama ilość dla wszystkich statków [$ilość = maksymalna suma]</t>
+ <t id="526"> $ilość towaru na każdy statek</t>
+ <t id="527">\033YZprzeznaczenie:\033X %s</t>
+ <t id="528">Zadokowane statki</t>
+ <t id="529">Aktywne statki</t>
+ <t id="530">\033YZatwierdź\033X</t>
+ <t id="531">Zatwierdź czynność</t>
+ <t id="532">Wybierz towar który chcesz przenieść</t>
+ <t id="533">Podaj ilość</t>
+
+ <t id="540">Raport Przeładunku</t>
+ <t id="541">Transferowane Towary</t>
+ <t id="542">\033W%s %s\033X przetransferowane do \033Y%s\033X</t>
+ <t id="543">\033W%s %s\033X rozładowane z \033Y%s\033X</t>
+ 
+ <t id="600">\033RADS:\033X Wyczyść Sektor</t>
+ <t id="601">\033RADS:\033X Zadokuj wszystkie moje statki</t>
+ <t id="602">\033RADS:\033X Atakuj mój cel</t>
+ <t id="603">\033RADS:\033X \033WZarządzanie\033W</t>
+
+ <t id="640">\033RADS:\033X Sprzedaż Towarów</t>
+ <t id="641">Wybrany Towar</t>
+ <t id="642">Szybki Wybór</t>
+ <t id="643">Wyczyść Listę</t>
+ <t id="644">Dodaj wszystkie dostępne towary</t>
+ <t id="645">Rozpoczęcie Transferu</t>
+ <t id="646">&lt; \033Ydodaj nowy towar\033X &gt;</t>
+ <t id="647">Ustawienia</t>
+ <t id="648">Maksymalny Dystans \033R&lt;\033X \033Y%s Sektor\033X \033R&gt;\033X</t>
+ <t id="649">To polecenie umożliwia twojemu lotniskowcowi na sprzedanie towarów do stacji za pomocą zadokowanych na nim statków. Statki nie posiadają możliwości wykrywania zagrożenia, to też ustal zasięg z rozwagą.\n\n\n\n</t>
+ <t id="650">\033W%s\033X - Suma: \033W%s\033X  &lt;\033Yusuń\033X&gt;</t>
+ <t id="651">Wybierz zasięg skoku</t>
+ <t id="652">Wybierz towar do dodania</t>
+ <t id="653">\033R[ADS]\033X \033Y%s\033X sprzedano \033Y%s\033X do \033Y%s\033X</t> 
+ <t id="654">\033R[ADS]\033X Brak stacji skupującej \033Y%s\033X</t> 
+ <t id="655">\033R[ADS]\033X Brak statku z odpowiednią klasą ładowni\033Y%s\033X</t>
+ <t id="656">\033R[ADS]\033X Brak stacji sprzedającej\033Y%s\033X w zasięgu</t> 
+ <t id="657">\033RADS:\033X Zakup Towarów</t>
+ <t id="658">To polecenie umożliwia lotniskowcowi na zakupienie towarów od stacji za pomocą zadokowanych na nim statków. Statki nie posiadają możliwości wykrywania zagrożenia, to też ustal zasięg z rozwagą.\n\n\n\n</t>
+ <t id="659">Wykonać</t>
+ <t id="660">\033W%s\033X - Ilość: \033W%s\033X  &lt;\033Yusunięto\033X&gt;</t>
+ <t id="661">\033R[ADS]\033X \033Y%s\033X kup \033Y%s %s\033X od \033Y%s\033X</t> 
+ <t id="662">Podaj żądaną sumę</t>
+ <t id="663">Dodaj wszystkie typy rakiet</t>
+ 
+
+ <t id="700">\033R[ADS]\033X \033WSkrzydło %s: \033X %s &lt;%s&gt;</t> 
+ <t id="702">\033R[ADS]\033X %s - \033WOdwrót...\033X</t>
+ <t id="703">\033R[ADS]\033X %s</t>
+ <t id="710">\033YLider\033X</t>
+ <t id="711">Skrzydłowy</t>
+ <t id="712">\033GEskorta\033X</t>
+ <t id="713">\033WBrak Celu\033X</t>
+ <t id="714">\033R%s\033X</t>
+ <t id="715">\033B%s\033X</t>
+
+
+ <t id="800">Rapot Zautomatyzowanych Lotniskowców</t>
+ <t id="801">\033WWybrano: \033X %s [%s]</t>
+ <t id="802">\033WRozkazy: \033X %s - \033WZautomatyzowany:\033X %s</t>
+ <t id="803">Selekcja</t>
+ <t id="804">\033Y%s\033X [\033Y%s\033X] - Sektor: \033Y%s\033X</t>
+ <t id="805">\033WLokalizacja: \033X %s [%s]</t>
+ <t id="806">Działania</t>
+ <t id="807">Ustawienia wybranego lotniskowca</t>
+ <t id="808">Dodaj obecne ustawienia do wszystkich lotniskowców</t>
+
+
+ <t id="820">\033GTak\033X</t>
+ <t id="821">\033RNie\033X</t>
+ 
+ <t id="001">** KOMENTARZ ** Tu zaczyna się v2.55</t>
+ 
+ <t id="1000">Menu ustawień ADS</t>
+ <t id="1001">\033YWybrany :\033X %s</t>
+ <t id="1002">Zarządzanie Stacją</t>
+ <t id="1003">Zarządzanie Statkami</t>
+ <t id="1004">\033YMenu\033X</t>
+ <t id="1005">Lista ADS %ss</t>
+ <t id="1006">Ostatnie wydarzenia</t>
+ <t id="1007">\033ROdinstaluj ADS\033X</t>
+ <t id="1008">Zastosuj ustawienia domyślne dla wszystkich %s</t>
+ <t id="1009">\033Y[\033X\033G%s\033X\033Y]\033X \033W%s\033X | auto: \033W%s\033X | ADS myśliwce: \033W%s\033X</t>
+ 
+ <t id="1010">\033RZarządzanie ADS\033X</t>
+ <t id="1011">To menu umożliwia dostęp do wszystkich \033Ykompatybilnych z ADS\033X własności</t>
+ <t id="1012">\033Y[\033X\033G%s\033X\033Y]\033X \033W%s\033X</t>
+ <t id="1013">- \033GIntegralność:\033X Kadłub \033Y%s/100\033X - Osłony \033Y%s/100\033X</t>
+ <t id="1014">- \033GStatus:\033X \033W%s\033X - \033Y%s\033X</t>
+ <t id="1015">- \033GWalka:\033X poziom zagrożenia \033Y%s\033X - zaatakowany \033Y%s\033X - rozmieszczone \033Y%s\033X</t>
+ <t id="1016">- \033GMyśliwce:\033X  posiadane \033Y%s\033X - zadokowane \033Y%s\033X - ADS \033Y%s\033X</t>
+ <t id="1017">\033Y%s Lista\033X</t>
+ <t id="1018">ADS Tryb automatyczny  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1019">Otwórz Menu ustawień ADS dla %s</t>
+
+ <t id="1020">\033Y[\033X\033G%s\033X\033Y]\033X \033G%s\033X | auto: \033W%s\033X | ADS myśliwce: \033W%s\033X</t>
+ <t id="1021">\033Y[\033X\033G%s\033X\033Y]\033X \033Y%s\033X | auto: \033W%s\033X | ADS myśliwce: \033W%s\033X</t>
+ <t id="1022">\033Y[\033X\033G%s\033X\033Y]\033X \033R%s\033X | auto: \033W%s\033X | ADS myśliwce: \033W%s\033X</t>
+
+ <t id="1023">\033G   Skocz do mnie</t>
+ <t id="1024">\033G   Skocz do sektora...\033X</t>
+ <t id="1025">\033G   Atakuj Cel...\033X</t>
+ <t id="1026">Wybierz pozycję</t>
+ <t id="1027">Wybierz Cel</t>
+ <t id="1028">\033G   Patroluj Sektory\033X</t>
+ <t id="1029">\033G   Atakuj Wszystkich\033X</t>
+ <t id="1030">Wybierz to co jest na celowniku i w pobliżu</t>
+ <t id="1031">%s rozmieść myśliwce w %s</t>
+ <t id="1032">\033WSprawozdanie :\033X %s | \033WKlasa :\033X %s\n\033WLokalizacja :\033X %s | \033WPoziom zagrożenia :\033X %s\n\n\033WAkcja :\033X Użyte myśliwce</t>
+ <t id="1033">\033G   Zadokuj w...\033X</t>
+ <t id="1034">\033WPanel Rozkazów\033X  \033Y&lt;\033G+\033X\033Y&gt;\033X</t>
+ <t id="1035">Zobacz statki będące własnością</t>
+ <t id="1036">\033G   Chroń...\033X</t>
+ <t id="1037">\033G   W gotowości\033X</t>
+ <t id="1038">\033WPanel Rozkazów\033X  \033Y&lt;\033G-\033X\033Y&gt;\033X</t>
+ <t id="1039">\033G   %s\033G</t>
+ <t id="1040">\033RADS:\033X \033WZarządzanie\033X</t>
+ <t id="1041">\033W%s\033X  \033G[\033X%s\033G]\033X  \033G[\033X \033Wkadłub\033X %s%% \033G|\033X \033Wosłony\033X %s%% \033G]\033X</t>
+
+ <t id="1042">Latające</t>
+ <t id="1043">Zadokowane</t> 
+ 
+ <t id="001">** KOMENTARZ ** Tu zaczyna się v2.60</t>
+ 
+ <t id="1044">Sieć Obrony</t>
+ <t id="1045">Główne Ustawienia</t>
+ <t id="1046">Zarządzanie Sektorami</t>
+ <t id="1047">Zobacz Statki  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1048">Satelita ADS (%s)</t>
+ <t id="1049">\033YSieć Obrony\033X</t>
+ 
+ <t id="1050">\033YLista Sektorów\033X</t>
+ <t id="1051">[\033G%s,%s\033X] \033W%s\033X | Stacja: \033G%s\033X | Poziom Zagrożenia: \033Y%s\033X</t>
+ <t id="1052">Filtr : %s</t>
+ <t id="1053">Wszystkie Sektory</t>
+ <t id="1054">Sektory chronione przez ADS</t>
+ <t id="1055">Zagrożone Sektory</t>
+
+ <t id="1056">\033YLista Statków\033X</t>
+ <t id="1057">[\033G%s\033X] \033W%s\033X - \033W%s\033X | Sieć Obrony : \033Y%s\033X</t>
+ <t id="1058">Sieć Obrony  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1059">Wykorzystywane przez Sieć Obrony  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ 
+ <t id="1060">[\033G%s\033X] [%s]  \033W%s\033X</t>
+ <t id="1061">\033WPanel Rozkazów\033X</t>
+ <t id="1062">\033GUruchom Skrzydło\033X</t>
+ <t id="1063">Zmień Cel  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1064">Statek główny</t>
+ <t id="1065">\033WRęczny wybór\033X</t>
+ <t id="1066">\033G%s\033X</t>
+ <t id="1067">\033Y%s\033X</t>
+ <t id="1068">\033R%s\033X</t>
+ 
+ <t id="1069">Uruchom</t>
+ <t id="1070">%s%%</t>
+ <t id="1071">Zadokowane</t>
+ <t id="1072">ręcznie</t>
+ <t id="1073">auto</t>
+ <t id="1074">Klasa: %s | Właściciel: %s | Relacje: %s</t>
+ 
+  <t id="001">** COMMENT ** v2.65 Begins Here</t> 
+ 
+ <t id="1075">Centrum Szkolenia Marines</t>
+ <t id="1076">Kwatery załogi</t>
+ <t id="1077">Standard szkolenia</t>
+ <t id="1078">Szkolenie bojowe</t>
+
+ <t id="001">** COMMENT ** Marine Statistics</t> 
+ <t id="1079">  \033Y[\033X Walka: \033W%s\033X - Mechanika: \033W%s\033X - Hacking: \033W%s\033X - Inżynieria: \033W%s\033X\033Y ]\033X</t>
+ 
+ <t id="001">** COMMENT ** Marine Name - Overall Skill</t> 
+ <t id="1080">\033G%s\033X - \033WPoziom:\033X \033G%s\033X</t>
+
+ <t id="1081">Nazwa</t>
+ <t id="1082">Walka</t>
+ <t id="1083">Mechanika</t>
+ <t id="1084">Hacking</t>
+ <t id="1085">Inżynieria</t>
+ <t id="1086">Koszary ...</t>
+ <t id="1087">\033GZapisz i zamknij\033X</t>
+ <t id="1088">\n\033RNaciśnij [Esc] aby zamknąc bez zapisywania\033X</t>
+ 
+ <t id="1089">\033WUstawienia Ogólne\033X</t>
+ <t id="1090">\033YUstawienia domyślne\033X</t>
+ <t id="1091">\033WEdycja ustawień domyślnych Lotniskowca\033W</t>
+ <t id="1092">\033WEdycja ustawień domyślnych Stacji\033W</t>
+ <t id="1093">\033YUstawienia Sieci Obrony\033X</t>
+ <t id="1094">\033WMaksymalny dystans w skokach\033X</t>
+ <t id="1095">\033WMinimalne zagrożenie wywołujące alert\033X</t>
+ <t id="1096">\033WPokaż Wiadomość otrzegawczą\033X</t>
+ <t id="1097">\033YZignoruj frakcję\033X</t>
+ <t id="1098">\033YUstawienia ogólne\033X</t>
+ <t id="1099">\033WSystem dynamicznych zmian nazw\033X</t>
+ <t id="1100">\033RResetuj Wszystkie ustawienia do domyślnych wartości\033X</t>
+ <t id="1101">Automatycznie</t>
+ <t id="1102">Ręcznie</t>
+ <t id="1103">Tylko Handlowcy</t>
+ <t id="1104">Ignoruj</t>
+
+ <t id="1105">\033W- Koszty treningu :\033X \033Y%s\033X \033Wkredytów na godzinę\033X</t>
+ <t id="1106">\033GZastosuj ustawienia\033X</t>
+ <t id="1107">Koszary</t>
+ <t id="1108">\033W- Twoich %s marines trenuje na pokładzie\033X</t>
+ <t id="1109">\033W- Pokój :\033X \033Y%s/%s\033X</t>
+ <t id="1110">Pasażerów</t>
+ <t id="1111">Zniewolić</t>
+ <t id="1112">Trenować</t>
+ <t id="1113">\033RADS:\033X \033Y%s\033X \033Wzostał zaatakowany [Zagrożenie :\033X \033Y%s\033X\033W]\033X</t>
+ <t id="1114">[\033G%s,%s\033X] \033W%s:\033X \033G%s</t>
+ <t id="1115">%s\033X \033W%s\033X [\033Gautomatycznie\033X|\033W%s\033X]</t>
+ <t id="1116">%s\033X \033W%s\033X [\033Wręcznie\033X|\033W%s\033X]</t>
+ <t id="1117">%s\033X \033W%s\033X</t>
+ <t id="1118">\033YCzłonkowie Sieci Obrony\033X</t>
+ <t id="1119">\033YNieprzypisani\033X</t>
+ <t id="1120">%s\033X \033W%s\033X [\033Ybitwa\033X|\033W%s\033X]</t>
+ <t id="1121">[\033G%s,%s\033X] \033W%s:\033X \033Y%s</t>
+ <t id="1122">[\033G%s,%s\033X] \033W%s:\033X %s</t>
+ <t id="1123">\033Y%s\033X  \033G[\033X%s\033G]\033X  \033G[\033X \033Wkadłub\033X %s%% \033G|\033X \033Wosłony\033X %s%% \033G]\033X</t>
+ 
+ </page>
+
+</language>

--- a/tools/fixtures/known_good/ADS/t/8510-L049.xml
+++ b/tools/fixtures/known_good/ADS/t/8510-L049.xml
@@ -1,0 +1,447 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<language id="49">
+
+<page id="2008" title="Script Object Commands" descr="0">
+ <t id="830">ANARKIS_SETDOCKED</t>
+ <t id="831">ANARKIS_SELLWARES</t>
+ <t id="832">ANARKIS_BUYWARES</t>
+ <t id="833">ANARKIS_DEFENSIVEWING</t>
+ <t id="834">ANARKIS_ATTACKWING</t>
+ <t id="835">ANARKIS_CLEANSECTOR</t>
+ <t id="836">ANARKIS_DOCKALL</t>
+ <t id="1231">ANARKIS_SETTACTICS</t>
+ <t id="1232">ANARKIS_AUTOCARRIER</t>
+ <t id="1131">ANARKIS_SETUPSTATION</t>
+ <t id="1132">ANARKIS_STATIONDEFENSE</t>
+</page>
+
+<page id="2010" title="Script Cmd Names" descr="Long version of commandos. These are the commandos assigned to ships using the commandconsole. Page 2010 and 2011 belong together and hold short and long versions of the same commands"> 
+ <t id="830">\033RAVS:\033X Heimatbasissetup</t>
+ <t id="831">\033RAVS:\033X Verkaufe Waren...</t>
+ <t id="832">\033RAVS:\033X Kaufe Waren für Träger...</t>
+ <t id="833">\033RAVS:\033X Sende Verteidigungsgeschwader</t>
+ <t id="834">\033RAVS:\033X Geschwaderangriff auf...</t>
+ <t id="835">\033RAVS:\033X Räume Sektor</t>
+ <t id="836">\033RAVS:\033X Alle Schiffe andocken</t>
+ <t id="1231">\033RAVS:\033X Trägersetup</t>
+ <t id="1232">\033RAVS:\033X Automatisierter Träger</t>
+ <t id="1131">\033RAVS:\033X Verteidigungssystemsetup</t>
+ <t id="1132">\033RAVS:\033X Sektorverteidigung</t>
+</page> 
+
+<page id="2011" title="Script Cmd Shorts" descr="Short version of commandos. These are the commandos assigned to ships using the commandconsole. Page 2010 and 2011 belong together and hold short and long versions of the same commands"> 
+ <t id="830">set.homebase</t>  
+ <t id="831">sell.ware</t>
+ <t id="832">buy.ware</t>
+ <t id="833">defense.wing</t>
+ <t id="834">attack.wing</t>
+ <t id="835">clean.sector</t>
+ <t id="836">dock.ships</t>
+ <t id="1131">set.defense</t>
+ <t id="1132">auto.station</t>
+ <t id="1231">set.tactics</t>
+ <t id="1232">auto.carrier</t>
+</page> 
+
+<page id="2022"> 
+ <t id="830">Erlaubt der ausgewählten Heimatbasis Einstellungen für die angedockten Jäger des Trägers. Schiffe werden umbenannt und Raketeneinstellungen zugewiesen.</t>  
+ <t id="831">Schicke mehrere Schiffe zum verkauf der Waren des Trägers</t>
+ <t id="832">Schicke mehrere Schiffe um eine bestimmte Anzahl an Waren von der nächstgelegenen Fabrik zu kaufen</t>
+ <t id="833">Schickt ein Geschwader um den Träger oder ein anderes Schiff zu verteidigen</t>
+ <t id="834">Schickt ein Geschwader zum Angriff gegen ein Schiff oder eine Fabrik</t>
+ <t id="835">Befreit den Sektor von allen Feinden</t>
+ <t id="836">Alle Schiffe die diese Heimatbasis eingestellt haben werden hier andocken. Weiter entfernte Schiffe die einen Sprungantrieb haben werden versuchen zum Träger zu springen.</t>
+ <t id="1131">Setup von Anarkis Verteidigungsstation auf dieser Station.</t>
+ <t id="1132">Aktiviert einen Verteidigungsmodus für diese Station. Sie wird Schiffe gegen Eindringlinge aussenden und gelandete Schiffe reparieren</t>
+ <t id="1231">Dieser Befehl erlaubt das Setup der gelandeten Schiffe und des Trägers im automatisierten Modus.</t>
+ <t id="1232">Automatisierter Modus. Der Träger wird sich selbst verteidigen und Schiffe bei Bedarf starten.</t>
+</page> 
+
+<page id="8510" title="ACC" descr="Anarkis Command Carrier">
+ <t id="100">\033RAVS:\033X Anarkis Verteidigungssystem</t>
+ <t id="101">265</t>
+ <t id="102">Anarkis Federation</t>
+ <t id="103">[author][b]Anarkis Federation[/b][/author][b]Anarkis Verteidigungssystem[/b] v%s erfolgreich installiert ! </t>
+ <t id="104">[author][b]Anarkis Federation[/b][/author][b]Anarkis Verteidigungssystem[/b] erfolgreich aufgerüstet auf v%s !</t>
+ <t id="105">[author][b]AVS - %s[/b][/author] Sie können diesen Befehl nicht auf ihrem Spielerschiff benutzen.</t>
+ <t id="106">[author][b]Anarkis Federation[/b][/author][b]Anarkis Verteidigungssystem[/b] wurde entfernt.\nBitte speichern Sie nun ihr Spiel, beenden es und führen die Datei 'uninstall avs.bat' im X3 Verzeichnis aus.</t>
+ 
+ <t id="200">Anarkis Trägermenü</t>
+
+ <t id="210">Allgemein</t>
+ <t id="211">Hangars ...</t>
+ <t id="212">Trägerübersicht</t>
+ <t id="213">Raketennutzung  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="214">Notsprung  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X - Schildlimit  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="215">Autosprung  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X - Minimale Reichweite  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="216">Treibstoffversorgungsmenge \(in Sprüngen\)  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="217">Setup der angedockten Schiffe</t>
+
+ <t id="220">Setup für automatisierten Träger</t>
+ <t id="221">\033WMinimale Gefahrenstufe\033X</t>
+ <t id="222">\033WWarnmitteilungen anzeigen\033X</t>
+ <t id="223">\033WBeschädigte Schiffe zum\033X</t>
+ <t id="224">\033WAngriffsmodus\033X</t>
+ <t id="225">\033WSchiffsanzahl für Verteidigung\033X</t>
+ <t id="226">\033WRadar Reichweite\033X</t>
+ <t id="227">Fraktionen ignorieren  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="228">Benachrichtigungen</t>
+ <t id="229">\033WWarnungsart\033X</t>
+  
+ <t id="230">AVS Plugin Einstellungen</t>
+ <t id="231">Einstellungen auf \033Yalle\033X angedockten Schiffe anwenden</t>
+ <t id="232">Eistellungen auf Standardwerte zurücksetzen</t>
+ <t id="233">Untertitel</t>
+ <t id="234">Audio</t>
+ <t id="235">Popup</t>
+ <t id="236">Debug Logfile Output  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="237">Einstellungen nur auf alle \033Yaktiven\033X angedockten Schiffe anwenden</t>
+ <t id="238">Verzögerung bevor eingesetzte Jäger andocken sollen \033R&lt;\033X \033Y%s sek\033X \033R&gt;\033X</t>
+ 
+ <t id="240">Trägermanagement</t>
+ <t id="241">Automatisierter Träger ...</t>
+ <t id="242">Reparaturbuchten ...</t>
+ <t id="243">Schiffsversorgung ...</t>
+ <t id="244">Turmeinstellungen : \033Y%s\033X</t>
+ <t id="245">Verteidige Schiff</t>
+ <t id="246">Feinde angreifen</t>
+ <t id="247">Raketenverteidigung</t>
+ <t id="248">\033RMARS:\033X Offensiv</t>
+ <t id="249">\033RMARS:\033X Defensiv</t>
+ 
+ <t id="201">Aktiviert</t>
+ <t id="202">Deaktiviert</t>
+ <t id="203">Ja</t>
+ <t id="204">Nein</t>
+ <t id="205">Standard</t>
+ <t id="206">Automatische Auswahl</t>
+ <t id="207">Stärkster zuerst</t>
+ <t id="208">Nächster zuerst</t>
+ <t id="209">Kein</t>
+ 
+ <t id="250">Träger : \033Y%s\033X [%s]</t>
+ <t id="251">Standort : \033Y%s\033X</t>
+ <t id="252">Angedockt : %s/%s - Besitzer : %s</t>
+ <t id="260">© Serial Kicked / [\033YAnarkis Federation\033X]</t>
+ 
+ <t id="300">Wähle die Anzahl an Schiffen die für Verteidigungszwecke genutzt werden sollen</t>
+ <t id="301">Zielauswahlsetup</t>
+ <t id="302">Wähle aus wie angreifende Schiffe gegnerische Schiffe auswählen sollen</t>
+ <t id="303">Beschädigte Schiffe zurückziehen ?</t>
+ <t id="304">Eine Warnmitteilung anzeigen wenn der Träger in Gefahr ist ?</t>
+ <t id="305">Dieses Menü erlaubt die Auswahl was die minimale Gefahrenstufe ist welche den start der Jäger auslöst. Um zu verstehen wie dieses Stufensystem arbeitet musst du die "Gefahrenwerte" wissen die jeder Art von Schiff zugeordnet ist und du solltest auch wissen das der Träger immer Schiffe aussenden wird wenn ein gegnerischer M1/M2 gesichtet wurde. Kampfdrohnen werden ignoriert.</t>
+ <t id="306">M5: 1 - M4: 2  - M3: 5 - M8: 10 - M6: 14 - M7: 35\nTL: 15 - TM: 8 - TP/TS: 2\n\n\n\n</t>
+ <t id="307">Minimale Gefahrenstufe</t>
+ <t id="308">Wähle die Treibstoffversorgungsmenge in Sprüngen</t>
+ <t id="309">Soll das Autosprung-Feature bei allen angedockten Schiffen aktiviert werden ?</t>
+ <t id="310">Lege die minimale Distanz für den Autosprung fest</t>
+ <t id="311">Soll das Notsprung-Feature bei allen angedockten Schiffen aktiviert werden ?</t>
+ <t id="312">Lege den Schwellenwert der Schilde in Prozent für den Notsprung fest</t>
+ <t id="313">Lege die Raketennutzung in Prozent fest</t>
+ <t id="314">Wähle eine neue Radarreichweite in Metern aus</t>
+ <t id="315">Lege eine neue Landeverzögerung in Sekunden fest</t>
+ 
+ <t id="400">Mechaniker</t>
+ <t id="401">Man kann Mechaniker einstellen um beschädigte Jäger zu reparieren. In jedem freundlichen Sektor kann man Mechaniker für Geld anheuern. Außer Dienst kostet ein Mechaniker etwa 1000 Credits pro Stunde und mehr wenn sie ein Schiff reparieren. Je mehr Mechaniker man hat desto schneller laufen die Reparaturen.\n\nDerzeitige Kosten außer Dienst : \033Y%s Credits pro Stunde\033X\nDerzeitge Kosten bei Reparaturen : \033Y%s Credits pro Stunde\033X\n\n\n\n</t>
+ <t id="402">Du hast derzeit : \033Y%s\033X Mechaniker (Kosten außer Dienst : \033Y%s\033X Credits pro Stunde)</t>
+ <t id="403">Einstellungen</t>
+ <t id="404">Angedockte Schiffe reparieren lassen  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="405">Den Träger reparieren lassen  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="406">Management : \033Y%s Mechaniker\033X</t>
+ <t id="407">Neue Mechaniker einstellen</t>
+ <t id="408">Mechaniker entlassen</t>
+ <t id="409">Beschädigte Schiffe</t>
+ <t id="410">  [%s] \033Y%s\033X - Hülle : %s/100</t>
+ <t id="411">Das anheuern eines neuen Mechanikers kostet 50.0000 Credits. Sind sie sicher ?</t>
+ <t id="412">Du hast nicht genug Geld um einen neuen Mechaniker einzustellen.</t>
+ <t id="413">Du benötigst eine freundliche Handelsstation im aktuellen Sektor des Trägers.</t>
+
+ <t id="420">Hangarmanagement</t>
+ <t id="421">Wähle die Schiffe aus die von AVS Befehlen genutzt werden sollen</t>
+ <t id="422">Liste der angedockten Schiffe</t>
+ <t id="423">Allgemeine Befehle</t>
+ <t id="424">Weise allen angedockten Schiffen die Heimatbasis zu</t>
+ <t id="425">Management</t>
+ <t id="426">Alle Schiffe hinzufügen</t>
+ <t id="427">Nur M3 und M4 Schiffe hinzufügen</t>
+ <t id="428">Nur M3 Schiffe hinzufügen</t>
+ <t id="429">Alle Schiffe entfernen</t>
+ <t id="430">  [%s] \033Y%s\033X - %s</t>
+ <t id="431">\033GAktiv\033X</t>
+ <t id="432">\033RInaktiv\033X</t>
+ <t id="433">\033YWird repariert\033X</t>
+ <t id="434">Angedockte Schiffe umbenennen</t>
+ <t id="435">Heimatbasis nur den aktiven Schiffen zuweisen</t>
+
+ <t id="440">Schiffsversorgung</t>
+ <t id="441">Hier kann nun Fracht zwischen dem Träger und dessen angedockten Schiffen bewegt werden\n\n\n</t>
+ <t id="442">Standardaktionen</t>
+ <t id="443">Bewege Fracht vom Träger zu den angedockten Schiffen</t>
+ <t id="444">Entlade Fracht in den Träger</t>
+ <t id="445">Erweitert</t>
+ <t id="446">Erlaube dem Träger zerstörte Jäger nachzukaufen  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="447">Erlaube dem Träger sich in der Schiffswerft zu reparieren  \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="448">Erlaube dem Träger die Schiffe automatisch zu versorgen \033R&lt;\033X \033Y%s\033X \033R&gt;\033X</t>
+ <t id="449">Dieses Menü erlaubt das bewegen von Waren von angedockten Schiffen zum Träger.\n\n</t>
+ <t id="450">\033YEntlade :\033X %s</t>
+ <t id="451">Nur Handelswaren [ausgenommen Energiezellen]</t>
+ <t id="452">Nur Handelswaren [inklusive Energiezellen]</t>
+ <t id="453">Raketen</t>
+ <t id="454">Alles nicht ausgerüstet</t>
+ <t id="455">\033YVon :\033X %s</t>
+ <t id="456">Nur aktive Schiffe</t>
+ <t id="457">Alle angedockten Schiffe</t>
+ <t id="458">\033YÜberprüfen\033X</t>
+ <t id="459">Aktion ausführen</t>
+ 
+ <t id="460">Ignorierte Fraktionen</t>
+ <t id="461">Manage</t>
+ <t id="462">Liste löschen</t>
+ <t id="463">Eine Fraktion zur Liste hinzufügen</t>
+ <t id="464">\033Y%s\033X - entfernen</t>
+ <t id="465">Wähle eine zu ignorierende Fraktion</t>
+
+ <t id="480">Schiffe umbenennen</t>
+ <t id="481">Shiffstyp Klasse - Nummer</t>
+ <t id="482">Trägername - Schiffstyp - Nummer</t>
+ <t id="483">Erbauerrasse Klasse - Nummer</t>
+ <t id="484">Erlaubt das umbenennen aller angedockten Schiffe auf einmal.</t>
+ <t id="485">Setup</t>
+ <t id="486">Allen angedockten Schiffen zuweisen</t>
+ <t id="487">Allen aktiven Schiffen zuweisen</t>
+ <t id="488">\033YAusgewählt : \033X%s</t>
+ <t id="489">\033YBeispiel : \033X%s</t>
+
+ 
+ <t id="500">[author][b]Anarkis Trägerkommandos[/b][/author] [b]Warnung:[/b] Ihr [b]%s[/b] im Sektor [b]%s[/b] ist in Gefahr und benötigt ihre Aufmerksamkeit.</t>
+ <t id="501">[author][b]Anarkis Trägerkommandos[/b][/author] [b]Abgebrochen:[/b] Für diesen Befehl haben Sie nicht genug Schiffe in %s</t>
+ <t id="502">[author][b]Anarkis Trägerkommandos[/b][/author] [b]Abgebrochen:[/b] Zum räumen des Sektors haben Sie nicht genug Schiffe in %s. Mindestens 5 werden benötigt.</t>
+ <t id="503">[author][b]Anarkis Trägerkommandos[/b][/author] [b]Fehler:[/b] Nicht genügend Waren im Frachtraum um ein Schiff auszurüsten.</t>
+ <t id="504">[author][b]Anarkis Trägerkommandos[/b][/author] [b]Erfolgreich:[/b] %s hat %s/%s Schiffe mit %s %s ausgerüstet.</t>
+ <t id="505">[author][b]Anarkis Trägerkommandos[/b][/author] [b]Abgebrochen:[/b] %s - Keine Station in Reichweite hat genügend %s.</t>
+ <t id="506">\033RALARM:\033X \033W%s im Sektor %s benötigt Hilfe !\033X</t>
+ 
+ <t id="520">Schiffe ausrüsten</t>
+ <t id="521">\033YWaren\033X</t>
+ <t id="522">&lt; \033Yneue Ware hinzufügen\033X &gt;</t>
+ <t id="523">\033W%s\033X [Menge: %s]  &lt;\033Rentfernen\033X&gt;</t>
+ <t id="524">\033YModus :\033X %s</t>
+ <t id="525">Identische Warenmenge zu allen Schiffen</t>
+ <t id="526">Festgelegte Warenmenge auf jedes Schiff</t>
+ <t id="527">\033YZiel :\033X %s</t>
+ <t id="528">Angedockten Schiffe</t>
+ <t id="529">Aktive Schiffe</t>
+ <t id="530">\033YÜberprüfen\033X</t>
+ <t id="531">Aktion ausführen</t>
+ <t id="532">Wähle die Ware aus die bewegt werden soll</t>
+ <t id="533">Wähle die Menge</t>
+
+ <t id="540">Transferbericht</t>
+ <t id="541">Waren transferiert</t>
+ <t id="542">\033W%s %s\033X transferiert zu \033Y%s\033X</t>
+ <t id="543">\033W%s %s\033X entladen von \033Y%s\033X</t>
+ 
+ <t id="600">\033RAVS:\033X Räume Sektor</t>
+ <t id="601">\033RAVS:\033X Alle meine Schiffe andocken</t>
+ <t id="602">\033RAVS:\033X Mein Ziel angreifen</t>
+ <t id="603">\033RADS\033X \033WManager\033W</t>
+
+ <t id="640">\033RAVS:\033X Verkaufe Waren</t>
+ <t id="641">Ausgewählte Waren</t>
+ <t id="642">Schnellauswahl</t>
+ <t id="643">Liste löschen</t>
+ <t id="644">Füge alle Handelswaren hinzu</t>
+ <t id="645">Beginne Transfer</t>
+ <t id="646">&lt; \033Yfüge neue Ware hinzu\033X &gt;</t>
+ <t id="647">Einstellungen</t>
+ <t id="648">Maximale Entfernung \033R&lt;\033X \033Y%s Sektoren\033X \033R&gt;\033X</t>
+ <t id="649">Dieser Befehl erlaubt es dem Träger seine Waren mit Hilfe der angedockten Schiffe an umliegende Stationen zu verkaufen. Es gibt keine Überprüfung auf gegnerische Sektoren daher wähle die Entfernung vorsichtig.\n\n\n\n</t>
+ <t id="650">\033W%s\033X - Anzahl: \033W%s\033X  &lt;\033Yentfernen\033X&gt;</t>
+ <t id="651">Wähle die neue Sprungreichweite</t>
+ <t id="652">Wähle eine Ware die hinzugefügt werden soll</t>
+ <t id="653">\033R[AVS]\033X \033Y%s\033X verkauft \033Y%s\033X an \033Y%s\033X</t> 
+ <t id="654">\033R[AVS]\033X Keine Station kauft \033Y%s\033X</t> 
+ <t id="655">\033R[AVS]\033X Kein Schiff fähig \033Y%s\033X zu transportieren</t>
+ <t id="656">\033R[AVS]\033X Keine Station in Reichweite verkauft \033Y%s\033X</t> 
+ <t id="657">\033RAVS:\033X Kaufe Waren</t>
+ <t id="658">Dieser Befehl erlaubt es dem Träger mit Hilfe der angedockten Schiffe Waren von umliegenden Stationen zu kaufen. Es gibt keine Überprüfung auf gegnerische Sektoren daher wähle die Entfernung vorsichtig.\n\n\n\n</t>
+ <t id="659">fortfahren</t>
+ <t id="660">\033W%s\033X - Menge: \033W%s\033X  &lt;\033Yentfernen\033X&gt;</t>
+ <t id="661">\033R[AVS]\033X \033Y%s\033X kaufe \033Y%s %s\033X bei \033Y%s\033X</t> 
+ <t id="662">Wähle die gewünschte Menge</t>
+ <t id="663">Füge alle Raketenarten hinzu</t>
+ 
+ <t id="700">\033R[AVS]\033X \033WGeschwader %s: \033X %s &lt;%s&gt;</t> 
+ <t id="702">\033R[AVS]\033X %s - \033WRückzug...\033X</t>
+ <t id="703">\033R[AVS]\033X %s</t>
+ <t id="710">\033YGeschwaderführer\033X</t>
+ <t id="711">Flügelmann</t>
+ <t id="712">\033GEskorte\033X</t>
+ <t id="713">\033WKein Ziel\033X</t>
+ <t id="714">\033R%s\033X</t>
+ <t id="715">\033B%s\033X</t>
+ 
+ <t id="800">Trägerübersicht</t>
+ <t id="801">\033WAusgewählt : \033X %s [%s]</t>
+ <t id="802">\033WBefehle : \033X %s - \033WAutomatisiert :\033X %s</t>
+ <t id="803">Auswahl</t>
+ <t id="804">\033Y%s\033X [\033Y%s\033X] - Sektor : \033Y%s\033X</t>
+ <t id="805">\033WStandort : \033X %s [%s]</t>
+ <t id="806">Aktionen</t>
+ <t id="807">Einstellen des ausgewählten Trägers</t>
+ <t id="808">Aktuelle Einstellungen auf alle Träger anwenden</t>
+
+ <t id="820">\033GJa\033X</t>
+ <t id="821">\033RNein\033X</t>
+
+<t id="001">** COMMENT ** v2.55 Begins Here</t>
+ 
+ <t id="1000">ADS Setup Menu</t>
+ <t id="1001">\033YSelected :\033X %s</t>
+ <t id="1002">Manage Stations</t>
+ <t id="1003">Manage Carriers</t>
+ <t id="1004">\033YMenu\033X</t>
+ <t id="1005">List ADS %ss</t>
+ <t id="1006">Recent Events</t>
+ <t id="1007">\033RUninstall ADS\033X</t>
+ <t id="1008">Apply default settings to all %ss</t>
+ <t id="1009">\033Y[\033X\033G%s\033X\033Y]\033X \033W%s\033X | auto: \033W%s\033X | Ships: \033W%s\033X</t>
+ 
+ <t id="1010">\033RADS Manager\033X</t>
+ <t id="1011">This menu gives you access to all \033YADS compatible\033X assets</t>
+ <t id="1012">\033Y[\033X\033G%s\033X\033Y]\033X \033W%s\033X</t>
+ <t id="1013">- \033GIntegrity:\033X Hull \033Y%s/100\033X - Shields \033Y%s/100\033X</t>
+ <t id="1014">- \033GStatus:\033X \033W%s\033X - \033Y%s\033X</t>
+ <t id="1015">- \033GCombat:\033X threat level \033Y%s\033X - attacked \033Y%s\033X - deployed \033Y%s\033X</t>
+ <t id="1016">- \033GFighters:\033X  owned \033Y%s\033X - docked \033Y%s\033X - ADS \033Y%s\033X</t>
+ <t id="1017">\033Y%s List\033X</t>
+ <t id="1018">ADS Automated Mode  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1019">Open ADS %s setup menu</t>
+
+ <t id="1020">\033Y[\033X\033G%s\033X\033Y]\033X \033G%s\033X | auto: \033W%s\033X | Ships: \033W%s\033X</t>
+ <t id="1021">\033Y[\033X\033G%s\033X\033Y]\033X \033Y%s\033X | auto: \033W%s\033X | Ships: \033W%s\033X</t>
+ <t id="1022">\033Y[\033X\033G%s\033X\033Y]\033X \033R%s\033X | auto: \033W%s\033X | Ships: \033W%s\033X</t>
+ <t id="1023">\033G   Jump to Me</t>
+ <t id="1024">\033G   Jump to Sector ...\033X</t>
+ <t id="1025">\033G   Attack Target ...\033X</t>
+ <t id="1026">Select Destination</t>
+ <t id="1027">Select Target</t>
+ <t id="1028">\033G   Patrol Sectors\033X</t>
+ <t id="1029">\033G   Attack All\033X</t>
+
+ <t id="1030">Select in crosshair and close</t>
+ <t id="1031">%s deployed fighters in %s</t>
+ <t id="1032">\033WReport From :\033X %s | \033WClass :\033X %s\n\033WLocation :\033X %s | \033WThreat Level :\033X %s\n\n\033WAction :\033X Fighters Launched</t>
+ <t id="1033">\033G   Dock at ...\033X</t>
+ <t id="1034">\033WCommand Panel\033X  \033Y&lt;\033G+\033X\033Y&gt;\033X</t>
+ <t id="1035">View owned ships</t>
+ <t id="1036">\033G   Protect ...\033X</t>
+ <t id="1037">\033G   Standby\033X</t>
+ <t id="1038">\033WCommand Panel\033X  \033Y&lt;\033G-\033X\033Y&gt;\033X</t>
+ <t id="1039">\033G   %s\033G</t>
+ 
+ <t id="1040">\033RADS:\033X \033WManager\033X</t>
+ <t id="1041">\033W%s\033X  \033G[\033X%s\033G]\033X  \033G[\033X \033Whull\033X %s%% \033G|\033X \033Wshield\033X %s%% \033G]\033X</t>
+ <t id="1042">Flying</t>
+ <t id="1043">Docked</t>
+ 
+<t id="001">** COMMENT ** v2.60 Begins Here</t>
+ 
+ <t id="1044">Defense Grid</t>
+ <t id="1045">General Settings</t>
+ <t id="1046">Manage Sectors</t>
+ <t id="1047">View Ships  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1048">ADS Satellite (%s)</t>
+ <t id="1049">\033YDefense Grid\033X</t>
+ 
+ <t id="1050">\033YSector List\033X</t>
+ <t id="1051">[\033G%s,%s\033X] \033W%s\033X | Stations: \033G%s\033X | Threat Level: \033Y%s\033X</t>
+ <t id="1052">Filter : %s</t>
+ <t id="1053">All Sectors</t>
+ <t id="1054">Sectors protected by ADS</t>
+ <t id="1055">Threatened sectors</t>
+ <t id="1056">\033YShip List\033X</t>
+ <t id="1057">[\033G%s\033X] \033W%s\033X - \033W%s\033X | Defense Grid : \033Y%s\033X</t>
+ <t id="1058">Defense Grid  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1059">Used by the Defense Grid  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ 
+ <t id="1060">[\033G%s\033X] [%s]  \033W%s\033X</t>
+ <t id="1061">\033WCommand Panel\033X</t>
+ <t id="1062">\033GLaunch Wing\033X</t>
+ <t id="1063">Change Target  \033Y&lt;\033X \033W%s\033X \033Y&gt;\033X</t>
+ <t id="1064">Ship Count</t>
+ <t id="1065">\033WManual Selection\033X</t>
+ <t id="1066">\033G%s\033X</t>
+ <t id="1067">\033Y%s\033X</t>
+ <t id="1068">\033R%s\033X</t> 
+ <t id="1069">Launch</t>
+ 
+ <t id="1070">%s%%</t>
+ <t id="1071">Stay Docked</t>
+ <t id="1072">manual</t>
+ <t id="1073">auto</t>
+ <t id="1074">Class: %s | Owner: %s | Relation: %s</t>
+
+ <t id="001">** COMMENT ** v2.65 Begins Here</t> 
+ 
+ <t id="1075">Marine Training Center</t>
+ <t id="1076">Crew Quarters</t>
+ <t id="1077">Standard Training</t>
+ <t id="1078">Combat Training</t>
+
+<t id="001">** COMMENT ** Marine Statistics</t> 
+ <t id="1079">  \033Y[\033X Fight: \033W%s\033X - Mech: \033W%s\033X - Hack: \033W%s\033X - Engineer: \033W%s\033X\033Y ]\033X</t>
+ 
+ <t id="001">** COMMENT ** Marine Name - Overall Skill</t> 
+ <t id="1080">\033G%s\033X - \033WOverall:\033X \033G%s\033X</t>
+
+<t id="1081">Name</t>
+ <t id="1082">Fightskill</t>
+ <t id="1083">Mechanical</t>
+ <t id="1084">Hacking</t>
+ <t id="1085">Engineering</t>
+ <t id="1086">Barracks ...</t>
+ <t id="1087">\033GSave and close\033X</t>
+ <t id="1088">\n\033RPress [Esc] to close without saving\033X</t>
+ 
+ <t id="1089">\033WGeneral Settings\033X</t>
+ <t id="1090">\033YDefault Setup\033X</t>
+ <t id="1091">\033WEdit Default Carrier Setup\033W</t>
+ <t id="1092">\033WEdit Default Station Setup\033W</t>
+ <t id="1093">\033YDefense Grid Settings\033X</t>
+ <t id="1094">\033WMaximum Jump Distance\033X</t>
+ <t id="1095">\033WMinimum Threat to trigger an alert\033X</t>
+ <t id="1096">\033WDisplay Warning Message\033X</t>
+ <t id="1097">\033YIgnore Factions\033X</t>
+ <t id="1098">\033YGeneral Settings\033X</t>
+ <t id="1099">\033WDynamic Renaming System\033X</t>
+ <t id="1100">\033RReset All Settings to default values\033X</t>
+ <t id="1101">Auto</t>
+ <t id="1102">Manual</t>
+ <t id="1103">Trade Only</t>
+ <t id="1104">Ignore</t>
+
+<t id="1105">\033W- Training Cost :\033X \033Y%s\033X \033Wcredits per hour\033X</t>
+<t id="1106">\033GApply Settings\033X</t>
+<t id="1107">Barracks</t>
+<t id="1108">\033W- There is %s marines training onboard\033X</t>
+<t id="1109">\033W- Room :\033X \033Y%s/%s\033X</t>
+<t id="1110">Passengers</t>
+<t id="1111">Enslave</t>
+<t id="1112">Train</t>
+<t id="1113">\033RADS:\033X \033Y%s\033X \033Wis under attack [threat :\033X \033Y%s\033X\033W]\033X</t>
+<t id="1114">[\033G%s,%s\033X] \033W%s:\033X \033G%s</t>
+<t id="1115">%s\033X \033W%s\033X [\033Gauto\033X|\033W%s\033X]</t>
+<t id="1116">%s\033X \033W%s\033X [\033Wmanual\033X|\033W%s\033X]</t>
+<t id="1117">%s\033X \033W%s\033X</t>
+<t id="1118">\033YGrid Members\033X</t>
+<t id="1119">\033YUnassigned\033X</t>
+<t id="1120">%s\033X \033W%s\033X [\033Ybattle\033X|\033W%s\033X]</t>
+<t id="1121">[\033G%s,%s\033X] \033W%s:\033X \033Y%s</t>
+<t id="1122">[\033G%s,%s\033X] \033W%s:\033X %s</t>
+<t id="1123">\033Y%s\033X  \033G[\033X%s\033G]\033X  \033G[\033X \033Whull\033X %s%% \033G|\033X \033Wshield\033X %s%% \033G]\033X</t>
+
+</page>
+
+</language>
+

--- a/tools/fixtures/known_good/ADS/t/8511-L033.xml
+++ b/tools/fixtures/known_good/ADS/t/8511-L033.xml
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<language id="33">
+
+<page id="8511" title="ECS" descr="Extended Communication System">
+ <t id="100">\033RECS:\033X \033WExtended Communication System\033X</t>
+ <t id="101">250</t>
+ <t id="102">Anarkis Federation</t>
+ <t id="103">\033RECS:\033X Extended Comm. System</t>
+ <t id="104">© Serial Kicked / [\033YAnarkis Federation\033X]</t>
+
+<t id="200">\033WECS 2.5 Manager\033X</t>
+<t id="201">Le système de communication étendu est actuellement %s</t>
+<t id="202">Plugins ECS installés</t>
+<t id="203">\033W%s\033X  &lt; %s &gt;</t>
+<t id="204">Sélection : \033W%s\033X</t>
+<t id="205">Configuration du plugin sélectionné</t>
+<t id="206">Désactiver le plugin</t>
+<t id="207">Script appelé : \033W%s\033X</t>
+<t id="208">Variable locale : \033W%s\033X</t>
+<t id="209">Race : \033W%s\033X</t>
+<t id="210">Classe : \033W%s\033X</t>
+<t id="211">Configuration ECS</t>
+<t id="212">Supprimer le raccourci et la configuration de ECS</t>
+<t id="213">Fermer cette fenetre</t>
+<t id="214">[author][b]Anarkis Federation[/b][/author] [b]ECS[/b] a été désactivé avec succés.</t>
+<t id="215">News System : \033W%s\033X</t>
+<t id="216">[%s] - \033W%s\033X</t>
+<t id="217">De: \033W%s\033X</t>
+<t id="218">%s \n\n- Publié il y a %s.\n\n\n\n</t>
+<t id="219">Fermer</t>
+<t id="220">\033W%s\033X\n\n</t>
+<t id="221">Dernières Info</t>
+<t id="222">Rien à afficher</t>
+<t id="223">\nVeuillez sélectionner un message\n\n\n</t>
+<t id="224">Choix</t>
+<t id="225">%s \n\n   - De: \033W%s\033X\n\n\n\n</t>
+<t id="226">Newsfeed Count : \033W%s\033X</t>
+<t id="227">Newsfeed Name : \033W%s\033X</t>
+
+<t id="300">\033GActif\033X</t>
+<t id="301">\033RDésactivé\033X</t>
+<t id="302">\033RIntrouvable\033X</t>
+<t id="303">\033GDétecté\033X</t>
+
+</page>
+
+</language>
+

--- a/tools/fixtures/known_good/ADS/t/8511-L039.xml
+++ b/tools/fixtures/known_good/ADS/t/8511-L039.xml
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<language id="39">
+
+<page id="8511" title="ECS" descr="Extended Communication System">
+ <t id="100">\033RECS:\033X \033WExtended Communication System\033X</t>
+ <t id="101">250</t>
+ <t id="102">Anarkis Federation</t>
+ <t id="103">\033RECS:\033X Extended Comm. System</t>
+ <t id="104">© Serial Kicked / [\033YAnarkis Federation\033X]</t>
+
+<t id="200">\033WECS 2.5 Manager\033X</t>
+<t id="201">The Extended Communication System is now %s</t>
+<t id="202">ECS Installed Plugins</t>
+<t id="203">\033W%s\033X  &lt; %s &gt;</t>
+<t id="204">Selected : \033W%s\033X</t>
+<t id="205">Selected Plugin Setup</t>
+<t id="206">Unregister Plugin</t>
+<t id="207">Script called : \033W%s\033X</t>
+<t id="208">Local variable : \033W%s\033X</t>
+<t id="209">Race : \033W%s\033X</t>
+<t id="210">Class : \033W%s\033X</t>
+<t id="211">ECS Setup</t>
+<t id="212">Remove ECS hotkey and config</t>
+<t id="213">Close this window</t>
+<t id="214">[author][b]Anarkis Federation[/b][/author] [b]ECS[/b] has been uninstalled succesfully.</t>
+<t id="215">News System : \033W%s\033X</t>
+<t id="216">[%s] - \033W%s\033X</t>
+<t id="217">From: \033W%s\033X</t>
+<t id="218">%s \n\n- Published %s ago.\n\n\n\n</t>
+<t id="219">Close</t>
+<t id="220">\033W%s\033X\n\n</t>
+<t id="221">Latest News</t>
+<t id="222">Nothing to display</t>
+<t id="223">\nPlease, select a message\n\n\n</t>
+<t id="224">Select</t>
+<t id="225">%s \n\n   -From: \033W%s\033X\n\n\n\n</t>
+<t id="226">Newsfeed Count : \033W%s\033X</t>
+<t id="227">Newsfeed Name : \033W%s\033X</t>
+
+<t id="300">\033GEnabled\033X</t>
+<t id="301">\033RDisabled\033X</t>
+<t id="302">\033RNot Found\033X</t>
+<t id="303">\033GDetected\033X</t>
+
+</page>
+
+</language>
+

--- a/tools/fixtures/known_good/ADS/t/8511-L044.xml
+++ b/tools/fixtures/known_good/ADS/t/8511-L044.xml
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<language id="44">
+
+<page id="8511" title="ECS" descr="Extended Communication System">
+ <t id="100">\033RECS:\033X \033WExtended Communication System\033X</t>
+ <t id="101">250</t>
+ <t id="102">Anarkis Federation</t>
+ <t id="103">\033RECS:\033X Extended Comm. System</t>
+ <t id="104">© Serial Kicked / [\033YAnarkis Federation\033X]</t>
+
+<t id="200">\033WECS 2.5 Manager\033X</t>
+<t id="201">The Extended Communication System is now %s</t>
+<t id="202">ECS Installed Plugins</t>
+<t id="203">\033W%s\033X  &lt; %s &gt;</t>
+<t id="204">Selected : \033W%s\033X</t>
+<t id="205">Selected Plugin Setup</t>
+<t id="206">Unregister Plugin</t>
+<t id="207">Script called : \033W%s\033X</t>
+<t id="208">Local variable : \033W%s\033X</t>
+<t id="209">Race : \033W%s\033X</t>
+<t id="210">Class : \033W%s\033X</t>
+<t id="211">ECS Setup</t>
+<t id="212">Remove ECS hotkey and config</t>
+<t id="213">Close this window</t>
+<t id="214">[author][b]Anarkis Federation[/b][/author] [b]ECS[/b] has been uninstalled succesfully.</t>
+<t id="215">News System : \033W%s\033X</t>
+<t id="216">[%s] - \033W%s\033X</t>
+<t id="217">From: \033W%s\033X</t>
+<t id="218">%s \n\n- Published %s ago.\n\n\n\n</t>
+<t id="219">Close</t>
+<t id="220">\033W%s\033X\n\n</t>
+<t id="221">Latest News</t>
+<t id="222">Nothing to display</t>
+<t id="223">\nPlease, select a message\n\n\n</t>
+<t id="224">Select</t>
+<t id="225">%s \n\n   -From: \033W%s\033X\n\n\n\n</t>
+<t id="226">Newsfeed Count : \033W%s\033X</t>
+<t id="227">Newsfeed Name : \033W%s\033X</t>
+
+<t id="300">\033GEnabled\033X</t>
+<t id="301">\033RDisabled\033X</t>
+<t id="302">\033RNot Found\033X</t>
+<t id="303">\033GDetected\033X</t>
+
+</page>
+
+</language>
+

--- a/tools/fixtures/known_good/ADS/t/8511-L048.xml
+++ b/tools/fixtures/known_good/ADS/t/8511-L048.xml
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<language id="48">
+
+<page id="8511" title="ECS" descr="Extended Communication System">
+ <t id="100">\033RECS:\033X \033WRozszerzony System Komunikacyjny\033X</t>
+ <t id="101">250</t>
+ <t id="102">Federacja Anarkis</t>
+ <t id="103">\033RECS:\033X Rozszerzony System Komunikacyjny</t>
+ <t id="104">© Serial Kicked / [\033YFederacja Anarkis\033X]</t>
+
+<t id="200">\033WECS 2.5 Menadżer\033X</t>
+<t id="201">Rozszerzony System Komunikacyjny jest teraz  %s</t>
+<t id="202">ECS wtyczka zainstalowana</t>
+<t id="203">\033W%s\033X  &lt; %s &gt;</t>
+<t id="204">Wybrany : \033W%s\033X</t>
+<t id="205">Wybrana wtyczka instalacyjna</t>
+<t id="206">Nie zarejestrowana wtyczka</t>
+<t id="207">Skrypt zwany : \033W%s\033X</t>
+<t id="208">Miejscowa zmienna : \033W%s\033X</t>
+<t id="209">Rasa : \033W%s\033X</t>
+<t id="210">Klasa : \033W%s\033X</t>
+<t id="211">ECS Ustawiony</t>
+<t id="212">Usunięcie ECS klawiszy i konfiguracji</t>
+<t id="213">Zamknij okno</t>
+<t id="214">[author][b]Anarkis Federation[/b][/author] [b]RSK[/b] zostało odinstalowane prawidłowo.</t>
+<t id="215">Wiadomości Systemowe : \033W%s\033X</t>
+<t id="216">[%s] - \033W%s\033X</t>
+<t id="217">Od: \033W%s\033X</t>
+<t id="218">%s \n\n- Opublikowany %s temu.\n\n\n\n</t>
+<t id="219">Zamknij</t>
+<t id="220">\033W%s\033X\n\n</t>
+<t id="221">Późniejsze wiadomości</t>
+<t id="222">Brak przekazu</t>
+<t id="223">\nWybór wiadomości\n\n\n</t>
+<t id="224">Wybierz</t>
+<t id="225">%s \n\n   -Od: \033W%s\033X\n\n\n\n</t>
+<t id="226">Liczba wiadomości : \033W%s\033X</t>
+<t id="227">Nazwa źródła informacji : \033W%s\033X</t>
+
+<t id="300">\033GWłączony\033X</t>
+<t id="301">\033RWyłączony\033X</t>
+<t id="302">\033RNie znaleziony\033X</t>
+<t id="303">\033GWykryty\033X</t>
+
+</page>
+
+</language>
+

--- a/tools/fixtures/known_good/ADS/t/8511-L049.xml
+++ b/tools/fixtures/known_good/ADS/t/8511-L049.xml
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<language id="49">
+
+<page id="8511" title="EKS" descr="Erweitertes Kommunikationssystem">
+ <t id="100">\033REKS:\033X \033WErweitertes Kommunikationssystem\033X</t>
+ <t id="101">250</t>
+ <t id="102">Anarkis Federation</t>
+ <t id="103">\033REKS:\033X Erweitertes Komm. System</t>
+ <t id="104">© Serial Kicked / [\033YAnarkis Federation\033X]</t>
+
+<t id="200">\033WEKS 2.5 Manager\033X</t>
+<t id="201">Das Erweiterte Kommunikationssystem ist jetzt %s</t>
+<t id="202">EKS Installierte Plugins</t>
+<t id="203">\033W%s\033X  &lt; %s &gt;</t>
+<t id="204">Ausgewählt : \033W%s\033X</t>
+<t id="205">Gewähltes Plugin konfigurieren</t>
+<t id="206">Plugin Entregistrieren</t>
+<t id="207">Script aufgerufen : \033W%s\033X</t>
+<t id="208">Lokale Variable : \033W%s\033X</t>
+<t id="209">Rasse : \033W%s\033X</t>
+<t id="210">Klasse : \033W%s\033X</t>
+<t id="211">EKS Konfiguration</t>
+<t id="212">EKS Hotkey und Konfiguration entfernen</t>
+<t id="213">Fenster schließen</t>
+<t id="214">[author][b]Anarkis Federation[/b][/author] [b]EKS[/b] wurde erfolgreich deinstalliert.</t>
+<t id="215">Nachrichten System : \033W%s\033X</t>
+<t id="216">[%s] - \033W%s\033X</t>
+<t id="217">Von: \033W%s\033X</t>
+<t id="218">%s \n\n- Herausgegeben vor %s .\n\n\n\n</t>
+<t id="219">Schließen</t>
+<t id="220">\033W%s\033X\n\n</t>
+<t id="221">Neueste Nachrichten</t>
+<t id="222">Nichts</t>
+<t id="223">\nBitte eine Nachricht auswählen\n\n\n</t>
+<t id="224">Wähle</t>
+<t id="225">%s \n\n   -Von: \033W%s\033X\n\n\n\n</t>
+<t id="226">Nachrichtenfeed Zähler : \033W%s\033X</t>
+<t id="227">Nachrichtenfeed Name : \033W%s\033X</t>
+
+<t id="300">\033GAktiviert\033X</t>
+<t id="301">\033RDeaktiviert\033X</t>
+<t id="302">\033RNicht Gefunden\033X</t>
+<t id="303">\033GGefunden\033X</t>
+
+</page>
+
+</language>
+

--- a/tools/test_x3s.py
+++ b/tools/test_x3s.py
@@ -1,13 +1,50 @@
 from pathlib import Path
 import subprocess, sys
+import xml.etree.ElementTree as ET
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def extract_xml_lines(xml_path: Path) -> list[str]:
+  root = ET.parse(xml_path).getroot()
+  tag = root.tag.lower()
+  if tag == 'codearray':
+    line_nodes = [n for n in root if n.tag.lower() == 'line']
+  elif tag == 'script':
+    st = root.find('sourcetext')
+    if st is None:
+      return []
+    line_nodes = [n for n in st if n.tag.lower() == 'line']
+  else:
+    return []
+
+  lines: list[str] = []
+  for node in line_nodes:
+    text = (node.text or '').replace('\n', '')
+    for child in node:
+      text += ''.join(child.itertext())
+    lines.append(text.rstrip())
+  return lines
+
+
+def read_x3s_body(x3s_path: Path) -> list[str]:
+  lines = x3s_path.read_text(encoding='utf-8').splitlines()
+  body_started = False
+  body: list[str] = []
+  for ln in lines:
+    if not body_started:
+      if ln.strip() == '':
+        body_started = True
+      continue
+    body.append(ln)
+  return body
 
 def run(cmd):
   print('>', ' '.join(cmd))
   p = subprocess.run(cmd, cwd=ROOT)
   if p.returncode:
     sys.exit(p.returncode)
+
 
 def run_fail(cmd):
   print('>', ' '.join(cmd))
@@ -16,7 +53,29 @@ def run_fail(cmd):
     print('expected failure but command passed')
     sys.exit(1)
 
+
 if __name__ == '__main__':
+  mods_dir = ROOT / 'tools/fixtures/mods'
+  ads_real = mods_dir / 'ads'
+  ads_symlink = mods_dir / 'ADS'
+  if not ads_symlink.exists():
+    ads_symlink.symlink_to(ads_real, target_is_directory=True)
+
+  # Run the converter for the ADS mod using a Windows-style path
+  run([sys.executable, 'tools/convert_mods.py', '--single-mod', '\\tools\\fixtures\\mods\\ADS', '--out-dir', 'tools/fixtures/known_good'])
+
+  # Validate line counts between XML and generated .x3s files
+  ads_xml_dir = ads_real / 'scripts'
+  ads_out_dir = ROOT / 'tools/fixtures/known_good/ADS/src/scripts'
+  for x3s_path in sorted(ads_out_dir.glob('*.x3s')):
+    xml_path = ads_xml_dir / f'{x3s_path.stem}.xml'
+    xml_lines = extract_xml_lines(xml_path)
+    x3s_lines = read_x3s_body(x3s_path)
+    assert len(xml_lines) == len(x3s_lines), f'line count mismatch for {x3s_path.name}'
+    for src, out in zip(xml_lines, x3s_lines):
+      if len(src) > 1:
+        assert len(out) > 1, f'unexpected single-character line in {x3s_path.name}'
+
   src_files = sorted((ROOT / 'src/scripts').glob('*.x3s'))
   good_files = sorted(ROOT.glob('tools/fixtures/known_good/**/src/scripts/*.x3s'))
   fail_files = sorted(ROOT.glob('tools/fixtures/should_fail/**/*.x3s'))


### PR DESCRIPTION
## Summary
- ensure `convert_mods.py` writes exactly one line per XML `<line>` and preserves caller-supplied mod name when converting a single mod
- extend `test_x3s.py` to convert the ADS mod, verify line counts, and lint the results
- add generated ADS fixtures under `tools/fixtures/known_good/ADS/`

## Testing
- `python tools/test_x3s.py`

------
https://chatgpt.com/codex/tasks/task_e_68c66f71b9108326b49c15f572cf98c0