### PR TITLE
Expand ADS fixtures and linter patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 SLX is a lightweight station-to-station logistics mod for X3TC: Terran Conflict. Moves wares between enrolled player stations (same- or cross-sector) — no NPC trade or scanning — via per-ware roles (Producer, Consumer, Store) with Min/Max/Chunk thresholds and a priority-based transfer loop.
 
 ## ADS Sample Files
-The linter is validated against these 20 known-good ADS scripts:
+The linter is validated against these 40 known-good ADS scripts:
 
 - !init.anarkis.modified.x3s
 - al.plugin.sk.ecs.x3s
@@ -24,3 +24,23 @@ The linter is validated against these 20 known-good ADS scripts:
 - anarkis.acc.cmd.dock.all.x3s
 - anarkis.acc.cmd.protect.x3s
 - anarkis.acc.cmd.sell.return.x3s
+- anarkis.acc.cmd.sellwares.pl.x3s
+- anarkis.acc.ecs.register.x3s
+- anarkis.acc.ecs.remove.x3s
+- anarkis.acc.evaluate.enemy.npc.x3s
+- anarkis.acc.evaluate.enemy.x3s
+- anarkis.acc.evaluate.findstrong.x3s
+- anarkis.acc.evalute.danger.npc.x3s
+- anarkis.acc.evalute.danger.off.x3s
+- anarkis.acc.evalute.danger.x3s
+- anarkis.acc.get.acc.carriers.x3s
+- anarkis.acc.get.all.x3s
+- anarkis.acc.get.dockedships.x3s
+- anarkis.acc.hotkey.cmd.attack.x3s
+- anarkis.acc.hotkey.cmd.clear.x3s
+- anarkis.acc.hotkey.cmd.dockall.x3s
+- anarkis.acc.hotkey.cmd.manage.x3s
+- anarkis.acc.hotkey.ecs.x3s
+- anarkis.acc.hotkey.install.x3s
+- anarkis.acc.hotkey.setup.x3s
+- anarkis.acc.hotkey.uninstall.x3s

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -54,6 +54,12 @@
 - **speak.text**: `= speak text: page=13 id=1276 priority=0`
 - **speak.array**: `= speak array: $d prio=0`
 
+### New Statements Recognized
+- **send.message.literal**: `send incoming message 'ECS Not Detected - Comms with ships and stations will be disabled !' to player: display it=[TRUE]`
+- **return.bool**: `return [TRUE]`
+- **start.speak.text**: `START speak text: page=13 id=131 priority=0`
+- **unregister.hotkey**: `unregister hotkey $hotkey.id`
+
 ## Fixtures
 
 Known-good mod fixtures live under `tools/fixtures/known_good/<mod_name>`. Each mod

--- a/tools/fixtures/known_good/anarkis.acc.cmd.sellwares.pl.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.cmd.sellwares.pl.x3s
@@ -1,0 +1,10 @@
+#name: anarkis.acc.cmd.sellwares.pl
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.cmd.sellwares.pl.xml
+
+[THIS] -> set command: ANARKIS_SELLWARES  target=null target2=null par1=null par2=null
+= [THIS] -> call script anarkis.acc.setup.sellwares :  selected ship=[THIS]
+[THIS] -> set command: null  target=null target2=null par1=null par2=null
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.ecs.register.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.ecs.register.x3s
@@ -1,0 +1,19 @@
+#name: anarkis.acc.ecs.register
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.ecs.register.xml
+
+* Added to prevent ADS to start before ECS
+= [THIS] -> call script anarkis.lib.wait :  wait time (in sec)=30  global to check=null
+
+$setup =  array alloc: size=7
+$setup[0] = 'anarkis.acc.plugin'
+$setup[1] = 'anarkis.acc.hotkey.ecs'
+$setup[2] = null
+$setup[3] = Player
+$setup[4] = null
+$setup[5] = 15
+$setup[6] = 'Latest ADS Reports'
+skip if [THIS] -> call script plugin.sk.ecs.register :  Setup Array=$setup
+send incoming message 'ECS Not Detected - Comms with ships and stations will be disabled !' to player: display it=[TRUE]
+return null

--- a/tools/fixtures/known_good/anarkis.acc.ecs.remove.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.ecs.remove.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.acc.ecs.remove
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.ecs.remove.xml
+
+
+= [THIS] -> call script plugin.sk.ecs.unregister :  Plugin ID='anarkis.acc.plugin'
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.evaluate.enemy.npc.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.evaluate.enemy.npc.x3s
@@ -1,0 +1,32 @@
+#name: anarkis.acc.evaluate.enemy.npc
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.evaluate.enemy.npc.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$setup.array = $refobject -> get local variable: name='anarkis.acc.setup'
+
+$owner = $refobject -> get object class
+if $owner == Player
+$ignore.list = $gl.setup[7]
+else
+$ignore.list = $setup.array[16]
+end
+
+$class = $target -> get object class
+$owner = $target -> get owner race
+
+if  find $owner in array: $ignore.list
+return [FALSE]
+end
+
+if not $target -> is $refobject a enemy
+return [FALSE]
+end
+
+if $class == Fighter Drone OR $class == All Satellites OR $class == Freight Drone
+return [FALSE]
+end
+
+
+return [TRUE]

--- a/tools/fixtures/known_good/anarkis.acc.evaluate.enemy.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.evaluate.enemy.x3s
@@ -1,0 +1,30 @@
+#name: anarkis.acc.evaluate.enemy
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.evaluate.enemy.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$setup.array = $refobject -> get local variable: name='anarkis.acc.setup'
+
+$owner = $refobject -> get owner race
+if $owner == Player
+$ignore.list = $gl.setup[7]
+else
+$ignore.list = $setup.array[16]
+end
+$class = $target -> get object class
+$owner = $target -> get owner race
+
+if  find $owner in array: $ignore.list
+return [FALSE]
+end
+
+if not $target -> is $refobject a enemy
+return [FALSE]
+end
+
+if $class == Fighter Drone OR $class == All Satellites OR $class == Freight Drone
+return [FALSE]
+end
+
+return [TRUE]

--- a/tools/fixtures/known_good/anarkis.acc.evaluate.findstrong.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.evaluate.findstrong.x3s
@@ -1,0 +1,76 @@
+#name: anarkis.acc.evaluate.findstrong
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.evaluate.findstrong.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+
+$setup.array = $refobject -> get local variable: name='anarkis.acc.setup'
+$radar.range = $setup.array[1]
+
+$owner = $refobject -> get owner race
+if $owner == Player
+$ignore.list = $gl.setup[7]
+else
+$ignore.list = $setup.array[16]
+end
+
+$flags = [Find.Enemy] | [Find.Multiple]
+$ship.list =  find ship: sector=$sector class or type=Moveable Ship race=null flags=$flags refobj=$refobject maxdist=$radar.range maxnum=50 refpos=null
+$ship.count =  size of array $ship.list
+
+$selected = null
+$selected.class = -1
+
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$class = $ship -> get object class
+$owner = $ship -> get owner race
+if  find $owner in array: $ignore.list
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+if not $ship -> is $refobject a enemy
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+if $class == M2 AND $selected.class < 10
+$selected = $ship
+$selected.class = 10
+else if $class == M1 AND $selected.class < 9
+$selected = $ship
+$selected.class = 9
+else if $class == M7 AND $selected.class < 8
+$selected = $ship
+$selected.class = 8
+else if $class == M6 AND $selected.class < 7
+$selected = $ship
+$selected.class = 7
+else if $class == TL AND $selected.class < 6
+$selected = $ship
+$selected.class = 6
+else if $class == M8 AND $selected.class < 5
+$selected = $ship
+$selected.class = 5
+else if $class == M3 AND $selected.class < 4
+$selected = $ship
+$selected.class = 4
+else if $class == M4 AND $selected.class < 3
+$selected = $ship
+$selected.class = 3
+else if $class == M5 AND $selected.class < 2
+$selected = $ship
+$selected.class = 2
+else if $class == TM AND $selected.class < 1
+$selected = $ship
+$selected.class = 1
+else if ( $class == TP OR $class == TS ) AND $selected.class < 0
+$selected = $ship
+$selected.class = 0
+end
+end
+
+return $selected

--- a/tools/fixtures/known_good/anarkis.acc.evalute.danger.npc.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.evalute.danger.npc.x3s
@@ -1,0 +1,64 @@
+#name: anarkis.acc.evalute.danger.npc
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.evalute.danger.npc.xml
+
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+
+$setup.array = $refobject -> get local variable: name='anarkis.acc.setup'
+$radar.range = $setup.array[1]
+$owner = $refobject -> get owner race
+if $owner == Player
+$ignore.list = $gl.setup[7]
+else
+$ignore.list = $setup.array[16]
+end
+
+
+$flags = [Find.Multiple] | [Find.Enemy]
+$ship.list =  find ship: sector=$sector class or type=Moveable Ship race=null flags=$flags refobj=$refobject maxdist=$radar.range maxnum=50 refpos=null
+$ship.count =  size of array $ship.list
+
+$threat.level = 0
+
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$class = $ship -> get object class
+$owner = $ship -> get true owner
+
+
+if $ship -> is script !job.trade.freetrader on stack of task=0
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $ship -> is script !job.trade.docktrader on stack of task=0
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $ship -> is script !job.special.tpliners on stack of task=0
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $ship -> is script !job.special.taxi on stack of task=0
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+if  find $owner in array: $ignore.list
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> is $refobject a enemy
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $ship -> is civilian ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+$ship.threat = [THIS] -> call script anarkis.ads.lib.get.shipthreat :  ship/class=$ship
+$threat.level = $threat.level + $ship.threat
+end
+return $threat.level

--- a/tools/fixtures/known_good/anarkis.acc.evalute.danger.off.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.evalute.danger.off.x3s
@@ -1,0 +1,40 @@
+#name: anarkis.acc.evalute.danger.off
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.evalute.danger.off.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$setup.array = $refobject -> get local variable: name='anarkis.acc.setup'
+
+$radar.range = $setup.array[1]
+
+$owner = $refobject -> get owner race
+if $owner == Player
+$ignore.list = $gl.setup[7]
+else
+$ignore.list = $setup.array[16]
+end
+
+$flags = [Find.Enemy] | [Find.Multiple] | [Find.Nearest]
+$ship.list =  find ship: sector=$sector class or type=Moveable Ship race=null flags=$flags refobj=$refobject maxdist=$radar.range maxnum=50 refpos=null
+$ship.count =  size of array $ship.list
+
+$threat.level = 0
+
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$class = $ship -> get object class
+$owner = $ship -> get owner race
+if  find $owner in array: $ignore.list
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $ship -> is civilian ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+$ship.threat = [THIS] -> call script anarkis.ads.lib.get.shipthreat :  ship/class=$ship
+$threat.level = $threat.level + $ship.threat
+end
+return $threat.level

--- a/tools/fixtures/known_good/anarkis.acc.evalute.danger.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.evalute.danger.x3s
@@ -1,0 +1,43 @@
+#name: anarkis.acc.evalute.danger
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.evalute.danger.xml
+
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+
+$setup.array = $refobject -> get local variable: name='anarkis.acc.setup'
+$radar.range = $setup.array[1]
+$owner = $refobject -> get owner race
+if $owner == Player
+$ignore.list = $gl.setup[7]
+else
+$ignore.list = $setup.array[16]
+end
+$flags = [Find.Enemy] | [Find.Multiple] | [Find.Nearest]
+$ship.list =  find ship: sector=$sector class or type=Moveable Ship race=null flags=$flags refobj=$refobject maxdist=$radar.range maxnum=50 refpos=null
+$ship.count =  size of array $ship.list
+
+$threat.level = 0
+
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$class = $ship -> get object class
+$owner = $ship -> get owner race
+if  find $owner in array: $ignore.list
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> is $refobject a enemy
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $ship -> is civilian ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+$ship.threat = [THIS] -> call script anarkis.ads.lib.get.shipthreat :  ship/class=$ship
+$threat.level = $threat.level + $ship.threat
+end
+return $threat.level

--- a/tools/fixtures/known_good/anarkis.acc.get.acc.carriers.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.get.acc.carriers.x3s
@@ -1,0 +1,39 @@
+#name: anarkis.acc.get.acc.carriers
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.get.acc.carriers.xml
+
+
+$array =  get ship array: of race Player class/type=Moveable Ship
+$cnt =  size of array $array
+
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+
+$v1 = $select -> get object class
+
+if not ( $v1 == M1 OR $v1 == M7 OR $v1 == TL OR $v1 == TM )
+remove element from array $array at index $cnt
+continue
+end
+
+if not $select -> get true amount of ware Carrier Command Software  in cargo bay
+remove element from array $array at index $cnt
+continue
+end
+
+if $active.only == [TRUE]
+if not $select -> is script anarkis.acc.task.autocarrier on stack of task=10
+if not $select -> is script anarkis.acc.task.autocarrier on stack of task=11
+if not $select -> is script anarkis.acc.task.autocarrier.npc on stack of task=894
+remove element from array $array at index $cnt
+continue
+end
+end
+end
+end
+
+end
+
+return $array

--- a/tools/fixtures/known_good/anarkis.acc.get.all.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.get.all.x3s
@@ -1,0 +1,35 @@
+#name: anarkis.acc.get.all
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.get.all.xml
+
+$array = [THIS] -> get owned ships: class/type=$ship.class
+$cnt =  size of array $array
+
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+if $select -> get local variable: name='anarkis.skipme'
+remove element from array $array at index $cnt
+continue
+end
+if $select -> get local variable: name='anarkis.acc.skipme'
+remove element from array $array at index $cnt
+continue
+end
+if $no.hull.dmg == [TRUE]
+$hull = $select -> get hull percent
+if $hull < 100
+remove element from array $array at index $cnt
+continue
+end
+end
+if $active.only == [TRUE]
+if not $select -> get local variable: name='anarkis.acc.ship'
+remove element from array $array at index $cnt
+continue
+end
+end
+end
+
+return $array

--- a/tools/fixtures/known_good/anarkis.acc.get.dockedships.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.get.dockedships.x3s
@@ -1,0 +1,66 @@
+#name: anarkis.acc.get.dockedships
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.get.dockedships.xml
+
+$ship.array = [THIS] -> get ship array from sector/ship/station
+$ship.cnt =  size of array $ship.array
+while $ship.cnt
+dec $ship.cnt =
+$test.ship = $ship.array[$ship.cnt]
+* - Check All-in-One no go variable
+if $test.ship -> get local variable: name='anarkis.skipme'
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+* - Check specific ADS ignore variable
+if $test.ship -> get local variable: name='anarkis.acc.skipme'
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+* - Check Ownership
+$owner = $test.ship -> get true owner
+if $owner != [OWNER]
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+* - Check ACC ownership
+if not $test.ship -> get local variable: name='anarkis.acc.ship'
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+* - Check Class
+if not $test.ship -> is of class $ship.class
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+* - Check Homebase
+$homebase = $test.ship -> get homebase
+if [OWNER] == Player
+if not $homebase -> exists
+$test.ship -> set homebase to [THIS]
+else if $homebase != [THIS]
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+end
+
+* - Let's stop ships with returnhome
+if $test.ship -> is script !move.movetostation on stack of task=0
+$test.ship -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$test.ship -> set command: null
+$test.ship -> set destination to null
+* - Else, check if they are not waiting to go
+else if $test.ship -> is task 0 in use
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+* - Check the hull
+$hull = $test.ship -> get hull percent
+if $hull < 95 AND $no.hull.dmg == [TRUE]
+remove element from array $ship.array at index $ship.cnt
+continue
+end
+end
+
+return $ship.array

--- a/tools/fixtures/known_good/anarkis.acc.hotkey.cmd.attack.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.hotkey.cmd.attack.x3s
@@ -1,0 +1,17 @@
+#name: anarkis.acc.hotkey.cmd.attack
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.cmd.attack.xml
+
+$aim =  get player tracking aim
+skip if $aim -> exists
+return null
+
+if [THIS] -> call script anarkis.acc.is.compatible :  target=[PLAYERSHIP]
+$v1 = $aim -> get object class
+$count = [THIS] -> call script anarkis.lib.get.shipcount :  class=$v1
+START [PLAYERSHIP] -> call script anarkis.acc.wing.attack.pl :  target=$aim  wing size=$count
+= speak text: page=13 id=131 priority=0
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.hotkey.cmd.clear.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.hotkey.cmd.clear.x3s
@@ -1,0 +1,10 @@
+#name: anarkis.acc.hotkey.cmd.clear
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.cmd.clear.xml
+
+if [THIS] -> call script anarkis.acc.is.compatible :  target=[PLAYERSHIP]
+START speak text: page=13 id=131 priority=0
+START [PLAYERSHIP] -> call script anarkis.acc.wing.clearsector.pl :
+end
+return null

--- a/tools/fixtures/known_good/anarkis.acc.hotkey.cmd.dockall.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.hotkey.cmd.dockall.x3s
@@ -1,0 +1,10 @@
+#name: anarkis.acc.hotkey.cmd.dockall
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.cmd.dockall.xml
+
+if [THIS] -> call script anarkis.acc.is.compatible :  target=[PLAYERSHIP]
+START speak text: page=13 id=131 priority=0
+START [PLAYERSHIP] -> call script anarkis.acc.cmd.dock.all.pl :
+end
+return null

--- a/tools/fixtures/known_good/anarkis.acc.hotkey.cmd.manage.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.hotkey.cmd.manage.x3s
@@ -1,0 +1,7 @@
+#name: anarkis.acc.hotkey.cmd.manage
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.cmd.manage.xml
+
+= [THIS] -> call script anarkis.ads.comm.manage.call :
+return null

--- a/tools/fixtures/known_good/anarkis.acc.hotkey.ecs.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.hotkey.ecs.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.acc.hotkey.ecs
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.ecs.xml
+
+if [THIS] -> call script anarkis.acc.is.compatible :  target=$target
+$owner = $target -> get owner race
+if $owner == Player
+$target -> start task 892 with script anarkis.acc.setup and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+end
+return null

--- a/tools/fixtures/known_good/anarkis.acc.hotkey.install.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.hotkey.install.x3s
@@ -1,0 +1,25 @@
+#name: anarkis.acc.hotkey.install
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.install.xml
+
+$page.id = 8510
+load text: id=$page.id
+$installed = get global variable: name='anarkis.acc.hotkey'
+if not $installed
+$installed =  array alloc: size=0
+$st =  read text: page=$page.id id=600
+$hotkey.id =  register hotkey $st to call script anarkis.acc.hotkey.cmd.clear
+append $hotkey.id to array $installed
+$st =  read text: page=$page.id id=601
+$hotkey.id =  register hotkey $st to call script anarkis.acc.hotkey.cmd.dockall
+append $hotkey.id to array $installed
+$st =  read text: page=$page.id id=602
+$hotkey.id =  register hotkey $st to call script anarkis.acc.hotkey.cmd.attack
+append $hotkey.id to array $installed
+$st =  read text: page=$page.id id=603
+$hotkey.id =  register hotkey $st to call script anarkis.ads.comm.manage.call
+append $hotkey.id to array $installed
+set global variable: name='anarkis.acc.hotkey' value=$installed
+end
+return null

--- a/tools/fixtures/known_good/anarkis.acc.hotkey.setup.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.hotkey.setup.x3s
@@ -1,0 +1,89 @@
+#name: anarkis.acc.hotkey.setup
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.setup.xml
+
+$page.id = 8510
+load text: id=$page.id
+
+* Retrieve setup, apply default if not found
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$cnt =  size of array $setup.array
+if not $cnt == 19
+$setup.array = [THIS] -> call script anarkis.acc.setup.default :
+= [THIS] -> call script anarkis.acc.apply.active :
+end
+skip if [THIS] -> is script anarkis.acc.task.repairs on stack of task=900
+[THIS] -> start task 900 with script anarkis.acc.task.repairs and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=240
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=211, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='setup.home'
+$st = sprintf: pageid=$page.id textid=242, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='repairbay'
+$st = sprintf: pageid=$page.id textid=241, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='autocarrier'
+$st = sprintf: pageid=$page.id textid=243, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='supplies'
+
+$st = sprintf: pageid=$page.id textid=210, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=212, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='report'
+
+$st =  read text: page=$page.id id=230
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=232, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='reset'
+
+$v1 = [THIS] -> get object class
+$st = sprintf: pageid=$page.id textid=250, [THIS], $v1, null, null, null
+add custom menu info line to array $menu: text=$st
+$st = sprintf: pageid=$page.id textid=251, [SECTOR], null, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 = [THIS] -> get number of landed ships
+$v2 = [THIS] -> get dock bay size
+$v3 = [THIS] -> get owned ships: class/type=Ship
+$v3 =  size of array $v3
+$st = sprintf: pageid=$page.id textid=252, $v1, $v2, $v3, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=200
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'autocarrier'
+= [THIS] -> call script anarkis.acc.setup.autocarrier :
+
+else if $menu.result == 'setup.home'
+= [THIS] -> call script anarkis.acc.setup.hangars :
+
+else if $menu.result == 'repairbay'
+= [THIS] -> call script anarkis.acc.setup.repair :
+
+else if $menu.result == 'supplies'
+= [THIS] -> call script anarkis.acc.setup.supplies :
+
+* dont loop here
+else if $menu.result == 'report'
+START $null -> call script anarkis.acc.setup.reports :  selected ship=[THIS]
+return null
+
+else if $menu.result == 'reset'
+$setup.array = [THIS] -> call script anarkis.acc.setup.default :
+
+
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.hotkey.uninstall.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.hotkey.uninstall.x3s
@@ -1,0 +1,15 @@
+#name: anarkis.acc.hotkey.uninstall
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.hotkey.uninstall.xml
+
+$page.id = 8510
+$installed = get global variable: name='anarkis.acc.hotkey'
+$cnt =  size of array $installed
+while $cnt
+dec $cnt =
+$hotkey.id = $installed[$cnt]
+unregister hotkey $hotkey.id
+end
+set global variable: name='anarkis.acc.hotkey' value=null
+return null

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -405,6 +405,34 @@
       "examples": [
         "play sample 972"
       ]
+    },
+    {
+      "name": "send.message.literal",
+      "regex": "^send incoming message '[^']+' to player: display it=\\[(TRUE|FALSE)\\]$",
+      "examples": [
+        "send incoming message 'ECS Not Detected - Comms with ships and stations will be disabled !' to player: display it=[TRUE]"
+      ]
+    },
+    {
+      "name": "return.bool",
+      "regex": "^return \\[(TRUE|FALSE)\\]$",
+      "examples": [
+        "return [TRUE]"
+      ]
+    },
+    {
+      "name": "start.speak.text",
+      "regex": "^START speak text: page=\\d+ id=\\d+ priority=\\d+$",
+      "examples": [
+        "START speak text: page=13 id=131 priority=0"
+      ]
+    },
+    {
+      "name": "unregister.hotkey",
+      "regex": "^unregister hotkey \\$[A-Za-z0-9_.]+$",
+      "examples": [
+        "unregister hotkey $hotkey.id"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Plan
- Pull in 20 more ADS scripts and teach the linter their line shapes
- Document new patterns and fixtures

## Changes
- Added 20 ADS fixtures and referenced them in the README
- Added regex patterns: `send.message.literal`, `return.bool`, `start.speak.text`, `unregister.hotkey`
- Documented the new patterns in `docs/x3s-language.md`

## Test Results
- `python tools/x3s_lint.py` ✅
- `python tools/test_x3s.py` ✅

## Pattern List
- `send.message.literal` – `send incoming message '...' to player: display it=[TRUE]`
- `return.bool` – `return [TRUE]`
- `start.speak.text` – `START speak text: page=13 id=131 priority=0`
- `unregister.hotkey` – `unregister hotkey $hotkey.id`

## Safety Checks
- Control-flow matching
- wait-in-while enforcement
- setup load-text rule

------
https://chatgpt.com/codex/tasks/task_e_68c68bd3f118832682f440cd4c73079b