### PR TITLE
Learn from known-good .x3s and update our linter (no XML build)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 SLX is a lightweight station-to-station logistics mod for X3TC: Terran Conflict. Moves wares between enrolled player stations (same- or cross-sector) — no NPC trade or scanning — via per-ware roles (Producer, Consumer, Store) with Min/Max/Chunk thresholds and a priority-based transfer loop.
 
 ## ADS Sample Files
-The linter is validated against these 40 known-good ADS scripts:
+The linter is validated against these 60 known-good ADS scripts:
 
 - !init.anarkis.modified.x3s
 - al.plugin.sk.ecs.x3s
@@ -44,3 +44,23 @@ The linter is validated against these 40 known-good ADS scripts:
 - anarkis.acc.hotkey.install.x3s
 - anarkis.acc.hotkey.setup.x3s
 - anarkis.acc.hotkey.uninstall.x3s
+- anarkis.lib.get.sector.x3s
+- anarkis.lib.task.autodocking.x3s
+- anarkis.lib.wing.join.x3s
+- setup.anarkis.acc.x3s
+- anarkis.lib.cmd.attack.x3s
+- anarkis.lib.unknown.x3s
+- anarkis.acc.uninstall.x3s
+- anarkis.lib.wait.x3s
+- anarkis.lib.get.bycargovalue.adv.x3s
+- anarkis.ads.crew.getrepair.x3s
+- anarkis.lib.get.ships.var.x3s
+- anarkis.lib.ask.shiparray.x3s
+- anarkis.acc.setup.default.to.x3s
+- anarkis.lib.guild.register.x3s
+- anarkis.acc.setup.repair.x3s
+- anarkis.lib.shipstate.restore.x3s
+- anarkis.acc.lib.get.leaderlist.x3s
+- anarkis.lib.custowned.init.x3s
+- anarkis.lib.vis.task.blink.x3s
+- anarkis.acc.task.autoname.x3s

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -60,6 +60,19 @@
 - **start.speak.text**: `START speak text: page=13 id=131 priority=0`
 - **unregister.hotkey**: `unregister hotkey $hotkey.id`
 
+### New Statements Recognized
+- **gosub.label**: `gosub dodock`
+- **send.message.var.bool**: `send incoming message $msg to player: display it=[TRUE]`
+- **set.command.upgrade.software**: `set script command upgrade: command=ANARKIS_DOCKALL  upgrade=Carrier Command Software`
+- **set.command.upgrade.bool**: `set script command upgrade: command=ANARKIS_STATIONDEFENSE  upgrade=[TRUE]`
+- **global.script.map.simple**: `global script map: set: key=ANARKIS_DOCKALL, class=M1, race=Player, script=anarkis.acc.cmd.dock.all.pl, prio=0`
+- **goto.label**: `goto label exit`
+- **add.money.literal**: `add money to player: -50000`
+- **menu.item.num**: `add custom menu item to array $menu: text=$dialog.yes returnvalue=1`
+- **insert.array**: `insert $my.news into array $news.list at index 0`
+- **copy.array.literal**: `copy array $setup index 0 ... 6 into array $config.to.update at index 0`
+- **start.command.args**: `START $new.leader -> command $cmd.name : arg1=$arg1, arg2=$arg2, arg3=$arg3, arg4=null`
+
 ## Fixtures
 
 Known-good mod fixtures live under `tools/fixtures/known_good/<mod_name>`. Each mod

--- a/tools/fixtures/known_good/anarkis.acc.lib.get.leaderlist.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.lib.get.leaderlist.x3s
@@ -1,0 +1,26 @@
+#name: anarkis.acc.lib.get.leaderlist
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.get.leaderlist.xml
+
+$arr = [THIS] -> call script anarkis.acc.lib.get.adsonly :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$env = $select -> get environment
+if $env == [THIS]
+remove element from array $arr at index $cnt
+continue
+end
+if not $select -> has formation ships
+remove element from array $arr at index $cnt
+continue
+end
+end
+$cnt =  size of array $arr
+skip if $cnt
+return null
+
+
+return $arr

--- a/tools/fixtures/known_good/anarkis.acc.setup.default.to.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.default.to.x3s
@@ -1,0 +1,60 @@
+#name: anarkis.acc.setup.default.to
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.default.to.xml
+
+$setup =  array alloc: size=0
+
+* 0 threat level
+append 15 to array $setup
+* 1 Radar Range
+append 20000 to array $setup
+* 2 Defense Ship count
+append 5 to array $setup
+* 3 Damaged ships retreat
+append [TRUE] to array $setup
+* 4 Display warning
+append [TRUE] to array $setup
+* 5 warning type (0 subtitle, 1 audio, 2 text)
+append 2 to array $setup
+* 6 attack mode (3 auto, 1 nearest first, 2 strongest first)
+append 3 to array $setup
+* 7 docked ship autojump on / off
+append [TRUE] to array $setup
+* 8 docked ship autojump distance
+append 1 to array $setup
+* 9 docked ship fuel resupply (jumps)
+append 10 to array $setup
+* 10 docked ship emergency jump/escape
+append [TRUE] to array $setup
+* 11 docked ship shield threshold (in percent)
+append 10 to array $setup
+* 12 docked ship missile usage
+append 15 to array $setup
+* 13 use logfile
+append [FALSE] to array $setup
+* 14 turret settings
+append 246 to array $setup
+* 15 enable autorename
+append [TRUE] to array $setup
+
+* 16 Ignore List (array)
+$ignore =  array alloc: size=0
+append $ignore to array $setup
+
+* 17 Mechanics
+$mechanists =  array alloc: size=0
+* - 0 Count
+append 0 to array $mechanists
+* - 1 Allow ship repairs
+append [FALSE] to array $mechanists
+* - 2 Allow carrier repairs
+append [FALSE] to array $mechanists
+append $mechanists to array $setup
+
+* 18 delay before dock
+append 300 to array $setup
+
+$dest -> set local variable: name='anarkis.acc.setup' value=$setup
+
+return $setup

--- a/tools/fixtures/known_good/anarkis.acc.setup.repair.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.repair.x3s
@@ -1,0 +1,111 @@
+#name: anarkis.acc.setup.repair
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.repair.xml
+
+$page.id = 8510
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$mecha.setup = $setup.array[17]
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=403
+add custom menu heading to array $menu: title=$st
+
+$repair.docked = $mecha.setup[1]
+if $repair.docked == [TRUE]
+$v1 = 203
+else
+$v1 = 204
+end
+$st =  read text: page=$page.id id=$v1
+$st = sprintf: pageid=$page.id textid=404, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='ship.toggle'
+
+$repair.carrier = $mecha.setup[2]
+if $repair.carrier == [TRUE]
+$v1 = 203
+else
+$v1 = 204
+end
+$st =  read text: page=$page.id id=$v1
+$st = sprintf: pageid=$page.id textid=405, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='carrier.toggle'
+
+$mecha.count = $mecha.setup[0]
+$st = sprintf: pageid=$page.id textid=406, $mecha.count, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$st =  read text: page=$page.id id=407
+add custom menu item to array $menu: text=$st returnvalue='add'
+if $mecha.count
+$st =  read text: page=$page.id id=408
+add custom menu item to array $menu: text=$st returnvalue='rem'
+end
+
+$st = sprintf: pageid=$page.id textid=409, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$class = $curr.ship -> get object class
+$hull = $curr.ship -> get hull percent
+if $hull < 100
+$st = sprintf: pageid=$page.id textid=410, $class, $curr.ship, $hull, null, null
+add custom menu item to array $menu: text=$st returnvalue=$curr.ship
+end
+end
+
+$v1 = $mecha.count * 1000
+$v2 = $mecha.count * 5000
+$st = sprintf: pageid=$page.id textid=401, $v1, $v2, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 =  read text: page=$page.id id=400
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'rem'
+dec $mecha.count =
+$mecha.setup[0] = $mecha.count
+
+else if $menu.result == 'add'
+$v1 = get player money
+if $v1 < 50000
+$v2 =  read text: page=$page.id id=407
+= [THIS] -> call script anarkis.lib.display.message :  title=$v2  page number=$page.id  page.id=412  text arg1=null  text arg2=null  text arg3=null
+continue
+end
+$v2 = [Find.Friend] | [Find.Neutral]
+$v1 =  find station: sector=[SECTOR] class or type=Trading Dock race=null flags=$v2 refobj=[THIS] maxdist=null maxnum=1 refpos=null
+if not $v1 -> exists
+$v2 =  read text: page=$page.id id=407
+= [THIS] -> call script anarkis.lib.display.message :  title=$v2  page number=$page.id  page.id=413  text arg1=null  text arg2=null  text arg3=null
+continue
+end
+$v1 =  read text: page=$page.id id=411
+$v1 = [THIS] -> get user input: type=Var/Boolean, title=$v1
+if $v1 == 1
+add money to player: -50000
+inc $mecha.count =
+$mecha.setup[0] = $mecha.count
+end
+
+else if $menu.result == 'ship.toggle'
+$repair.docked = ! $repair.docked
+$mecha.setup[1] = $repair.docked
+
+else if $menu.result == 'carrier.toggle'
+$repair.carrier = ! $repair.carrier
+$mecha.setup[2] = $repair.carrier
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.task.autoname.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.task.autoname.x3s
@@ -1,0 +1,31 @@
+#name: anarkis.acc.task.autoname
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.task.autoname.xml
+
+$page.id = 8510
+
+while [THIS] -> is task 0 in use
+
+if [ENVIRONMENT] == [HOMEBASE]
+$saved.name = [THIS] -> get local variable: name='anarkis.acc.oldname'
+[THIS] -> set name to $saved.name
+end
+
+= wait 1000 ms
+if not [HOMEBASE] -> exists
+$saved.name = [THIS] -> get local variable: name='anarkis.acc.oldname'
+if $saved.name
+[THIS] -> set name to $saved.name
+else
+$saved.name = [THIS] -> get ware type code of object
+[THIS] -> set name to $saved.name
+end
+[THIS] -> set local variable: name='anarkis.acc.oldname' value=null
+[THIS] -> set local variable: name='anarkis.acc.wing' value=null
+return null
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.uninstall.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.uninstall.x3s
@@ -1,0 +1,59 @@
+#name: anarkis.acc.uninstall
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.uninstall.xml
+
+$page.id = 8510
+set global variable: name='anarkis.ads.grid.mode' value=null
+$array = [THIS] -> call script anarkis.acc.get.acc.carriers :  active only?=[FALSE]
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$curr.ship = $array[$cnt]
+$repairs = null
+if $curr.ship -> is script anarkis.acc.task.repairs on stack of task=900
+$curr.ship -> start task 900 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+$task.id = null
+if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=10
+$task.id = 10
+else if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=11
+$task.id = 11
+else if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=894
+$task.id = 894
+else if $curr.ship -> is script anarkis.acc.task.autocarrier.npc on stack of task=894
+$task.id = 894
+end
+if $task.id
+$curr.ship -> start task $task.id with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+end
+$array =  get station array: of race Player class/type=Dock
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$curr.ship = $array[$cnt]
+$curr.ship -> start task 900 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$task.id = null
+if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=10
+$task.id = 10
+else if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=11
+$task.id = 11
+else if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=894
+$task.id = 894
+else if $curr.ship -> is script anarkis.acc.task.autocarrier.npc on stack of task=894
+$task.id = 894
+end
+if $task.id
+$curr.ship -> start task $task.id with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+end
+
+
+= [THIS] -> call script anarkis.acc.ecs.remove :
+= [THIS] -> call script anarkis.acc.hotkey.uninstall :
+set global variable: name='anarkis.acc.plugin' value=null
+
+$msg =  read text: page=$page.id id=106
+send incoming message $msg to player: display it=[TRUE]
+return null

--- a/tools/fixtures/known_good/anarkis.ads.crew.getrepair.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.crew.getrepair.x3s
@@ -1,0 +1,27 @@
+#name: anarkis.ads.crew.getrepair
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.crew.getrepair.xml
+
+$array = $ref.object -> get marines array
+$cnt =  size of array $array
+$result = 0
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$type = $select -> get local variable: name='anarkis.ads.marine'
+* - s
+if $type
+$mech = $select -> get marine mechanical skill
+if $mech > 50
+$result = $result + $mech - 50
+end
+$mech = $select -> get marine engineering skill
+if $mech > 50
+$result = $result + $mech - 50
+end
+end
+* - s
+
+end
+return $result

--- a/tools/fixtures/known_good/anarkis.lib.ask.shiparray.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.ask.shiparray.x3s
@@ -1,0 +1,39 @@
+#name: anarkis.lib.ask.shiparray
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.ask.shiparray.xml
+
+$ship.array =  array alloc: size=0
+
+while $menu.result != -1
+$ship.cnt =  size of array $ship.array
+$menu.box =  create custom menu array
+add custom menu heading to array $menu.box: title='Commands'
+add custom menu item to array $menu.box: text='Add a ship' returnvalue='add.ship'
+skip if not $ship.cnt
+add custom menu item to array $menu.box: text='Clear the list' returnvalue='clear'
+
+add custom menu heading to array $menu.box: title='Selected Ships'
+while $ship.cnt
+dec $ship.cnt =
+$ship = $ship.array[$ship.cnt]
+$sector = $ship -> get sector
+$st = sprintf: fmt='%s - %s <remove>', $ship, $sector, null, null, null
+$x = $ship.cnt + 10
+add custom menu item to array $menu.box: text=$st returnvalue=$x
+end
+
+$menu.result =  open custom menu: title=$menu.title description=$menu.desc option array=$menu.box
+
+if $menu.result == 'add.ship'
+$addship = [THIS] -> get user input: type=Var/Ship, title='Select a ship'
+skip if not $addship -> exists
+append $addship to array $ship.array
+else if $menu.result == 'clear'
+$ship.array =  array alloc: size=0
+else if $menu.result >= 10
+$x = $menu.result - 10
+remove element from array $ship.array at index $x
+end
+end
+return null

--- a/tools/fixtures/known_good/anarkis.lib.cmd.attack.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.cmd.attack.x3s
@@ -1,0 +1,77 @@
+#name: anarkis.lib.cmd.attack
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.attack.xml
+
+* ===========================================
+* CMD : Tell a ship to attack a ship with sector following
+* ===========================================
+
+* Init Command
+[THIS] -> set command: COMMAND_ATTACK  target=$victim target2=null par1=null par2=null
+
+$victim.sector = $victim -> get sector
+[THIS] -> set destination to $victim.sector
+[THIS] -> set attack target to $victim
+[THIS] -> set local variable: name='anarkis.acc.skipme' value=[TRUE]
+
+while $victim -> exists
+* - If the victim is of a weird race, cancel
+$victim.race = $victim -> get true owner
+skip if $victim.race
+$victim.race = $victim -> get owner race
+if $victim.race == Neutral Race OR $victim.race == Unknown OR $victim.race == Friendly Race OR $victim.race == [OWNER]
+goto label exit
+end
+
+* - If the victim is player owned, check if enemy
+*$pl.rel = [THIS] -> get relation to race Player
+*if $victim.race == Player AND $pl.rel != Foe
+*goto label exit
+*end
+
+* - If in different sector, we have to go there
+while $victim.sector != [SECTOR]
+skip if $victim -> exists
+goto label exit
+
+$res = FLRET_ERROR
+* - - Try jumping ?
+if [THIS] -> is autojump activated
+$victim.dest = $victim -> get destination
+if $victim.dest == null
+$victim.leader = $victim -> get formation leader
+skip if not $victim.leader
+$victim.dest = $victim.leader -> get destination
+end
+
+if $victim.dest != null
+skip if  is datatyp[ $victim.dest ] == DATATYP_SECTOR
+$victim.dest = $victim.dest -> get sector
+$gate =  get next gate on route from $victim.sector to $victim.dest
+else
+$gate =  get next gate on route from $victim.sector to [SECTOR]
+end
+$res = [THIS] -> call script !move.jump :  gate or sector=$gate  followers should jump too=[TRUE]
+end
+* - - Else move to
+if $res == FLRET_ERROR
+$next.sector = get next sector on route from sector [SECTOR] to sector $victim.sector
+= [THIS] -> call script !move.movetosector :  sector=$next.sector
+end
+= wait 100 ms
+skip if $victim -> exists
+goto label exit
+$victim.sector = $victim -> get sector
+end
+
+* - Here we go i guess
+[THIS] -> set command: COMMAND_ATTACK  target=$victim target2=null par1=null par2=null
+= [THIS] -> call script !fight.attack.object :  the victim=$victim  follow in new sector=[TRUE]  Only attack shields=[FALSE]
+= wait 100 ms
+end
+
+exit:
+[THIS] -> set command: null  target=null target2=null par1=null par2=null
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.custowned.init.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.custowned.init.x3s
@@ -1,0 +1,8 @@
+#name: anarkis.lib.custowned.init
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.init.xml
+
+$var =  array alloc: size=0
+[THIS] -> set local variable: name='anarkis.owned' value=$var
+return $var

--- a/tools/fixtures/known_good/anarkis.lib.get.bycargovalue.adv.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.bycargovalue.adv.x3s
@@ -1,0 +1,22 @@
+#name: anarkis.lib.get.bycargovalue.adv
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.bycargovalue.adv.xml
+
+$class =  array alloc: size=3
+$class[0] = TS
+$class[1] = TP
+$class[2] = TM
+$array = [THIS] -> call script anarkis.lib.get.ships.var :  array of class=$class  force race=null  jump.range=$jump.range  ignore khaak/xenon?=[TRUE]  ignore pirate/yaki?=$ignore.pirate  ignore civilians?=[TRUE]  ignore player?=$ignore.player  local.var=null  from=$from
+$cnt =  size of array $array
+$result =  array alloc: size=0
+while $cnt
+dec $cnt =
+$ship = $array[$cnt]
+$value = [THIS] -> call script anarkis.lib.get.ship.cargovalue :  ship=$ship
+if $value < $mincargo
+remove element from array $array at index $cnt
+end
+end
+
+return $array

--- a/tools/fixtures/known_good/anarkis.lib.get.sector.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.sector.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.lib.get.sector
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.sector.xml
+
+* ===========================================
+* Get a sector according to the params
+* ===========================================
+
+$sector = [THIS] -> call script anarkis.lib.get.sector.plus :  ref object=[THIS]  max jump=$max.jump  race=$race  remove border sectors=$only.core  remove core=[FALSE]  remove xenon/khaak sectors=[TRUE]  remove unknown=[TRUE]  ignore pirate/yaki=[TRUE]
+
+return $sector

--- a/tools/fixtures/known_good/anarkis.lib.get.ships.var.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.ships.var.x3s
@@ -1,0 +1,90 @@
+#name: anarkis.lib.get.ships.var
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.ships.var.xml
+
+* ===========================================
+* Find all ships according to the parameters
+* ===========================================
+
+$null = null
+$class.cnt =  size of array $class.array
+if $class.array == null
+$class.cnt = 0
+else if $class.cnt == 0
+$class.array = null
+end
+
+$military.array =  array alloc: size=0
+
+if $jump.range > 0
+$sector.list = $from -> find all sectors within $jump.range jumps: Only known sectors=[FALSE]
+else
+$sector.list =  array alloc: size=0
+append [SECTOR] to array $sector.list
+end
+$cnt =  size of array $sector.list
+
+* For all sectors
+$sl.cnt = 0
+while $cnt
+dec $cnt =
+$sector = $sector.list[$cnt]
+$ship.array = $sector -> get ship array from sector/ship/station
+$cnt.ship =  size of array $ship.array
+* - For each ship in sector
+while $cnt.ship
+inc $sl.cnt =
+if $sl.cnt == 75
+$sl.cnt = 0
+= wait 100 ms
+end
+dec $cnt.ship =
+$test.ship = $ship.array[$cnt.ship]
+* - - Check Race
+$owner = $test.ship -> get true owner
+if $force.race != null AND $owner != $force.race
+continue
+else if $force.race != null AND $owner == $force.race
+goto label skipracecheck
+end
+* - - Ignore Player
+if $ignore.player == [TRUE] AND $owner == Player
+continue
+end
+* - - Ignore Khaaks and Xenons ?
+if $ignore.aliens == [TRUE] AND ( $owner == Kha'ak OR $owner == Xenon )
+continue
+end
+* - - Ignore Pirates ?
+if $ignore.pirates == [TRUE] AND ( $owner == Pirates OR $owner == Yaki )
+continue
+end
+skipracecheck:
+* - - Ignore invincible
+skip if not $test.ship -> is invincible
+continue
+* - - Ignore civilians
+if $ignore.civilians
+skip if not $test.ship -> is civilian ship
+continue
+skip if $test.ship -> get current laser strength
+continue
+end
+* - - Check Local
+if $checkvar
+skip if $test.ship -> get local variable: name=$checkvar
+continue
+end
+
+* - - Check class
+$ship.class = $test.ship -> get object class
+$found =  find $ship.class in array: $class.array
+if $found == [TRUE] OR $class.array == null
+append $test.ship to array $military.array
+end
+
+end
+end
+
+return $military.array

--- a/tools/fixtures/known_good/anarkis.lib.guild.register.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.guild.register.x3s
@@ -1,0 +1,14 @@
+#name: anarkis.lib.guild.register
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.guild.register.xml
+
+$global.name = sprintf: fmt='anarkis.guild.%s', $plugin.name, null, null, null, null
+$array =  array alloc: size=4
+$array[0] = $page.id
+$array[1] = 0
+$array[2] = 0
+$array[3] = [FALSE]
+set global variable: name=$global.name value=$array
+
+return $array

--- a/tools/fixtures/known_good/anarkis.lib.shipstate.restore.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.shipstate.restore.x3s
@@ -1,0 +1,20 @@
+#name: anarkis.lib.shipstate.restore
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.shipstate.restore.xml
+
+$array = $ref.object -> get local variable: name='anarkis.ship.state'
+$v1 = $array[0]
+$ref.object -> set destination to $v1
+$v1 = $array[1]
+$ref.object -> set command: $v1
+$v1 = $array[2]
+$ref.object -> set command target: $v1
+$v1 = $array[3]
+$ref.object -> set command target2: $v1
+$v1 = $array[4]
+$ref.object -> set name to $v1
+
+$ref.object -> set local variable: name='anarkis.ship.state' value=null
+
+return $array

--- a/tools/fixtures/known_good/anarkis.lib.task.autodocking.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.task.autodocking.x3s
@@ -1,0 +1,93 @@
+#name: anarkis.lib.task.autodocking
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.task.autodocking.xml
+
+* ===========================================
+* Securely Dock All Ships to a Carrier / Station
+* ===========================================
+
+
+$owner = [THIS] -> get owner race
+
+while [OWNER] == $owner
+= wait 5000 ms
+$array = [THIS] -> get owned ships: class/type=Moveable Ship
+$cnt =  size of array $array
+while $cnt
+= wait 50 ms
+dec $cnt =
+$ship = $array[$cnt]
+* - - Check existence
+if not $ship -> exists
+remove element from array $array at index $cnt
+continue
+end
+* - - Check environment
+$env = $ship -> get environment
+if not [THIS] -> is docking possible of $ship
+remove element from array $array at index $cnt
+continue
+end
+* - - Check if docked
+if $env == [THIS]
+gosub dodock
+remove element from array $array at index $cnt
+continue
+end
+* - - Ship has return flag or is doing nothing, order to go back
+if $ship -> get local variable: name='anarkis.flag.return'
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+$ship -> set local variable: name='anarkis.flag.return' value=null
+remove element from array $array at index $cnt
+continue
+end
+if not $ship -> is task 0 in use
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+remove element from array $array at index $cnt
+continue
+end
+* - - Ship is moving, skip it
+$speed = $ship -> get current speed
+if $speed > 0
+remove element from array $array at index $cnt
+continue
+end
+* - - Now handling returning stuck ships
+$cmd = $ship -> get command
+$r1 = $ship -> is script !move.returntohomebase on stack of task=0
+$r2 = $ship -> is script !ship.cmd.retreat.std on stack of task=0
+if $cmd == COMMAND_RETURN_HOME OR $r1 == [TRUE] OR $r2 == [TRUE]
+$transport.device = $ship -> get true amount of ware Transporter Device in cargo bay
+$distance = get distance between [THIS] and $ship
+* - - - If transport device teleport
+if $distance <= 5000 AND $transport.device >= 1
+$ship -> put into environment [THIS] ->
+gosub dodock
+remove element from array $array at index $cnt
+continue
+* - - - Else Re issue orders
+else
+START $ship -> call script !ship.cmd.idle.std :
+= wait 1000 ms
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+end
+end
+
+end
+
+end
+
+return null
+
+
+dodock:
+$ship -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$ship -> set command: COMMAND_NONE  target=null target2=null par1=null par2=null
+$ship -> set destination to null
+$v1 = $ship -> get maximum shield strength
+$ship -> set current shield strength to $v1
+endsub
+
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.unknown.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.unknown.x3s
@@ -1,0 +1,7 @@
+#name: anarkis.lib.unknown
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.unknown.xml
+
+$sec -> set known status to [FALSE]
+return null

--- a/tools/fixtures/known_good/anarkis.lib.vis.task.blink.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.vis.task.blink.x3s
@@ -1,0 +1,45 @@
+#name: anarkis.lib.vis.task.blink
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.vis.task.blink.xml
+
+$page.id = 8513
+
+$saved.name = [THIS] -> get name
+$save.owner = [THIS] -> get owner race
+
+$blink1 = sprintf: pageid=$page.id textid=150, [THIS], null, null, null, null
+$blink2 = sprintf: pageid=$page.id textid=151, [THIS], null, null, null, null
+$cnt = 0
+while [TRUE]
+if $check.local
+skip if [THIS] -> get local variable: name=$check.local
+break
+end
+if $stop.oos
+$pl.sector = [PLAYERSHIP] -> get sector
+skip if [SECTOR] == $pl.sector
+break
+end
+
+$curr.owner = [THIS] -> get owner race
+if $curr.owner != $save.owner
+break
+end
+
+[THIS] -> set name to $blink1
+= wait 1000 ms
+[THIS] -> set name to $blink2
+= wait 1000 ms
+if $duration
+inc $cnt =
+inc $cnt =
+skip if $cnt <= $duration
+break
+end
+end
+
+[THIS] -> set name to $saved.name
+[THIS] -> set local variable: name='anarkis.isblinking' value=null
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.wait.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.wait.x3s
@@ -1,0 +1,19 @@
+#name: anarkis.lib.wait
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.wait.xml
+
+$curr.time = playing time
+$end.time = $curr.time + $delay
+
+while $curr.time < $end.time
+= wait 2000 ms
+$curr.time = playing time
+
+if $global
+$exit = get global variable: name=$global
+skip if not $exit == [TRUE]
+return null
+end
+end
+return null

--- a/tools/fixtures/known_good/anarkis.lib.wing.join.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.wing.join.x3s
@@ -1,0 +1,22 @@
+#name: anarkis.lib.wing.join
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.wing.join.xml
+
+* ===========================================
+* Merge 2 wings in one
+* ===========================================
+
+$wing2 = [THIS] -> call script anarkis.lib.wing.getall :  ship=$leader.b
+$cnt =  size of array $wing2
+
+while $cnt
+dec $cnt =
+$ship = $wing2[$cnt]
+$ship -> remove from any formation
+$ship -> add to formation with leader $leader.a
+START $ship -> call script !ship.cmd.attacksame.std :  the target=$leader.a  stop if leader is docked=[TRUE]
+end
+
+
+return $leader.a

--- a/tools/fixtures/known_good/setup.anarkis.acc.x3s
+++ b/tools/fixtures/known_good/setup.anarkis.acc.x3s
@@ -1,0 +1,108 @@
+#name: setup.anarkis.acc
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/setup.anarkis.acc.xml
+
+$PageID = 8510
+load text: id=$PageID
+
+$ver =  read text: page=$PageID id=101
+$ver =  string $ver to integer
+$c.ver = get global variable: name='anarkis.acc.plugin'
+$update = [FALSE]
+set global variable: name='anarkis.ads.manager.open' value=null
+
+* New install, add hotkeys
+if $c.ver == null
+= [THIS] -> call script anarkis.acc.hotkey.install :
+$gl.setup = [THIS] -> call script anarkis.ads.setup.init :
+$msg = sprintf: pageid=$PageID textid=103, $ver, null, null, null, null
+send incoming message $msg to player: display it=[TRUE]
+set global variable: name='anarkis.acc.plugin' value=$ver
+START [THIS] -> call script anarkis.acc.ecs.register :
+* Upgrade Needed
+else if $ver > $c.ver
+$update = [TRUE]
+if $ver == 255
+= [THIS] -> call script anarkis.acc.hotkey.uninstall :
+end
+= [THIS] -> call script anarkis.acc.ecs.remove :
+
+skip if get global variable: name='anarkis.ads.setup'
+$gl.setup = [THIS] -> call script anarkis.ads.setup.init :
+
+= [THIS] -> call script anarkis.acc.upgrade.disable :
+
+
+end
+= wait 1000 ms
+
+set script command upgrade: command=ANARKIS_DOCKALL  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_DOCKALL, class=M1, race=Player, script=anarkis.acc.cmd.dock.all.pl, prio=0
+global script map: set: key=ANARKIS_DOCKALL, class=M7, race=Player, script=anarkis.acc.cmd.dock.all.pl, prio=0
+global script map: set: key=ANARKIS_DOCKALL, class=TL, race=Player, script=anarkis.acc.cmd.dock.all.pl, prio=0
+global script map: set: key=ANARKIS_DOCKALL, class=TM, race=Player, script=anarkis.acc.cmd.dock.all.pl, prio=0
+
+
+set script command upgrade: command=ANARKIS_BUYWARES  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_BUYWARES, class=M1, race=Player, script=anarkis.acc.cmd.buywares.pl, prio=0
+global script map: set: key=ANARKIS_BUYWARES, class=M7, race=Player, script=anarkis.acc.cmd.buywares.pl, prio=0
+global script map: set: key=ANARKIS_BUYWARES, class=TL, race=Player, script=anarkis.acc.cmd.buywares.pl, prio=0
+global script map: set: key=ANARKIS_BUYWARES, class=TM, race=Player, script=anarkis.acc.cmd.buywares.pl, prio=0
+
+set script command upgrade: command=ANARKIS_SELLWARES  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_SELLWARES, class=M1, race=Player, script=anarkis.acc.cmd.sellwares.pl, prio=0
+global script map: set: key=ANARKIS_SELLWARES, class=M7, race=Player, script=anarkis.acc.cmd.sellwares.pl, prio=0
+global script map: set: key=ANARKIS_SELLWARES, class=TL, race=Player, script=anarkis.acc.cmd.sellwares.pl, prio=0
+global script map: set: key=ANARKIS_SELLWARES, class=TM, race=Player, script=anarkis.acc.cmd.sellwares.pl, prio=0
+
+set script command upgrade: command=ANARKIS_STATIONDEFENSE  upgrade=[TRUE]
+global script map: set: key=ANARKIS_STATIONDEFENSE, class=Dock, race=Player, script=anarkis.acc.cmd.call.autostation, prio=0
+
+set script command upgrade: command=ANARKIS_SETUPSTATION  upgrade=[TRUE]
+global script map: set: key=ANARKIS_SETUPSTATION, class=Dock, race=Player, script=anarkis.acc.setup, prio=0
+
+set script command upgrade: command=ANARKIS_AUTOCARRIER  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_AUTOCARRIER, class=M1, race=Player, script=anarkis.acc.cmd.call.autocarrier, prio=0
+global script map: set: key=ANARKIS_AUTOCARRIER, class=M7, race=Player, script=anarkis.acc.cmd.call.autocarrier, prio=0
+global script map: set: key=ANARKIS_AUTOCARRIER, class=TL, race=Player, script=anarkis.acc.cmd.call.autocarrier, prio=0
+global script map: set: key=ANARKIS_AUTOCARRIER, class=TM, race=Player, script=anarkis.acc.cmd.call.autocarrier, prio=0
+
+set script command upgrade: command=ANARKIS_SETTACTICS  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_SETTACTICS, class=M1, race=Player, script=anarkis.acc.setup, prio=0
+global script map: set: key=ANARKIS_SETTACTICS, class=M7, race=Player, script=anarkis.acc.setup, prio=0
+global script map: set: key=ANARKIS_SETTACTICS, class=TL, race=Player, script=anarkis.acc.setup, prio=0
+global script map: set: key=ANARKIS_SETTACTICS, class=TM, race=Player, script=anarkis.acc.setup, prio=0
+
+set script command upgrade: command=ANARKIS_ATTACKWING  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_ATTACKWING, class=M1, race=Player, script=anarkis.ads.wing.attack.pl, prio=0
+global script map: set: key=ANARKIS_ATTACKWING, class=M7, race=Player, script=anarkis.ads.wing.attack.pl, prio=0
+global script map: set: key=ANARKIS_ATTACKWING, class=TL, race=Player, script=anarkis.ads.wing.attack.pl, prio=0
+global script map: set: key=ANARKIS_ATTACKWING, class=TM, race=Player, script=anarkis.ads.wing.attack.pl, prio=0
+
+set script command upgrade: command=ANARKIS_DEFENSIVEWING  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_DEFENSIVEWING, class=M1, race=Player, script=anarkis.ads.wing.defense.pl, prio=0
+global script map: set: key=ANARKIS_DEFENSIVEWING, class=M7, race=Player, script=anarkis.ads.wing.defense.pl, prio=0
+global script map: set: key=ANARKIS_DEFENSIVEWING, class=TL, race=Player, script=anarkis.ads.wing.defense.pl, prio=0
+global script map: set: key=ANARKIS_DEFENSIVEWING, class=TM, race=Player, script=anarkis.ads.wing.defense.pl, prio=0
+
+set script command upgrade: command=ANARKIS_CLEANSECTOR  upgrade=Carrier Command Software
+global script map: set: key=ANARKIS_CLEANSECTOR, class=M1, race=Player, script=anarkis.acc.wing.clearsector.pl, prio=0
+global script map: set: key=ANARKIS_CLEANSECTOR, class=M7, race=Player, script=anarkis.acc.wing.clearsector.pl, prio=0
+global script map: set: key=ANARKIS_CLEANSECTOR, class=TL, race=Player, script=anarkis.acc.wing.clearsector.pl, prio=0
+global script map: set: key=ANARKIS_CLEANSECTOR, class=TM, race=Player, script=anarkis.acc.wing.clearsector.pl, prio=0
+
+* Restore cmds if doing update
+if $update == [TRUE]
+= [THIS] -> call script anarkis.acc.upgrade.enable :
+= [THIS] -> call script anarkis.acc.ecs.register :
+if $ver == 255
+= [THIS] -> call script anarkis.acc.hotkey.install :
+end
+
+set global variable: name='anarkis.acc.plugin' value=$ver
+$msg = sprintf: pageid=$PageID textid=104, $ver, null, null, null, null
+send incoming message $msg to player: display it=[TRUE]
+end
+
+return null

--- a/tools/test_x3s.py
+++ b/tools/test_x3s.py
@@ -23,7 +23,7 @@ def run_fail(cmd: list[str]):
 if __name__ == '__main__':
   src_files = sorted((ROOT / 'src/scripts').glob('*.x3s'))
   good_files = sorted((ROOT / 'tools/fixtures/known_good').glob('*.x3s'))
-  fail_files = sorted(ROOT.glob('tools/fixtures/should_fail/**/*.x3s'))
+  fail_files = sorted((ROOT / 'tools/fixtures/should_fail').rglob('*.x3s'))
 
   run([sys.executable, 'tools/x3s_lint.py', *[str(p.relative_to(ROOT)) for p in src_files + good_files]])
   if fail_files:

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -1,438 +1,515 @@
 {
-  "patterns": [
-    {
-      "name": "load.text",
-      "regex": "^load text:\\s*id=(\\d+|\\$[A-Za-z0-9_.]+)$",
-      "examples": [
-        "load text: id=9055"
-      ]
-    },
-    {
-      "name": "al.register",
-      "regex": "^al engine:\\s*register script='[^']+'$",
-      "examples": [
-        "al engine: register script='al.plugin.slx'"
-      ]
-    },
-    {
-      "name": "al.description",
-      "regex": "^al engine:\\s*set plugin '[^']+' description to '.*'$",
-      "examples": [
-        "al engine: set plugin 'al.plugin.slx' description to 'SLX Station Logistics'"
-      ]
-    },
-    {
-      "name": "al.timer",
-      "regex": "^al engine:\\s*set plugin '[^']+' timer interval to \\d+\\s*s$",
-      "examples": [
-        "al engine: set plugin 'al.plugin.slx' timer interval to 30 s"
-      ]
-    },
-    {
-      "name": "stop.task",
-      "regex": "^\\[THIS]->stop task \\d+$",
-      "examples": [
-        "[THIS]->stop task 0"
-      ]
-    },
-    {
-      "name": "start.task",
-      "regex": "^start task \\d+\\s+with script='[^']+'\\s+on=\\[THIS\\]$",
-      "examples": [
-        "start task 123 with script='plugin.example' on=[THIS]"
-      ]
-    },
-    {
-      "name": "call.script",
-      "regex": "^=?\\s*\\[THIS]->\\s*call script '[^']+'( : .*)?$",
-      "examples": [
-        "= [THIS]-> call script 'plugin.config.addscript' : argument1=$txt"
-      ]
-    },
-    {
-      "name": "wait",
-      "regex": "^\\s*=?\\s*wait (\\d+|\\$[A-Za-z0-9_.]+)\\s*ms$",
-      "examples": [
-        "wait 1000 ms"
-      ]
-    },
-    {
-      "name": "set.global",
-      "regex": "^set global variable:\\s*name='[^']+'\\s*value=.*$",
-      "examples": [
-        "set global variable: name='g.slx.foo' value=$bar"
-      ]
-    },
-    {
-      "name": "return",
-      "regex": "^return (null|value .+)$",
-      "examples": [
-        "return null"
-      ]
-    },
-    {
-      "name": "write.log",
-      "regex": "^write to log file \\$[A-Za-z0-9_.]+\\s+append=\\[(TRUE|FALSE)\\]\\s+value=(\\$[A-Za-z0-9_.]+|'[^']+')$",
-      "examples": [
-        "write to log file $DebugID append=[FALSE] value=$txt"
-      ]
-    },
-    {
-      "name": "dec",
-      "regex": "^dec \\$[A-Za-z0-9_.]+(?:\\s*=\\s*)?$",
-      "examples": [
-        "dec $s ="
-      ]
-    },
-    {
-      "name": "remove.array.elem",
-      "regex": "^remove element from array \\$[A-Za-z0-9_.]+ at index \\$[A-Za-z0-9_.]+$",
-      "examples": [
-        "remove element from array $config.Array at index $s"
-      ]
-    },
-    {
-      "name": "skip.if",
-      "regex": "^skip if \\$[A-Za-z0-9_.]+(\\[[^\\]]+\\])?$",
-      "examples": [
-        "skip if $section"
-      ]
-    },
-    {
-      "name": "al.description.var",
-      "regex": "^al engine:\\s*set plugin \\$[A-Za-z0-9_.]+ description to \\$[A-Za-z0-9_.]+$",
-      "examples": [
-        "al engine: set plugin $al.PluginID description to $plugin.description"
-      ]
-    },
-    {
-      "name": "al.timer.var",
-      "regex": "^al engine:\\s*set plugin \\$[A-Za-z0-9_.]+ timer interval to \\d+\\s*s$",
-      "examples": [
-        "al engine: set plugin $al.PluginID timer interval to 25 s"
-      ]
-    },
-    {
-      "name": "al.timer.vars",
-      "regex": "^al engine:\\s*set plugin \\$[A-Za-z0-9_.]+ timer interval to \\$[A-Za-z0-9_.]+\\s*s$",
-      "examples": [
-        "al engine: set plugin $plugin.ID timer interval to $interval s"
-      ]
-    },
-    {
-      "name": "set.global.var",
-      "regex": "^set global variable:\\s*name=\\$[A-Za-z0-9_.]+\\s*value=\\$[A-Za-z0-9_.]+$",
-      "examples": [
-        "set global variable: name=$al.PluginID value=$al.Settings"
-      ]
-    },
-    {
-      "name": "return.var",
-      "regex": "^return \\$[A-Za-z0-9_.]+$",
-      "examples": [
-        "return $al.Ret"
-      ]
-    },
-    {
-      "name": "append.array",
-      "regex": "^append \\$[A-Za-z0-9_.]+ to array \\$[A-Za-z0-9_.]+$",
-      "examples": [
-        "append $station to array $exclude.array"
-      ]
-    },
-    {
-      "name": "gosub",
-      "regex": "^gosub [A-Za-z0-9_.]+:$",
-      "examples": [
-        "gosub Debug.Sub:"
-      ]
-    },
-    {
-      "name": "label",
-      "regex": "^[A-Za-z0-9_.]+:$",
-      "examples": [
-        "Debug.Sub:"
-      ]
-    },
-    {
-      "name": "endsub",
-      "regex": "^endsub$",
-      "examples": [
-        "endsub"
-      ]
-    },
-    {
-      "name": "obj.add.units",
-      "regex": "^\\s*=?\\s*\\$[A-Za-z0-9_.]+\\s*->\\s*add (\\$[A-Za-z0-9_.]+|[-]?\\d+) units of \\$[A-Za-z0-9_.]+$",
-      "examples": [
-        "= $station-> add $amount units of $ware"
-      ]
-    },
-    {
-      "name": "wait.random",
-      "regex": "^\\s*=?\\s*wait randomly from (\\d+|\\$[A-Za-z0-9_.]+) to (\\d+|\\$[A-Za-z0-9_.]+) ms$",
-      "examples": [
-        "= wait randomly from 500 to 1000 ms"
-      ]
-    },
-    {
-      "name": "al.register.noquote",
-      "regex": "^al engine:\\s*register script=[A-Za-z0-9_.]+$",
-      "examples": [
-        "al engine: register script=al.LI.FDN.event"
-      ]
-    },
-    {
-      "name": "inc",
-      "regex": "^inc \\$[A-Za-z0-9_.]+(?:\\s*=\\s*)?$",
-      "examples": [
-        "inc $sector.count ="
-      ]
-    },
-    {
-      "name": "set.global.var.null",
-      "regex": "^set global variable:\\s*name=\\$[A-Za-z0-9_.]+\\s*value=null$",
-      "examples": [
-        "set global variable: name=$var value=null"
-      ]
-    },
-    {
-      "name": "menu.info",
-      "regex": "^add custom menu info line to array \\$[A-Za-z0-9_.]+: text=(\\$[A-Za-z0-9_.]+|'[^']*')$",
-      "examples": [
-        "add custom menu info line to array $menu: text=$txt"
-      ]
-    },
-    {
-      "name": "menu.heading",
-      "regex": "^add custom menu heading to array \\$[A-Za-z0-9_.]+: title=(\\$[A-Za-z0-9_.]+|'[^']*')$",
-      "examples": [
-        "add custom menu heading to array $menu: title=$txt"
-      ]
-    },
-    {
-      "name": "menu.item",
-      "regex": "^add custom menu item to array \\$[A-Za-z0-9_.]+: text=(\\$[A-Za-z0-9_.]+|'[^']*') returnvalue=(\\$[A-Za-z0-9_.]+|'[^']*'|null)$",
-      "examples": [
-        "add custom menu item to array $menu: text=$txt returnvalue=$return.array"
-      ]
-    },
-    {
-      "name": "menu.section",
-      "regex": "^add section to custom menu: \\$[A-Za-z0-9_.]+$",
-      "examples": [
-        "add section to custom menu: $menu"
-      ]
-    },
-    {
-      "name": "menu.group.start",
-      "regex": "^add new grouping to menu: \\$[A-Za-z0-9_.]+, text=(\\$[A-Za-z0-9_.]+|'[^']*'), open=\\$[A-Za-z0-9_.]+$",
-      "examples": [
-        "add new grouping to menu: $menu, text=$txt, open=$check"
-      ]
-    },
-    {
-      "name": "menu.group.end",
-      "regex": "^add end grouping to menu: \\$[A-Za-z0-9_.]+$",
-      "examples": [
-        "add end grouping to menu: $menu"
-      ]
-    },
-    {
-      "name": "menu.nonselect",
-      "regex": "^add non selectable menu item: \\$[A-Za-z0-9_.]+, text=(\\$[A-Za-z0-9_.]+|'[^']*')$",
-      "examples": [
-        "add non selectable menu item: $menu, text=$temp.array"
-      ]
-    },
-    {
-      "name": "display.subtitle",
-      "regex": "^display subtitle text: text=\\$[A-Za-z0-9_.]+ duration=\\d+\\s*ms$",
-      "examples": [
-        "display subtitle text: text=$txt duration=2000 ms"
-      ]
-    },
-    {
-      "name": "menu.open",
-      "regex": "^\\s*=?\\s*open custom menu: title=\\$[A-Za-z0-9_.]+ description=(\\$[A-Za-z0-9_.]+|null) option array=\\$[A-Za-z0-9_.]+$",
-      "examples": [
-        "open custom menu: title=$txt description=null option array=$menu"
-      ]
-    },
-    {
-      "name": "menu.open.info",
-      "regex": "^\\s*=?\\s*open custom info menu: title=\\$[A-Za-z0-9_.]+ description=(\\$[A-Za-z0-9_.]+|null) option array=\\$[A-Za-z0-9_.]+(?: maxoptions=\\d+)?$",
-      "examples": [
-        "open custom info menu: title=$txt description=null option array=$menu maxoptions=2"
-      ]
-    },
-    {
-      "name": "skip.if.eq",
-      "regex": "^skip if \\$[A-Za-z0-9_.]+ == \\d+$",
-      "examples": [
-        "skip if $open.menu == 1"
-      ]
-    },
-    {
-      "name": "break",
-      "regex": "^break$",
-      "examples": [
-        "break"
-      ]
-    },
-    {
-      "name": "continue",
-      "regex": "^continue$",
-      "examples": [
-        "continue"
-      ]
-    },
-    {
-      "name": "do.if",
-      "regex": "^do if .+$",
-      "examples": [
-        "do if $Config[$Config.Debug.Enabled]"
-      ]
-    },
-    {
-      "name": "resize.array",
-      "regex": "^resize array \\$[A-Za-z0-9_.]+ to (\\d+|\\$[A-Za-z0-9_.]+)$",
-      "examples": [
-        "resize array $State to 30"
-      ]
-    },
-    {
-      "name": "append.const",
-      "regex": "^append (\\d+|\\[[A-Za-z0-9_ '()]+\\]|\\{[^}]+\\}) to array \\$[A-Za-z0-9_.]+$",
-      "examples": [
-        "append 0 to array $Mins"
-      ]
-    },
-    {
-      "name": "copy.array",
-      "regex": "^copy array \\$[A-Za-z0-9_.]+ index 0 \\.{3} \\$[A-Za-z0-9_.]+\\.Length into array \\$[A-Za-z0-9_.]+ at index (0|\\$[A-Za-z0-9_.]+)$",
-      "examples": [
-        "copy array $Arg2 index 0 ... $Arg2.Length into array $rc at index $Arg1.Length"
-      ]
-    },
-    {
-      "name": "return.int",
-      "regex": "^return -?\\d+$",
-      "examples": [
-        "return 0"
-      ]
-    },
-    {
-      "name": "skip.if.any",
-      "regex": "^skip if .+$",
-      "examples": [
-        "skip if $rc >= 0"
-      ]
-    },
-    {
-      "name": "write.log.printf",
-      "regex": "^write to log file \\$[A-Za-z0-9_.]+ append=\\d+ printf: .+$",
-      "examples": [
-        "write to log file $PageId append=1 printf: fmt='New install', null, null"
-      ]
-    },
-    {
-      "name": "write.logbook.printf",
-      "regex": "^write to player logbook: printf: .+$",
-      "examples": [
-        "write to player logbook: printf: pageid=$PageId textid=$Id.Logbook.Installed, null, null"
-      ]
-    },
-    {
-      "name": "set.command.upgrade",
-      "regex": "^set script command upgrade: command=\\[[A-Za-z0-9_ ]+\\]\\s+upgrade=\\[(TRUE|FALSE)\\]$",
-      "examples": [
-        "set script command upgrade: command=[GLEN_OK_TRADE]  upgrade=[TRUE]"
-      ]
-    },
-    {
-      "name": "global.script.map",
-      "regex": "^global script map: set: key=\\[[A-Za-z0-9_ ]+\\], class=\\[[A-Za-z0-9_ ]+\\], race=\\[[A-Za-z0-9_ ]+\\], script=[A-Za-z0-9_.]+, prio=\\d+$",
-      "examples": [
-        "global script map: set: key=[GLEN_OK_TRADE], class=[Moveable Ship], race=[Player], script=glen.trade.ok.cmd, prio=0"
-      ]
-    },
-    {
-      "name": "set.command.preload",
-      "regex": "^set ship command preload script: command=\\[[A-Za-z0-9_ ]+\\] script=[A-Za-z0-9_.]+$",
-      "examples": [
-        "set ship command preload script: command=[GLEN_OK_TRADE] script=glen.trade.ok.menu"
-      ]
-    },
-    {
-      "name": "add.money",
-      "regex": "^add money to player: \\$[A-Za-z0-9_.]+$",
-      "examples": [
-        "add money to player: $Cost"
-      ]
-    },
-    {
-      "name": "set.script.command",
-      "regex": "^set script command: \\[[A-Za-z0-9_ ]+\\]$",
-      "examples": [
-        "set script command: [GLEN_OK_TRADE]"
-      ]
-    },
-    {
-      "name": "send.message",
-      "regex": "^send incoming message \\$[A-Za-z0-9_.]+ to player: display it=\\d+$",
-      "examples": [
-        "send incoming message $Msg to player: display it=0"
-      ]
-    },
-    {
-      "name": "speak.text",
-      "regex": "^=?\\s*speak text: page=\\d+ id=\\d+ priority=\\d+$",
-      "examples": [
-        "= speak text: page=13 id=1276 priority=0"
-      ]
-    },
-    {
-      "name": "speak.array",
-      "regex": "^=?\\s*speak array: \\$[A-Za-z0-9_.]+ prio=\\d+$",
-      "examples": [
-        "= speak array: $d prio=0"
-      ]
-    },
-    {
-      "name": "play.sample",
-      "regex": "^play sample \\d+$",
-      "examples": [
-        "play sample 972"
-      ]
-    },
-    {
-      "name": "send.message.literal",
-      "regex": "^send incoming message '[^']+' to player: display it=\\[(TRUE|FALSE)\\]$",
-      "examples": [
-        "send incoming message 'ECS Not Detected - Comms with ships and stations will be disabled !' to player: display it=[TRUE]"
-      ]
-    },
-    {
-      "name": "return.bool",
-      "regex": "^return \\[(TRUE|FALSE)\\]$",
-      "examples": [
-        "return [TRUE]"
-      ]
-    },
-    {
-      "name": "start.speak.text",
-      "regex": "^START speak text: page=\\d+ id=\\d+ priority=\\d+$",
-      "examples": [
-        "START speak text: page=13 id=131 priority=0"
-      ]
-    },
-    {
-      "name": "unregister.hotkey",
-      "regex": "^unregister hotkey \\$[A-Za-z0-9_.]+$",
-      "examples": [
-        "unregister hotkey $hotkey.id"
-      ]
-    }
-  ]
+    "patterns": [
+        {
+            "name": "load.text",
+            "regex": "^load text:\\s*id=(\\d+|\\$[A-Za-z0-9_.]+)$",
+            "examples": [
+                "load text: id=9055"
+            ]
+        },
+        {
+            "name": "al.register",
+            "regex": "^al engine:\\s*register script='[^']+'$",
+            "examples": [
+                "al engine: register script='al.plugin.slx'"
+            ]
+        },
+        {
+            "name": "al.description",
+            "regex": "^al engine:\\s*set plugin '[^']+' description to '.*'$",
+            "examples": [
+                "al engine: set plugin 'al.plugin.slx' description to 'SLX Station Logistics'"
+            ]
+        },
+        {
+            "name": "al.timer",
+            "regex": "^al engine:\\s*set plugin '[^']+' timer interval to \\d+\\s*s$",
+            "examples": [
+                "al engine: set plugin 'al.plugin.slx' timer interval to 30 s"
+            ]
+        },
+        {
+            "name": "stop.task",
+            "regex": "^\\[THIS]->stop task \\d+$",
+            "examples": [
+                "[THIS]->stop task 0"
+            ]
+        },
+        {
+            "name": "start.task",
+            "regex": "^start task \\d+\\s+with script='[^']+'\\s+on=\\[THIS\\]$",
+            "examples": [
+                "start task 123 with script='plugin.example' on=[THIS]"
+            ]
+        },
+        {
+            "name": "call.script",
+            "regex": "^=?\\s*\\[THIS]->\\s*call script '[^']+'( : .*)?$",
+            "examples": [
+                "= [THIS]-> call script 'plugin.config.addscript' : argument1=$txt"
+            ]
+        },
+        {
+            "name": "wait",
+            "regex": "^\\s*=?\\s*wait (\\d+|\\$[A-Za-z0-9_.]+)\\s*ms$",
+            "examples": [
+                "wait 1000 ms"
+            ]
+        },
+        {
+            "name": "set.global",
+            "regex": "^set global variable:\\s*name='[^']+'\\s*value=.*$",
+            "examples": [
+                "set global variable: name='g.slx.foo' value=$bar"
+            ]
+        },
+        {
+            "name": "return",
+            "regex": "^return (null|value .+)$",
+            "examples": [
+                "return null"
+            ]
+        },
+        {
+            "name": "write.log",
+            "regex": "^write to log file \\$[A-Za-z0-9_.]+\\s+append=\\[(TRUE|FALSE)\\]\\s+value=(\\$[A-Za-z0-9_.]+|'[^']+')$",
+            "examples": [
+                "write to log file $DebugID append=[FALSE] value=$txt"
+            ]
+        },
+        {
+            "name": "dec",
+            "regex": "^dec \\$[A-Za-z0-9_.]+(?:\\s*=\\s*)?$",
+            "examples": [
+                "dec $s ="
+            ]
+        },
+        {
+            "name": "remove.array.elem",
+            "regex": "^remove element from array \\$[A-Za-z0-9_.]+ at index \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "remove element from array $config.Array at index $s"
+            ]
+        },
+        {
+            "name": "skip.if",
+            "regex": "^skip if \\$[A-Za-z0-9_.]+(\\[[^\\]]+\\])?$",
+            "examples": [
+                "skip if $section"
+            ]
+        },
+        {
+            "name": "al.description.var",
+            "regex": "^al engine:\\s*set plugin \\$[A-Za-z0-9_.]+ description to \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "al engine: set plugin $al.PluginID description to $plugin.description"
+            ]
+        },
+        {
+            "name": "al.timer.var",
+            "regex": "^al engine:\\s*set plugin \\$[A-Za-z0-9_.]+ timer interval to \\d+\\s*s$",
+            "examples": [
+                "al engine: set plugin $al.PluginID timer interval to 25 s"
+            ]
+        },
+        {
+            "name": "al.timer.vars",
+            "regex": "^al engine:\\s*set plugin \\$[A-Za-z0-9_.]+ timer interval to \\$[A-Za-z0-9_.]+\\s*s$",
+            "examples": [
+                "al engine: set plugin $plugin.ID timer interval to $interval s"
+            ]
+        },
+        {
+            "name": "set.global.var",
+            "regex": "^set global variable:\\s*name=\\$[A-Za-z0-9_.]+\\s*value=\\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "set global variable: name=$al.PluginID value=$al.Settings"
+            ]
+        },
+        {
+            "name": "return.var",
+            "regex": "^return \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "return $al.Ret"
+            ]
+        },
+        {
+            "name": "append.array",
+            "regex": "^append \\$[A-Za-z0-9_.]+ to array \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "append $station to array $exclude.array"
+            ]
+        },
+        {
+            "name": "gosub",
+            "regex": "^gosub [A-Za-z0-9_.]+:$",
+            "examples": [
+                "gosub Debug.Sub:"
+            ]
+        },
+        {
+            "name": "label",
+            "regex": "^[A-Za-z0-9_.]+:$",
+            "examples": [
+                "Debug.Sub:"
+            ]
+        },
+        {
+            "name": "endsub",
+            "regex": "^endsub$",
+            "examples": [
+                "endsub"
+            ]
+        },
+        {
+            "name": "obj.add.units",
+            "regex": "^\\s*=?\\s*\\$[A-Za-z0-9_.]+\\s*->\\s*add (\\$[A-Za-z0-9_.]+|[-]?\\d+) units of \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "= $station-> add $amount units of $ware"
+            ]
+        },
+        {
+            "name": "wait.random",
+            "regex": "^\\s*=?\\s*wait randomly from (\\d+|\\$[A-Za-z0-9_.]+) to (\\d+|\\$[A-Za-z0-9_.]+) ms$",
+            "examples": [
+                "= wait randomly from 500 to 1000 ms"
+            ]
+        },
+        {
+            "name": "al.register.noquote",
+            "regex": "^al engine:\\s*register script=[A-Za-z0-9_.]+$",
+            "examples": [
+                "al engine: register script=al.LI.FDN.event"
+            ]
+        },
+        {
+            "name": "inc",
+            "regex": "^inc \\$[A-Za-z0-9_.]+(?:\\s*=\\s*)?$",
+            "examples": [
+                "inc $sector.count ="
+            ]
+        },
+        {
+            "name": "set.global.var.null",
+            "regex": "^set global variable:\\s*name=\\$[A-Za-z0-9_.]+\\s*value=null$",
+            "examples": [
+                "set global variable: name=$var value=null"
+            ]
+        },
+        {
+            "name": "menu.info",
+            "regex": "^add custom menu info line to array \\$[A-Za-z0-9_.]+: text=(\\$[A-Za-z0-9_.]+|'[^']*')$",
+            "examples": [
+                "add custom menu info line to array $menu: text=$txt"
+            ]
+        },
+        {
+            "name": "menu.heading",
+            "regex": "^add custom menu heading to array \\$[A-Za-z0-9_.]+: title=(\\$[A-Za-z0-9_.]+|'[^']*')$",
+            "examples": [
+                "add custom menu heading to array $menu: title=$txt"
+            ]
+        },
+        {
+            "name": "menu.item",
+            "regex": "^add custom menu item to array \\$[A-Za-z0-9_.]+: text=(\\$[A-Za-z0-9_.]+|'[^']*') returnvalue=(\\$[A-Za-z0-9_.]+|'[^']*'|null)$",
+            "examples": [
+                "add custom menu item to array $menu: text=$txt returnvalue=$return.array"
+            ]
+        },
+        {
+            "name": "menu.section",
+            "regex": "^add section to custom menu: \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "add section to custom menu: $menu"
+            ]
+        },
+        {
+            "name": "menu.group.start",
+            "regex": "^add new grouping to menu: \\$[A-Za-z0-9_.]+, text=(\\$[A-Za-z0-9_.]+|'[^']*'), open=\\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "add new grouping to menu: $menu, text=$txt, open=$check"
+            ]
+        },
+        {
+            "name": "menu.group.end",
+            "regex": "^add end grouping to menu: \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "add end grouping to menu: $menu"
+            ]
+        },
+        {
+            "name": "menu.nonselect",
+            "regex": "^add non selectable menu item: \\$[A-Za-z0-9_.]+, text=(\\$[A-Za-z0-9_.]+|'[^']*')$",
+            "examples": [
+                "add non selectable menu item: $menu, text=$temp.array"
+            ]
+        },
+        {
+            "name": "display.subtitle",
+            "regex": "^display subtitle text: text=\\$[A-Za-z0-9_.]+ duration=\\d+\\s*ms$",
+            "examples": [
+                "display subtitle text: text=$txt duration=2000 ms"
+            ]
+        },
+        {
+            "name": "menu.open",
+            "regex": "^\\s*=?\\s*open custom menu: title=\\$[A-Za-z0-9_.]+ description=(\\$[A-Za-z0-9_.]+|null) option array=\\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "open custom menu: title=$txt description=null option array=$menu"
+            ]
+        },
+        {
+            "name": "menu.open.info",
+            "regex": "^\\s*=?\\s*open custom info menu: title=\\$[A-Za-z0-9_.]+ description=(\\$[A-Za-z0-9_.]+|null) option array=\\$[A-Za-z0-9_.]+(?: maxoptions=\\d+)?$",
+            "examples": [
+                "open custom info menu: title=$txt description=null option array=$menu maxoptions=2"
+            ]
+        },
+        {
+            "name": "skip.if.eq",
+            "regex": "^skip if \\$[A-Za-z0-9_.]+ == \\d+$",
+            "examples": [
+                "skip if $open.menu == 1"
+            ]
+        },
+        {
+            "name": "break",
+            "regex": "^break$",
+            "examples": [
+                "break"
+            ]
+        },
+        {
+            "name": "continue",
+            "regex": "^continue$",
+            "examples": [
+                "continue"
+            ]
+        },
+        {
+            "name": "do.if",
+            "regex": "^do if .+$",
+            "examples": [
+                "do if $Config[$Config.Debug.Enabled]"
+            ]
+        },
+        {
+            "name": "resize.array",
+            "regex": "^resize array \\$[A-Za-z0-9_.]+ to (\\d+|\\$[A-Za-z0-9_.]+)$",
+            "examples": [
+                "resize array $State to 30"
+            ]
+        },
+        {
+            "name": "append.const",
+            "regex": "^append (\\d+|\\[[A-Za-z0-9_ '()]+\\]|\\{[^}]+\\}) to array \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "append 0 to array $Mins"
+            ]
+        },
+        {
+            "name": "copy.array",
+            "regex": "^copy array \\$[A-Za-z0-9_.]+ index 0 \\.{3} \\$[A-Za-z0-9_.]+\\.Length into array \\$[A-Za-z0-9_.]+ at index (0|\\$[A-Za-z0-9_.]+)$",
+            "examples": [
+                "copy array $Arg2 index 0 ... $Arg2.Length into array $rc at index $Arg1.Length"
+            ]
+        },
+        {
+            "name": "return.int",
+            "regex": "^return -?\\d+$",
+            "examples": [
+                "return 0"
+            ]
+        },
+        {
+            "name": "skip.if.any",
+            "regex": "^skip if .+$",
+            "examples": [
+                "skip if $rc >= 0"
+            ]
+        },
+        {
+            "name": "write.log.printf",
+            "regex": "^write to log file \\$[A-Za-z0-9_.]+ append=\\d+ printf: .+$",
+            "examples": [
+                "write to log file $PageId append=1 printf: fmt='New install', null, null"
+            ]
+        },
+        {
+            "name": "write.logbook.printf",
+            "regex": "^write to player logbook: printf: .+$",
+            "examples": [
+                "write to player logbook: printf: pageid=$PageId textid=$Id.Logbook.Installed, null, null"
+            ]
+        },
+        {
+            "name": "set.command.upgrade",
+            "regex": "^set script command upgrade: command=\\[[A-Za-z0-9_ ]+\\]\\s+upgrade=\\[(TRUE|FALSE)\\]$",
+            "examples": [
+                "set script command upgrade: command=[GLEN_OK_TRADE]  upgrade=[TRUE]"
+            ]
+        },
+        {
+            "name": "global.script.map",
+            "regex": "^global script map: set: key=\\[[A-Za-z0-9_ ]+\\], class=\\[[A-Za-z0-9_ ]+\\], race=\\[[A-Za-z0-9_ ]+\\], script=[A-Za-z0-9_.]+, prio=\\d+$",
+            "examples": [
+                "global script map: set: key=[GLEN_OK_TRADE], class=[Moveable Ship], race=[Player], script=glen.trade.ok.cmd, prio=0"
+            ]
+        },
+        {
+            "name": "set.command.preload",
+            "regex": "^set ship command preload script: command=\\[[A-Za-z0-9_ ]+\\] script=[A-Za-z0-9_.]+$",
+            "examples": [
+                "set ship command preload script: command=[GLEN_OK_TRADE] script=glen.trade.ok.menu"
+            ]
+        },
+        {
+            "name": "add.money",
+            "regex": "^add money to player: \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "add money to player: $Cost"
+            ]
+        },
+        {
+            "name": "set.script.command",
+            "regex": "^set script command: \\[[A-Za-z0-9_ ]+\\]$",
+            "examples": [
+                "set script command: [GLEN_OK_TRADE]"
+            ]
+        },
+        {
+            "name": "send.message",
+            "regex": "^send incoming message \\$[A-Za-z0-9_.]+ to player: display it=\\d+$",
+            "examples": [
+                "send incoming message $Msg to player: display it=0"
+            ]
+        },
+        {
+            "name": "speak.text",
+            "regex": "^=?\\s*speak text: page=\\d+ id=\\d+ priority=\\d+$",
+            "examples": [
+                "= speak text: page=13 id=1276 priority=0"
+            ]
+        },
+        {
+            "name": "speak.array",
+            "regex": "^=?\\s*speak array: \\$[A-Za-z0-9_.]+ prio=\\d+$",
+            "examples": [
+                "= speak array: $d prio=0"
+            ]
+        },
+        {
+            "name": "play.sample",
+            "regex": "^play sample \\d+$",
+            "examples": [
+                "play sample 972"
+            ]
+        },
+        {
+            "name": "send.message.literal",
+            "regex": "^send incoming message '[^']+' to player: display it=\\[(TRUE|FALSE)\\]$",
+            "examples": [
+                "send incoming message 'ECS Not Detected - Comms with ships and stations will be disabled !' to player: display it=[TRUE]"
+            ]
+        },
+        {
+            "name": "return.bool",
+            "regex": "^return \\[(TRUE|FALSE)\\]$",
+            "examples": [
+                "return [TRUE]"
+            ]
+        },
+        {
+            "name": "start.speak.text",
+            "regex": "^START speak text: page=\\d+ id=\\d+ priority=\\d+$",
+            "examples": [
+                "START speak text: page=13 id=131 priority=0"
+            ]
+        },
+        {
+            "name": "unregister.hotkey",
+            "regex": "^unregister hotkey \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "unregister hotkey $hotkey.id"
+            ]
+        },
+        {
+            "name": "gosub.label",
+            "regex": "^gosub\\s+[A-Za-z0-9_.]+$",
+            "examples": [
+                "gosub dodock"
+            ]
+        },
+        {
+            "name": "send.message.var.bool",
+            "regex": "^send incoming message\\s+\\$[A-Za-z0-9_.]+\\s+to player: display it=\\[(TRUE|FALSE)\\]$",
+            "examples": [
+                "send incoming message $msg to player: display it=[TRUE]"
+            ]
+        },
+        {
+            "name": "set.command.upgrade.software",
+            "regex": "^set script command upgrade: command=[A-Za-z0-9_]+\\s+upgrade=Carrier Command Software$",
+            "examples": [
+                "set script command upgrade: command=ANARKIS_DOCKALL  upgrade=Carrier Command Software"
+            ]
+        },
+        {
+            "name": "set.command.upgrade.bool",
+            "regex": "^set script command upgrade: command=[A-Za-z0-9_]+\\s+upgrade=\\[(TRUE|FALSE)\\]$",
+            "examples": [
+                "set script command upgrade: command=ANARKIS_STATIONDEFENSE  upgrade=[TRUE]"
+            ]
+        },
+        {
+            "name": "global.script.map.simple",
+            "regex": "^global script map: set: key=[A-Za-z0-9_]+, class=[A-Za-z0-9]+, race=Player, script=[A-Za-z0-9_.]+, prio=\\d+$",
+            "examples": [
+                "global script map: set: key=ANARKIS_DOCKALL, class=M1, race=Player, script=anarkis.acc.cmd.dock.all.pl, prio=0"
+            ]
+        },
+        {
+            "name": "goto.label",
+            "regex": "^goto label [A-Za-z0-9_.]+$",
+            "examples": [
+                "goto label exit"
+            ]
+        },
+        {
+            "name": "add.money.literal",
+            "regex": "^add money to player: -?\\d+$",
+            "examples": [
+                "add money to player: -50000"
+            ]
+        },
+        {
+            "name": "menu.item.num",
+            "regex": "^add custom menu item to array\\s+\\$[A-Za-z0-9_.]+:\\s*text=\\$[A-Za-z0-9_.]+\\s+returnvalue=-?\\d+$",
+            "examples": [
+                "add custom menu item to array $menu: text=$dialog.yes returnvalue=1"
+            ]
+        },
+        {
+            "name": "insert.array",
+            "regex": "^insert\\s+\\$[A-Za-z0-9_.]+\\s+into array\\s+\\$[A-Za-z0-9_.]+\\s+at index\\s+-?\\d+$",
+            "examples": [
+                "insert $my.news into array $news.list at index 0"
+            ]
+        },
+        {
+            "name": "copy.array.literal",
+            "regex": "^copy array\\s+\\$[A-Za-z0-9_.]+\\s+index\\s+\\d+\\s+\\.\\.\\.\\s+\\d+\\s+into array\\s+\\$[A-Za-z0-9_.]+\\s+at index\\s+\\d+$",
+            "examples": [
+                "copy array $setup index 0 ... 6 into array $config.to.update at index 0"
+            ]
+        },
+        {
+            "name": "start.command.args",
+            "regex": "^START\\s+\\$[A-Za-z0-9_.]+\\s+->\\s+command\\s+\\$[A-Za-z0-9_.]+\\s+:\\s+arg1=\\$[A-Za-z0-9_.]+,\\s+arg2=\\$[A-Za-z0-9_.]+,\\s+arg3=\\$[A-Za-z0-9_.]+,\\s+arg4=(\\$[A-Za-z0-9_.]+|null)$",
+            "examples": [
+                "START $new.leader -> command $cmd.name : arg1=$arg1, arg2=$arg2, arg3=$arg3, arg4=null"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
## Plan
- Import 20 additional ADS scripts as lint fixtures and document them
- Expand x3s regex allowlist to cover newly seen statements while keeping control-flow and wait rules intact
- Update docs and tests to exercise new fixtures and patterns

## Changes
- Added 20 ADS scripts under `tools/fixtures/known_good` and listed them in `README.md`
- Extended `tools/x3s_rules.json` with patterns for gosub labels, send-message booleans, command upgrades, global script map constants, goto labels, numeric menu return values, array insert/copy forms, start-command args, and more
- Updated `tools/test_x3s.py` to lint new fixtures
- Documented new statements in `docs/x3s-language.md`

## Test Results
- `python tools/test_x3s.py`

## Pattern List
- gosub.label
- send.message.var.bool
- set.command.upgrade.software
- set.command.upgrade.bool
- global.script.map.simple
- goto.label
- add.money.literal
- menu.item.num
- insert.array
- copy.array.literal
- start.command.args

## Safety Checks
- Control-flow stack, wait-in-while, and setup load-text checks remain enforced

------
https://chatgpt.com/codex/tasks/task_e_68c68d96ae388326b44974ef89a79312