### PR TITLE
Learn from known-good .x3s and update our linter (no XML build)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 SLX is a lightweight station-to-station logistics mod for X3TC: Terran Conflict. Moves wares between enrolled player stations (same- or cross-sector) — no NPC trade or scanning — via per-ware roles (Producer, Consumer, Store) with Min/Max/Chunk thresholds and a priority-based transfer loop.
 
 ## ADS Sample Files
-The linter is validated against these 60 known-good ADS scripts:
+The linter is validated against these 80 known-good ADS scripts:
 
 - !init.anarkis.modified.x3s
 - al.plugin.sk.ecs.x3s
@@ -64,3 +64,23 @@ The linter is validated against these 60 known-good ADS scripts:
 - anarkis.lib.custowned.init.x3s
 - anarkis.lib.vis.task.blink.x3s
 - anarkis.acc.task.autoname.x3s
+- anarkis.acc.is.compatible.x3s
+- anarkis.acc.lib.applyallowned.x3s
+- anarkis.acc.lib.arr.remove.ads.x3s
+- anarkis.acc.lib.dockads.x3s
+- anarkis.acc.lib.get.adsonly.from.x3s
+- anarkis.acc.lib.get.adsonly.x3s
+- anarkis.acc.lib.get.enemies.x3s
+- anarkis.acc.lib.get.flyads.x3s
+- anarkis.acc.lib.get.leader.big.x3s
+- anarkis.acc.lib.get.lonely.x3s
+- anarkis.acc.lib.givetarget.x3s
+- anarkis.acc.lib.isadsactive.x3s
+- anarkis.acc.lib.name.load.x3s
+- anarkis.acc.lib.name.save.x3s
+- anarkis.acc.repairshields.single.x3s
+- anarkis.acc.repairshields.x3s
+- anarkis.acc.setup.attackmode.x3s
+- anarkis.acc.setup.autocarrier.x3s
+- anarkis.acc.setup.buywares.x3s
+- anarkis.acc.setup.copy.x3s

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -73,6 +73,10 @@
 - **copy.array.literal**: `copy array $setup index 0 ... 6 into array $config.to.update at index 0`
 - **start.command.args**: `START $new.leader -> command $cmd.name : arg1=$arg1, arg2=$arg2, arg3=$arg3, arg4=null`
 
+### New Statements Recognized
+- **append.class**: `append M2 to array $class.list`
+- **menu.value.selection**: `add value selection to menu: $menu, text=$st, value array=$sel.threat, default=$sel.threat.selection, return id=$sel.threat.id`
+
 ## Fixtures
 
 Known-good mod fixtures live under `tools/fixtures/known_good/<mod_name>`. Each mod

--- a/tools/fixtures/known_good/anarkis.acc.is.compatible.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.is.compatible.x3s
@@ -1,0 +1,21 @@
+#name: anarkis.acc.is.compatible
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.is.compatible.xml
+
+$v1 = $select -> get object class
+
+skip if not $select -> is of class Station
+return [TRUE]
+
+if not ( $v1 == M1 OR $v1 == M7 OR $v1 == TL OR $v1 == TM )
+return [FALSE]
+end
+
+skip if $select -> get true amount of ware Carrier Command Software  in cargo bay
+return [FALSE]
+
+skip if $select -> get dock bay size
+return [FALSE]
+
+return [TRUE]

--- a/tools/fixtures/known_good/anarkis.acc.lib.applyallowned.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.lib.applyallowned.x3s
@@ -1,0 +1,15 @@
+#name: anarkis.acc.lib.applyallowned
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.applyallowned.xml
+
+$dock.list = [THIS] -> get owned ships: class/type=Moveable Ship
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+skip if not $curr.ship -> get local variable: name='anarkis.skipme'
+continue
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=[TRUE]
+end
+return null

--- a/tools/fixtures/known_good/anarkis.acc.lib.arr.remove.ads.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.lib.arr.remove.ads.x3s
@@ -1,0 +1,18 @@
+#name: anarkis.acc.lib.arr.remove.ads
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.arr.remove.ads.xml
+
+* ===========================================
+* Remove ADS ships from an array of ships
+* ===========================================
+$null = null
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+skip if not $select -> get local variable: name='anarkis.acc.ship'
+remove element from array $arr at index $cnt
+end
+
+return $arr

--- a/tools/fixtures/known_good/anarkis.acc.lib.dockads.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.lib.dockads.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.acc.lib.dockads
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.dockads.xml
+
+
+[THIS] -> start task 895 with script anarkis.lib.dockall.adsonly and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+= wait 1000 ms
+while [THIS] -> is script anarkis.lib.dockall.adsonly on stack of task=895
+= wait 1000 ms
+end
+return null

--- a/tools/fixtures/known_good/anarkis.acc.lib.get.adsonly.from.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.lib.get.adsonly.from.x3s
@@ -1,0 +1,47 @@
+#name: anarkis.acc.lib.get.adsonly.from
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.get.adsonly.from.xml
+
+* ===========================================
+* Improved to handle NPC carriers too
+* ===========================================
+$null = null
+$isship = $target -> is of class Moveable Ship
+$owner = $target -> get owner race
+
+$arr = null
+if $isship == [TRUE] AND $owner != Player
+$ini = [THIS] -> call script anarkis.lib.custowned.getarray.f :  from=$target
+if $ini
+$cnt =  size of array $ini
+dec $cnt =
+$arr =  clone array $ini : index 0 ... $cnt
+end
+end
+
+skip if $arr
+$arr = $target -> get owned ships: class/type=Moveable Ship
+
+
+$cnt =  size of array $arr
+
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+if $select -> is of class Freighter
+remove element from array $arr at index $cnt
+continue
+end
+
+if $select -> get local variable: name='anarkis.acc.skipme'
+remove element from array $arr at index $cnt
+continue
+end
+if not $select -> get local variable: name='anarkis.acc.ship'
+remove element from array $arr at index $cnt
+continue
+end
+end
+
+return $arr

--- a/tools/fixtures/known_good/anarkis.acc.lib.get.adsonly.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.lib.get.adsonly.x3s
@@ -1,0 +1,44 @@
+#name: anarkis.acc.lib.get.adsonly
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.get.adsonly.xml
+
+* ===========================================
+* Improved to handle NPC carriers too
+* ===========================================
+$null = null
+$isship = [THIS] -> is of class Moveable Ship
+
+$arr = null
+if $isship == [TRUE] AND [OWNER] != Player
+$ini = [THIS] -> call script anarkis.lib.custowned.getarray :
+if $ini
+$cnt =  size of array $ini
+dec $cnt =
+$arr =  clone array $ini : index 0 ... $cnt
+end
+end
+
+skip if $arr
+$arr = [THIS] -> get owned ships: class/type=Moveable Ship
+
+$cnt =  size of array $arr
+
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+if $select -> is of class Freighter
+remove element from array $arr at index $cnt
+continue
+end
+if $select -> get local variable: name='anarkis.acc.skipme'
+remove element from array $arr at index $cnt
+continue
+end
+if not $select -> get local variable: name='anarkis.acc.ship'
+remove element from array $arr at index $cnt
+continue
+end
+end
+
+return $arr

--- a/tools/fixtures/known_good/anarkis.acc.lib.get.enemies.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.lib.get.enemies.x3s
@@ -1,0 +1,58 @@
+#name: anarkis.acc.lib.get.enemies
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.get.enemies.xml
+
+$class.list =  array alloc: size=0
+
+append M2 to array $class.list
+append M1 to array $class.list
+append M7 to array $class.list
+append TL to array $class.list
+append M6 to array $class.list
+append M8 to array $class.list
+append M3 to array $class.list
+append M4 to array $class.list
+append M5 to array $class.list
+append TM to array $class.list
+append TP to array $class.list
+append TS to array $class.list
+
+$class.count =  size of array $class.list
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$setup.array = $refobject -> get local variable: name='anarkis.acc.setup'
+$owner = $refobject -> get owner race
+if $owner == Player
+$ignore.list = $gl.setup[7]
+else
+$ignore.list = $setup.array[16]
+end
+$radar.range = $setup.array[1]
+$flags = [Find.Enemy] | [Find.Multiple]
+
+$final.list =  array alloc: size=0
+
+
+while $class.count
+dec $class.count =
+$select.class = $class.list[$class.count]
+$ship.list =  find ship: sector=$sector class or type=$select.class race=null flags=$flags refobj=$refobject maxdist=$radar.range maxnum=50 refpos=null
+$ship.count =  size of array $ship.list
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$owner = $ship -> get owner race
+$class = $ship -> get object class
+skip if not  find $owner in array: $ignore.list
+continue
+skip if $ship -> is $refobject a enemy
+continue
+skip if not $ship -> is civilian ship
+continue
+append $ship to array $final.list
+end
+end
+
+
+return $final.list

--- a/tools/fixtures/known_good/anarkis.acc.lib.get.flyads.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.lib.get.flyads.x3s
@@ -1,0 +1,19 @@
+#name: anarkis.acc.lib.get.flyads
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.get.flyads.xml
+
+$arr = [THIS] -> call script anarkis.acc.lib.get.adsonly :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$env = $select -> get environment
+skip if not $env == [THIS]
+remove element from array $arr at index $cnt
+end
+$cnt =  size of array $arr
+skip if $cnt
+return null
+
+return $arr

--- a/tools/fixtures/known_good/anarkis.acc.lib.get.leader.big.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.lib.get.leader.big.x3s
@@ -1,0 +1,22 @@
+#name: anarkis.acc.lib.get.leader.big
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.get.leader.big.xml
+
+$arr = [THIS] -> call script anarkis.acc.lib.get.leaderlist :
+$res = null
+$follow.count = 0
+
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$formation = $select -> get formation follower ships
+$formation =  size of array $formation
+if $formation >= $follow.count
+$res = $select
+$follow.count = $formation
+end
+end
+
+return $res

--- a/tools/fixtures/known_good/anarkis.acc.lib.get.lonely.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.lib.get.lonely.x3s
@@ -1,0 +1,23 @@
+#name: anarkis.acc.lib.get.lonely
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.get.lonely.xml
+
+$arr = [THIS] -> call script anarkis.acc.lib.get.adsonly :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$env = $select -> get environment
+skip if not $env == [THIS]
+remove element from array $arr at index $cnt
+skip if not $select -> has formation ships
+remove element from array $arr at index $cnt
+skip if not $select -> get formation leader
+remove element from array $arr at index $cnt
+end
+$cnt =  size of array $arr
+skip if $cnt
+return null
+
+return $arr

--- a/tools/fixtures/known_good/anarkis.acc.lib.givetarget.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.lib.givetarget.x3s
@@ -1,0 +1,33 @@
+#name: anarkis.acc.lib.givetarget
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.givetarget.xml
+
+$setup = [THIS] -> get local variable: name='anarkis.acc.setup'
+$radar.range = $setup[1]
+
+$leader.list = [THIS] -> call script anarkis.acc.lib.get.leaderlist :
+$leader.cnt =  size of array $leader.list
+while $leader.cnt
+dec $leader.cnt =
+$leader = $leader.list[$leader.cnt]
+* - Skip if a target is already assigned or on protect duty
+skip if not $leader -> is script !ship.cmd.protect.std on stack of task=0
+continue
+skip if not $leader -> is script anarkis.acc.cmd.protect on stack of task=0
+continue
+skip if not $leader -> get attack target
+continue
+* - Search for an enemy in the home radar range
+$flag = [Find.Random] | [Find.Enemy]
+$enemy =  find ship: sector=[SECTOR] class or type=Moveable Ship race=null flags=$flag refobj=[THIS] maxdist=$radar.range maxnum=1 refpos=null
+* - If not found, look around the leader
+skip if $enemy -> exists
+$enemy =  find ship: sector=[SECTOR] class or type=Moveable Ship race=null flags=$flag refobj=$leader maxdist=$radar.range maxnum=1 refpos=null
+if $enemy -> exists
+START $leader -> call script anarkis.acc.cmd.attack.return :  victim=$enemy  dst=[THIS]
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.lib.isadsactive.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.lib.isadsactive.x3s
@@ -1,0 +1,17 @@
+#name: anarkis.acc.lib.isadsactive
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.isadsactive.xml
+
+
+skip if not $target -> is script anarkis.acc.task.autocarrier on stack of task=10
+return [TRUE]
+skip if not $target -> is script anarkis.acc.task.autocarrier on stack of task=11
+return [TRUE]
+skip if not $target -> is script anarkis.acc.task.autocarrier.npc on stack of task=894
+return [TRUE]
+skip if not $target -> is script anarkis.acc.task.autocarrier on stack of task=894
+return [TRUE]
+
+return [FALSE]
+

--- a/tools/fixtures/known_good/anarkis.acc.lib.name.load.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.lib.name.load.x3s
@@ -1,0 +1,21 @@
+#name: anarkis.acc.lib.name.load
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.name.load.xml
+
+$arr = [THIS] -> call script anarkis.acc.lib.get.adsonly :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$name = $select -> get local variable: name='anarkis.acc.oldname'
+if $name
+$select -> set name to $name
+else
+$name = $select -> get ware type code of object
+$select -> set name to $name
+end
+$select -> set local variable: name='anarkis.acc.oldname' value=null
+end
+
+return $arr

--- a/tools/fixtures/known_good/anarkis.acc.lib.name.save.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.lib.name.save.x3s
@@ -1,0 +1,15 @@
+#name: anarkis.acc.lib.name.save
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.lib.name.save.xml
+
+$arr = [THIS] -> call script anarkis.acc.lib.get.adsonly :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+$name = $select -> get name
+$select -> set local variable: name='anarkis.acc.oldname' value=$name
+end
+
+return $arr

--- a/tools/fixtures/known_good/anarkis.acc.repairshields.single.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.repairshields.single.x3s
@@ -1,0 +1,8 @@
+#name: anarkis.acc.repairshields.single
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.repairshields.single.xml
+
+$max = $ship -> get maximum shield strength
+$ship -> set current shield strength to $max
+return null

--- a/tools/fixtures/known_good/anarkis.acc.repairshields.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.repairshields.x3s
@@ -1,0 +1,21 @@
+#name: anarkis.acc.repairshields
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.repairshields.xml
+
+$array = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$max = $select -> get maximum shield strength
+$select -> set current shield strength to $max
+$select -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$select -> set command: COMMAND_NONE
+$select -> set destination to null
+$select -> set attack target to null
+$select -> set command target: null
+$select -> set command target2: null
+$select -> set ship command/signal SIGNAL_ATTACKED to global default behaviour
+end
+return null

--- a/tools/fixtures/known_good/anarkis.acc.setup.attackmode.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.attackmode.x3s
@@ -1,0 +1,28 @@
+#name: anarkis.acc.setup.attackmode
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.attackmode.xml
+
+$page.id = 8510
+
+$menu.result = -1
+while $menu.result == -1
+$menu =  create custom menu array
+
+$st = sprintf: pageid=$page.id textid=301, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=206, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=3
+$st = sprintf: pageid=$page.id textid=207, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=1
+$st = sprintf: pageid=$page.id textid=208, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=2
+
+$st = sprintf: pageid=$page.id textid=302, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 = sprintf: pageid=$page.id textid=301, null, null, null, null, null
+$menu.result =  open custom menu: title=$v1 description=null option array=$menu
+end
+
+return $menu.result

--- a/tools/fixtures/known_good/anarkis.acc.setup.autocarrier.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.autocarrier.x3s
@@ -1,0 +1,233 @@
+#name: anarkis.acc.setup.autocarrier
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.autocarrier.xml
+
+$page.id = 8510
+
+* ====
+* Retrieve setup, apply default if not found
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$cnt =  size of array $setup.array
+if not $cnt == 19
+$setup.array = [THIS] -> call script anarkis.ads.setup.createdefault :  ref.object=[THIS]
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup.array
+end
+* ====
+
+* ====
+* Init selection arrays
+* - Alert Level
+$threat.level = $setup.array[0]
+$sel.threat =  array alloc: size=0
+append 1 to array $sel.threat
+append 3 to array $sel.threat
+append 5 to array $sel.threat
+append 8 to array $sel.threat
+append 10 to array $sel.threat
+append 15 to array $sel.threat
+append 20 to array $sel.threat
+append 25 to array $sel.threat
+append 30 to array $sel.threat
+append 35 to array $sel.threat
+append 40 to array $sel.threat
+$sel.threat.selection =  get index of $threat.level in array $sel.threat offset=-1 + 1
+$sel.threat.id = 'threat'
+* - Radar Range
+$radar.range = $setup.array[1]
+$sel.radar =  array alloc: size=0
+$v1 = 0
+while $v1 < 100000
+$v1 = $v1 + 5000
+append $v1 to array $sel.radar
+end
+$sel.radar.selection =  get index of $radar.range in array $sel.radar offset=-1 + 1
+$sel.radar.id = 'radar'
+* - Retreat Yes/No
+$retreat = $setup.array[3]
+$sel.yesno =  array alloc: size=0
+$v1 =  read text: page=$page.id id=820
+append $v1 to array $sel.yesno
+$v1 =  read text: page=$page.id id=821
+append $v1 to array $sel.yesno
+if $retreat == [TRUE]
+$sel.retreat.selection = 0
+else
+$sel.retreat.selection = 1
+end
+$sel.retreat.id = 'retreat'
+* - Attack Mode
+$sel.attack =  array alloc: size=0
+$v1 =  read text: page=$page.id id=206
+append $v1 to array $sel.attack
+$v1 =  read text: page=$page.id id=207
+append $v1 to array $sel.attack
+$v1 =  read text: page=$page.id id=208
+append $v1 to array $sel.attack
+$sel.attack.selection = $setup.array[6]
+skip if $sel.attack.selection != 3
+$sel.attack.selection = 0
+$sel.attack.id = 'attack'
+* - Defense ship count
+$defence = $setup.array[2]
+$sel.defense =  array alloc: size=0
+append 0 to array $sel.defense
+append 1 to array $sel.defense
+append 3 to array $sel.defense
+append 5 to array $sel.defense
+append 8 to array $sel.defense
+append 10 to array $sel.defense
+append 15 to array $sel.defense
+$sel.defense.selection =  get index of $defence in array $sel.defense offset=-1 + 1
+$sel.defense.id = 'defense'
+* - Delay before docking ships
+$delay = $setup.array[18]
+$sel.delay =  array alloc: size=0
+append 0 to array $sel.delay
+$v1 = 0
+while $v1 < 600
+$v1 = $v1 + 30
+append $v1 to array $sel.delay
+end
+$sel.delay.selection =  get index of $delay in array $sel.delay offset=-1 + 1
+$sel.delay.id = 'delay'
+* - Display Warning message Yes/No
+$warning = $setup.array[4]
+if $warning == [TRUE]
+$sel.warning.selection = 0
+else
+$sel.warning.selection = 1
+end
+$sel.warning.id = 'warning'
+* - Alert Type
+$sel.alert =  array alloc: size=0
+$v1 =  read text: page=$page.id id=233
+append $v1 to array $sel.alert
+$v1 =  read text: page=$page.id id=234
+append $v1 to array $sel.alert
+$v1 =  read text: page=$page.id id=235
+append $v1 to array $sel.alert
+$sel.alert.selection = $setup.array[5]
+skip if $sel.alert.selection != 3
+$sel.alert.selection = 0
+$sel.alert.id = 'warning.type'
+* End of init selection arrays
+* ====
+
+
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=220
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=221, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.threat, default=$sel.threat.selection, return id=$sel.threat.id
+
+$st = sprintf: pageid=$page.id textid=226, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.radar, default=$sel.radar.selection, return id=$sel.radar.id
+
+$st = sprintf: pageid=$page.id textid=223, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.yesno, default=$sel.retreat.selection, return id=$sel.retreat.id
+
+$st = sprintf: pageid=$page.id textid=224, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.attack, default=$sel.attack.selection, return id=$sel.attack.id
+
+$st = sprintf: pageid=$page.id textid=225, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.defense, default=$sel.defense.selection, return id=$sel.defense.id
+
+$st = sprintf: pageid=$page.id textid=238, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.delay, default=$sel.delay.selection, return id=$sel.delay.id
+
+$st =  read text: page=$page.id id=228
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=222, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.yesno, default=$sel.warning.selection, return id=$sel.warning.id
+
+$st = sprintf: pageid=$page.id textid=229, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.alert, default=$sel.alert.selection, return id=$sel.alert.id
+
+$st =  read text: page=$page.id id=403
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=1087
+add custom menu item to array $menu: text=$st returnvalue='save'
+
+$v1 = [THIS] -> get object class
+$st = sprintf: pageid=$page.id textid=250, [THIS], $v1, null, null, null
+add custom menu info line to array $menu: text=$st
+$st = sprintf: pageid=$page.id textid=251, [SECTOR], null, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 = [THIS] -> get number of landed ships
+$v2 = [THIS] -> get dock bay size
+$v3 = [THIS] -> get owned ships: class/type=Ship
+$v3 =  size of array $v3
+$st = sprintf: pageid=$page.id textid=252, $v1, $v2, $v3, null, null
+add custom menu info line to array $menu: text=$st
+$st = sprintf: pageid=$page.id textid=1088, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$st = sprintf: fmt='%s - Carrier Setup', [THIS], null, null, null, null
+$v1 =  read text: page=$page.id id=200
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if  is datatyp[ $menu.result ] == DATATYP_ARRAY
+$cnt =  size of array $menu.result
+while $cnt
+dec $cnt =
+$r.id = $menu.result[$cnt][0]
+$r.val = $menu.result[$cnt][1]
+* - - - Defense Ships
+if $r.id == $sel.defense.id
+$setup.array[2] = $sel.defense[$r.val]
+$sel.defense.selection = $r.val
+* - - - Radar Range
+else if $r.id == $sel.radar.id
+$setup.array[1] = $sel.radar[$r.val]
+$sel.radar.selection = $r.val
+* - - - Warning Type
+else if $r.id == $sel.alert.id
+$setup.array[5] = $r.val
+$sel.alert.selection = $r.val
+* - - - Attack Mode
+else if $r.id == $sel.attack.id
+skip if not $r.val == 0
+$r.val = 0
+$setup.array[6] = $r.val
+$sel.attack.selection = $r.val
+* - - - Retreat Mode
+else if $r.id == $sel.retreat.id
+if $r.val == 0
+$setup.array[3] = [TRUE]
+else
+$setup.array[3] = [FALSE]
+end
+$sel.retreat.selection = $r.val
+* - - - Delay before dock
+else if $r.id == $sel.delay.id
+$setup.array[18] = $sel.delay[$r.val]
+$sel.delay.selection = $r.val
+* - - - Warning Toggle
+else if $r.id == $sel.warning.id
+if $r.val == 0
+$setup.array[4] = [TRUE]
+else
+$setup.array[4] = [FALSE]
+end
+$sel.warning.selection = $r.val
+* - - - Threat Setting
+else if $r.id == $sel.threat.id
+$setup.array[0] = $sel.threat[$r.val]
+$sel.threat.selection = $r.val
+
+end
+end
+
+
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.setup.buywares.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.buywares.x3s
@@ -1,0 +1,173 @@
+#name: anarkis.acc.setup.buywares
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.buywares.xml
+
+skip if $selected -> exists
+return null
+
+$page.id = 8510
+$null = null
+$setup.array = $selected -> get local variable: name='anarkis.acc.setup'
+$ware.list =  array alloc: size=0
+$quant.list =  array alloc: size=0
+$jump.range = 2
+$sector = $selected -> get sector
+
+while $menu.result != -1
+$menu =  create custom menu array
+$st =  read text: page=$page.id id=641
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=646
+add custom menu item to array $menu: text=$st returnvalue='add.ware'
+$cnt =  size of array $ware.list
+while $cnt
+dec $cnt =
+$v1 = $ware.list[$cnt]
+$v2 = $quant.list[$cnt]
+$st = sprintf: pageid=$page.id textid=660, $v1, $v2, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=$v1
+end
+$st =  read text: page=$page.id id=647
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=643
+add custom menu item to array $menu: text=$st returnvalue='rem.all'
+$st = sprintf: pageid=$page.id textid=648, $jump.range, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='jump.range'
+$st =  read text: page=$page.id id=659
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=645
+add custom menu item to array $menu: text=$st returnvalue='proceed'
+
+$st = sprintf: pageid=$page.id textid=658, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=657
+$st = sprintf: pageid=$page.id textid=488, $selected, null, null, null, null
+$menu.result =  open custom menu: title=$v1 description=$st option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'rem.all'
+$ware.list =  array alloc: size=0
+$quant.list =  array alloc: size=0
+
+else if $menu.result == 'jump.range'
+$st =  read text: page=$page.id id=651
+$jump.range = $selected -> get user input: type=Var/Number, title=$st
+
+else if $menu.result == 'add.ware'
+$st =  read text: page=$page.id id=652
+$v1 = $selected -> get user input: type=Var/Ware, title=$st
+if $v1
+if not  find $v1 in array: $ware.list
+$st =  read text: page=$page.id id=662
+$v2 = $selected -> get user input: type=Var/Number, title=$st
+if $v2
+append $v1 to array $ware.list
+append $v2 to array $quant.list
+end
+end
+end
+
+
+else if  is datatyp[ $menu.result ] == DATATYP_WARE
+$v1 =  get index of $menu.result in array $ware.list offset=-1 + 1
+remove element from array $ware.list at index $v1
+remove element from array $quant.list at index $v1
+
+else if $menu.result == 'proceed'
+$ok = [TRUE]
+
+while $ok == [TRUE]
+$ok = [FALSE]
+gosub cleanlist
+$proc.count =  size of array $ware.list
+while $proc.count
+dec $proc.count =
+$select.ware = $ware.list[$proc.count]
+$ware.amount = $quant.list[$proc.count]
+gosub getbestship
+if $select.ship -> exists
+$ok = [TRUE]
+$dest.station = $select.ship -> call script !lib.get.bestbuy :  Ware=$select.ware  Max Price=null  Max Jumps=$jump.range  Check for Property=[FALSE]  Find around sector=$selected
+$proc.warecount = $select.ship -> get max amount of ware $select.ware that can be stored in cargo bay
+if $proc.warecount >= $ware.amount
+$proc.warecount = $ware.amount
+$quant.list[$proc.count] = 0
+else
+$ware.amount = $ware.amount - $proc.warecount
+$quant.list[$proc.count] = $ware.amount
+end
+START $select.ship -> call script anarkis.acc.cmd.buy.return :  ware=$select.ware  station=$dest.station  quantity=$proc.warecount  min price=null
+$st = sprintf: pageid=$page.id textid=661, $select.ship, $proc.warecount, $select.ware, $dest.station, null
+display subtitle text: text=$st duration=2000 ms
+= wait 2000 ms
+end
+end
+end
+$menu.result = -1
+end
+end
+
+return null
+
+
+cleanlist:
+$cnt =  size of array $ware.list
+while $cnt
+dec $cnt =
+$select.ware = $ware.list[$cnt]
+$ware.amount = $quant.list[$cnt]
+gosub getbestship
+if $ware.amount == 0
+remove element from array $ware.list at index $cnt
+remove element from array $quant.list at index $cnt
+continue
+end
+if not $select.ship -> exists
+remove element from array $ware.list at index $cnt
+remove element from array $quant.list at index $cnt
+$st = sprintf: pageid=$page.id textid=655, $select.ware, null, null, null, null
+display subtitle text: text=$st duration=2000 ms
+= wait 2000 ms
+continue
+end
+if not [THIS] -> call script !lib.get.bestbuy :  Ware=$select.ware  Max Price=null  Max Jumps=$jump.range  Check for Property=[FALSE]  Find around sector=$selected
+remove element from array $ware.list at index $cnt
+$st = sprintf: pageid=$page.id textid=656, $select.ware, null, null, null, null
+display subtitle text: text=$st duration=2000 ms
+= wait 2000 ms
+continue
+end
+end
+
+endsub
+
+getbestship:
+$select.ship = null
+$v2 = 0
+$id = null
+$ship.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$ship.count =  size of array $ship.list
+while $ship.count
+dec $ship.count =
+$v1 = $ship.list[$ship.count]
+skip if not $v1 -> is task 0 in use
+continue
+$amt = $v1 -> get max amount of ware $select.ware that can be stored in cargo bay
+if $amt > $v2
+$v2 = $amt
+$id = $ship.count
+skip if not $amt >= $ware.amount
+break
+end
+end
+if $id != null
+$select.ship = $ship.list[$id]
+end
+endsub
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.setup.copy.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.copy.x3s
@@ -1,0 +1,44 @@
+#name: anarkis.acc.setup.copy
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.copy.xml
+
+$null = null
+$setup = $base -> get local variable: name='anarkis.acc.setup'
+$v1 =  size of array $setup
+skip if $v1 == 19
+return [FALSE]
+
+$dest.setup = $dest -> get local variable: name='anarkis.acc.setup'
+$v1 =  size of array $dest.setup
+skip if $v1 == 19
+$dest.setup = $null -> call script anarkis.acc.setup.default.to :  dest=$dest
+
+* base setup (0-15)
+$v1 = 16
+while $v1
+dec $v1 =
+$dest.setup[$v1] = $setup[$v1]
+end
+$dest.setup[18] = $setup[18]
+
+* Ignore List (16)
+$arr = $setup[16]
+$v1 =  size of array $arr
+$arr.d =  array alloc: size=$v1
+while $v1
+dec $v1 =
+$arr.d[$v1] = $arr[$v1]
+end
+$dest.setup[16] = $arr.d
+
+* Mechanists (17) - ignore mech.count
+$arr = $setup[17]
+$arr.d = $dest.setup[17]
+$arr.d[1] = $arr[1]
+$arr.d[2] = $arr[2]
+$dest.setup[17] = $arr.d
+
+$dest -> set local variable: name='anarkis.acc.setup' value=$dest.setup
+
+return $dest.setup

--- a/tools/test_x3s.py
+++ b/tools/test_x3s.py
@@ -25,7 +25,8 @@ if __name__ == '__main__':
   good_files = sorted((ROOT / 'tools/fixtures/known_good').glob('*.x3s'))
   fail_files = sorted((ROOT / 'tools/fixtures/should_fail').rglob('*.x3s'))
 
-  run([sys.executable, 'tools/x3s_lint.py', *[str(p.relative_to(ROOT)) for p in src_files + good_files]])
+  ok_files = src_files + good_files
+  run([sys.executable, 'tools/x3s_lint.py', *[str(p.relative_to(ROOT)) for p in ok_files]])
   if fail_files:
     run_fail([sys.executable, 'tools/x3s_lint.py', *[str(p.relative_to(ROOT)) for p in fail_files]])
 

--- a/tools/x3s_lint.py
+++ b/tools/x3s_lint.py
@@ -124,6 +124,12 @@ def lint_file(path: Path, patterns: list[re.Pattern[str]] | None = None) -> list
         if b.kind == "while" and b.var == var:
           b.has_progress = True
           break
+    if m := re.match(r"\$([A-Za-z0-9_.]+)\s*=", low):
+      var = m.group(1)
+      for b in reversed(stack):
+        if b.kind == "while" and b.var == var:
+          b.has_progress = True
+          break
 
     # treat certain blocking calls as progress (e.g., menu interaction)
     if "open custom menu:" in low or "open custom info menu:" in low:

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -510,6 +510,20 @@
             "examples": [
                 "START $new.leader -> command $cmd.name : arg1=$arg1, arg2=$arg2, arg3=$arg3, arg4=null"
             ]
+        },
+        {
+            "name": "append.class",
+            "regex": "^append (M1|M2|M3|M4|M5|M6|M7|M8|TM|TP|TS|TL) to array \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "append M2 to array $class.list"
+            ]
+        },
+        {
+            "name": "menu.value.selection",
+            "regex": "^add value selection to menu: \\$[A-Za-z0-9_.]+, text=\\$[A-Za-z0-9_.]+, value array=\\$[A-Za-z0-9_.]+, default=\\$[A-Za-z0-9_.]+, return id=\\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "add value selection to menu: $menu, text=$st, value array=$sel.threat, default=$sel.threat.selection, return id=$sel.threat.id"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Plan
- Import 20 additional ADS scripts and list them in the README
- Capture new statement forms in x3s_rules.json and extend the linter
- Document the newly recognized statements and verify fixtures

## Changes
- Added 20 ADS fixtures and referenced them in the README
- Expanded x3s_rules.json with `append.class` and `menu.value.selection` patterns
- Updated linter to treat assignments to loop variables as progress
- Adjusted test harness to lint all sources and fixtures
- Documented the new statement patterns in `docs/x3s-language.md`

## Test Results
- `python tools/x3s_lint.py`
- `python tools/test_x3s.py` *(tail)*

## Pattern List
- append.class — `append M2 to array $class.list`
- menu.value.selection — `add value selection to menu: $menu, text=$st, value array=$sel.threat, default=$sel.threat.selection, return id=$sel.threat.id`

## Safety Checks
- Control flow stack: if/else/end and while/end
- Busy loop guard: while blocks require wait or progress
- Setup scripts must include `load text: id=<page>`


------
https://chatgpt.com/codex/tasks/task_e_68c69062576883268a715ed9cb994284