### PR TITLE
Expand ADS fixtures and linter rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 SLX is a lightweight station-to-station logistics mod for X3TC: Terran Conflict. Moves wares between enrolled player stations (same- or cross-sector) — no NPC trade or scanning — via per-ware roles (Producer, Consumer, Store) with Min/Max/Chunk thresholds and a priority-based transfer loop.
 
 ## ADS Sample Files
-The linter is validated against these 80 known-good ADS scripts:
+The linter is validated against these 100 known-good ADS scripts:
 
 - !init.anarkis.modified.x3s
 - al.plugin.sk.ecs.x3s
@@ -84,3 +84,23 @@ The linter is validated against these 80 known-good ADS scripts:
 - anarkis.acc.setup.autocarrier.x3s
 - anarkis.acc.setup.buywares.x3s
 - anarkis.acc.setup.copy.x3s
+- anarkis.acc.setup.default.st.x3s
+- anarkis.acc.setup.default.x3s
+- anarkis.acc.setup.hangars.x3s
+- anarkis.acc.setup.ignorerace.x3s
+- anarkis.acc.setup.rename.x3s
+- anarkis.acc.setup.reports.x3s
+- anarkis.acc.setup.sellwares.x3s
+- anarkis.acc.setup.ships.x3s
+- anarkis.acc.setup.supplies.c2s.x3s
+- anarkis.acc.setup.supplies.s2c.x3s
+- anarkis.acc.setup.supplies.x3s
+- anarkis.acc.setup.threatsetup.x3s
+- anarkis.acc.setup.x3s
+- anarkis.acc.signal.killed.npc.x3s
+- anarkis.acc.task.autocarrier.npc.x3s
+- anarkis.acc.task.autocarrier.x3s
+- anarkis.acc.task.autoname.plus.x3s
+- anarkis.acc.task.hullcheck.x3s
+- anarkis.acc.upgrade.disable.x3s
+- anarkis.acc.upgrade.enable.x3s

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -77,6 +77,10 @@
 - **append.class**: `append M2 to array $class.list`
 - **menu.value.selection**: `add value selection to menu: $menu, text=$st, value array=$sel.threat, default=$sel.threat.selection, return id=$sel.threat.id`
 
+### New Statements Recognized
+- **play.sample.named**: `play sample [IncomingTransmission.SOS]`
+- **menu.item.textnum**: `add custom menu item to array $menu: text='1' returnvalue=1`
+
 ## Fixtures
 
 Known-good mod fixtures live under `tools/fixtures/known_good/<mod_name>`. Each mod

--- a/tools/fixtures/known_good/anarkis.acc.setup.default.st.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.default.st.x3s
@@ -1,0 +1,60 @@
+#name: anarkis.acc.setup.default.st
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.default.st.xml
+
+$setup =  array alloc: size=0
+
+* 0 threat level
+append 5 to array $setup
+* 1 Radar Range
+append 100000 to array $setup
+* 2 Defense Ship count
+append 5 to array $setup
+* 3 Damaged ships retreat
+append [TRUE] to array $setup
+* 4 Display warning
+append [TRUE] to array $setup
+* 5 warning type (0 subtitle, 1 audio, 2 text)
+append 2 to array $setup
+* 6 attack mode (3 auto, 1 nearest first, 2 strongest first)
+append 3 to array $setup
+* 7 docked ship autojump on / off
+append [TRUE] to array $setup
+* 8 docked ship autojump distance
+append 1 to array $setup
+* 9 docked ship fuel resupply (jumps)
+append 10 to array $setup
+* 10 docked ship emergency jump/escape
+append [TRUE] to array $setup
+* 11 docked ship shield threshold (in percent)
+append 10 to array $setup
+* 12 docked ship missile usage
+append 15 to array $setup
+* 13 use logfile
+append [FALSE] to array $setup
+* 14 turret settings
+append 246 to array $setup
+* 15 enable auto rename
+append [TRUE] to array $setup
+
+* 16 Ignore List (array)
+$ignore =  array alloc: size=0
+append $ignore to array $setup
+
+* 17 Mechanics
+$mechanists =  array alloc: size=0
+* - 0 Count
+append 4 to array $mechanists
+* - 1 Allow ship repairs
+append [FALSE] to array $mechanists
+* - 2 Allow carrier repairs
+append [FALSE] to array $mechanists
+append $mechanists to array $setup
+
+* 18 Delay before the autocarrier docks its ships
+append 600 to array $setup
+
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup
+
+return $setup

--- a/tools/fixtures/known_good/anarkis.acc.setup.default.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.default.x3s
@@ -1,0 +1,60 @@
+#name: anarkis.acc.setup.default
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.default.xml
+
+$setup =  array alloc: size=0
+
+* 0 threat level
+append 15 to array $setup
+* 1 Radar Range
+append 20000 to array $setup
+* 2 Defense Ship count
+append 5 to array $setup
+* 3 Damaged ships retreat
+append [TRUE] to array $setup
+* 4 Display warning
+append [TRUE] to array $setup
+* 5 warning type (0 subtitle, 1 audio, 2 text)
+append 2 to array $setup
+* 6 attack mode (3 auto, 1 nearest first, 2 strongest first)
+append 3 to array $setup
+* 7 docked ship autojump on / off
+append [TRUE] to array $setup
+* 8 docked ship autojump distance
+append 1 to array $setup
+* 9 docked ship fuel resupply (jumps)
+append 10 to array $setup
+* 10 docked ship emergency jump/escape
+append [TRUE] to array $setup
+* 11 docked ship shield threshold (in percent)
+append 10 to array $setup
+* 12 docked ship missile usage
+append 15 to array $setup
+* 13 use logfile
+append [FALSE] to array $setup
+* 14 turret settings
+append 246 to array $setup
+* 15 enable auto rename
+append [TRUE] to array $setup
+
+* 16 Ignore List (array)
+$ignore =  array alloc: size=0
+append $ignore to array $setup
+
+* 17 Mechanics
+$mechanists =  array alloc: size=0
+* - 0 Count
+append 0 to array $mechanists
+* - 1 Allow ship repairs
+append [FALSE] to array $mechanists
+* - 2 Allow carrier repairs
+append [FALSE] to array $mechanists
+append $mechanists to array $setup
+
+* 18 Delay before the autocarrier docks its ships
+append 300 to array $setup
+
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup
+
+return $setup

--- a/tools/fixtures/known_good/anarkis.acc.setup.hangars.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.hangars.x3s
@@ -1,0 +1,143 @@
+#name: anarkis.acc.setup.hangars
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.hangars.xml
+
+$page.id = 8510
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=423
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=424
+add custom menu item to array $menu: text=$st returnvalue='set.home.all'
+$st =  read text: page=$page.id id=434
+add custom menu item to array $menu: text=$st returnvalue='set.name'
+$st =  read text: page=$page.id id=217
+add custom menu item to array $menu: text=$st returnvalue='setup'
+
+$st = sprintf: pageid=$page.id textid=425, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=426
+add custom menu item to array $menu: text=$st returnvalue='add.all'
+$st =  read text: page=$page.id id=427
+add custom menu item to array $menu: text=$st returnvalue='add.m3m4'
+$st =  read text: page=$page.id id=428
+add custom menu item to array $menu: text=$st returnvalue='add.m3'
+$st =  read text: page=$page.id id=429
+add custom menu item to array $menu: text=$st returnvalue='rem.all'
+
+$st = sprintf: pageid=$page.id textid=422, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$class = $curr.ship -> get object class
+$enabled = $curr.ship -> get local variable: name='anarkis.acc.ship'
+if $enabled == [TRUE]
+$v1 =  read text: page=$page.id id=431
+else
+$v1 =  read text: page=$page.id id=432
+end
+$st = sprintf: pageid=$page.id textid=430, $class, $curr.ship, $v1, null, null
+add custom menu item to array $menu: text=$st returnvalue=$curr.ship
+end
+
+$st = sprintf: pageid=$page.id textid=421, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 =  read text: page=$page.id id=420
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'add.all'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=[TRUE]
+$name = $curr.ship -> get name
+$curr.ship -> set local variable: name='anarkis.acc.oldname' value=$name
+if [OWNER] == Player
+$curr.ship -> set homebase to [THIS]
+end
+end
+
+else if $menu.result == 'rem.all'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=null
+end
+
+else if $menu.result == 'add.m3m4'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$v1 = $curr.ship -> get object class
+if $v1 == M3 OR $v1 == M4
+$name = $curr.ship -> get name
+$curr.ship -> set local variable: name='anarkis.acc.oldname' value=$name
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=[TRUE]
+$curr.ship -> set homebase to [THIS]
+end
+end
+
+else if $menu.result == 'add.m3'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$v1 = $curr.ship -> get object class
+if $v1 == M3
+$name = $curr.ship -> get name
+$curr.ship -> set local variable: name='anarkis.acc.oldname' value=$name
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=[TRUE]
+$curr.ship -> set homebase to [THIS]
+end
+end
+
+else if $menu.result == 'setup'
+= [THIS] -> call script anarkis.acc.setup.ships :
+
+else if $menu.result == 'set.home.all'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$curr.ship -> set homebase to [THIS]
+end
+
+else if $menu.result == 'set.name'
+= [THIS] -> call script anarkis.acc.setup.rename :
+
+else if $menu.result -> exists
+$enabled = $menu.result -> get local variable: name='anarkis.acc.ship'
+$enabled = ! $enabled
+$menu.result -> set local variable: name='anarkis.acc.ship' value=$enabled
+*$menu.result -> set local variable: name='anarkis.acc.skipme' value=$enabled
+if $enabled == [TRUE]
+$name = $menu.result -> get name
+$menu.result -> set local variable: name='anarkis.acc.oldname' value=$name
+$menu.result -> set homebase to [THIS]
+end
+end
+
+
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.setup.ignorerace.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.ignorerace.x3s
@@ -1,0 +1,67 @@
+#name: anarkis.acc.setup.ignorerace
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.ignorerace.xml
+
+$page.id = 8510
+
+* Retrieve setup, apply default if not found
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+
+
+while $menu.result != -1
+
+$race.array = $setup.array[16]
+$race.count =  size of array $race.array
+
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=461
+add custom menu heading to array $menu: title=$st
+
+$st =  read text: page=$page.id id=463
+add custom menu item to array $menu: text=$st returnvalue='add'
+if $race.count
+$st =  read text: page=$page.id id=462
+add custom menu item to array $menu: text=$st returnvalue='clear'
+end
+
+if $race.count
+$st =  read text: page=$page.id id=460
+add custom menu heading to array $menu: title=$st
+$cnt = $race.count
+while $cnt
+dec $cnt =
+$v1 = $race.array[$cnt]
+$st = sprintf: pageid=$page.id textid=464, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=$v1
+end
+end
+
+$v1 =  read text: page=$page.id id=460
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'clear'
+resize array $race.array to 0
+
+else if $menu.result == 'add'
+$st =  read text: page=$page.id id=465
+$v1 = [THIS] -> get user input: type=Var/Race, title=$st
+skip if  is datatyp[ $v1 ] == DATATYP_RACE
+continue
+skip if  find $v1 in array: $race.array
+append $v1 to array $race.array
+
+else if $menu.result != -1
+$index =  get index of $menu.result in array $race.array offset=-1 + 1
+remove element from array $race.array at index $index
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.setup.rename.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.rename.x3s
@@ -1,0 +1,76 @@
+#name: anarkis.acc.setup.rename
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.rename.xml
+
+$page.id = 8510
+$rename.mode = 481
+
+while $menu.result != -1
+
+$menu =  create custom menu array
+
+$v1 =  read text: page=$page.id id=$rename.mode
+$st = sprintf: pageid=$page.id textid=488, $v1, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$st =  read text: page=$page.id id=481
+add custom menu item to array $menu: text=$st returnvalue=481
+$st =  read text: page=$page.id id=482
+add custom menu item to array $menu: text=$st returnvalue=482
+$st =  read text: page=$page.id id=483
+add custom menu item to array $menu: text=$st returnvalue=483
+
+$st =  read text: page=$page.id id=485
+add custom menu heading to array $menu: title=$st
+
+$st =  read text: page=$page.id id=486
+add custom menu item to array $menu: text=$st returnvalue='ren.docked'
+$st =  read text: page=$page.id id=487
+add custom menu item to array $menu: text=$st returnvalue='ren.active'
+
+$st =  read text: page=$page.id id=484
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=480
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result > 480
+$rename.mode = $menu.result
+
+else if $menu.result == 'ren.docked' OR $menu.result == 'ren.active'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+$nb = 0
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$enabled = $curr.ship -> get local variable: name='anarkis.acc.ship'
+if $menu.result == 'ren.active' AND $enabled != [TRUE]
+continue
+end
+inc $nb =
+$v1 = $curr.ship -> get ware type code of object
+$v2 = $curr.ship -> get object class
+$v3 = $curr.ship -> get maker race
+$v4 = [THIS] -> get name
+if $rename.mode == 481
+$newname = sprintf: fmt='%s %s - %s', $v1, $v2, $nb, null, null
+else if $rename.mode == 482
+$newname = sprintf: fmt='%s - %s - %s', $v4, $v1, $nb, null, null
+else if $rename.mode == 483
+$newname = sprintf: fmt='%s %s - %s', $v3, $v2, $nb, null, null
+end
+$curr.ship -> set local variable: name='anarkis.acc.oldname' value=$newname
+$curr.ship -> set name to $newname
+end
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.setup.reports.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.reports.x3s
@@ -1,0 +1,86 @@
+#name: anarkis.acc.setup.reports
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.reports.xml
+
+$page.id = 8510
+$null = null
+$setup.array = $selected -> get local variable: name='anarkis.acc.setup'
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+if $selected -> exists
+$st =  read text: page=$page.id id=806
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=807
+add custom menu item to array $menu: text=$st returnvalue='setup'
+$st =  read text: page=$page.id id=808
+add custom menu item to array $menu: text=$st returnvalue='all'
+end
+
+$st =  read text: page=$page.id id=803
+add custom menu heading to array $menu: title=$st
+$array = $null -> call script anarkis.acc.get.acc.carriers :  active only?=[FALSE]
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$v1 = $array[$cnt]
+$v2 = $v1 -> get object class
+$v3 = $v1 -> get sector
+$st = sprintf: pageid=$page.id textid=804, $v1, $v2, $v3, null, null
+add custom menu item to array $menu: text=$st returnvalue=$v1
+end
+
+
+if $selected -> exists
+$v1 = $selected -> get object class
+$st = sprintf: pageid=$page.id textid=801, $selected, $v1, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v3 = $selected -> get sector
+$v2 = $v3 -> get owner race
+$st = sprintf: pageid=$page.id textid=805, $v3, $v2, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 = $selected -> get command
+$v2 =  read text: page=$page.id id=820
+if not $selected -> is script anarkis.acc.task.autocarrier on stack of task=10
+if not $selected -> is script anarkis.acc.task.autocarrier on stack of task=11
+$v2 =  read text: page=$page.id id=821
+end
+end
+$st = sprintf: pageid=$page.id textid=802, $v1, $v2, null, null, null
+add custom menu info line to array $menu: text=$st
+end
+$v1 =  read text: page=$page.id id=800
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result -> is of class Moveable Ship
+$selected = $menu.result
+
+else if $menu.result == 'all'
+$array = $null -> call script anarkis.acc.get.acc.carriers :  active only?=[FALSE]
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$v1 = $array[$cnt]
+if $v1 != $selected
+= $null -> call script anarkis.acc.setup.copy :  base=$selected  dest=$v1
+end
+end
+
+else if $menu.result == 'setup'
+$selected -> start task 892 with script anarkis.acc.setup and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+return null
+end
+
+
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.setup.sellwares.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.sellwares.x3s
@@ -1,0 +1,189 @@
+#name: anarkis.acc.setup.sellwares
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.sellwares.xml
+
+skip if $selected -> exists
+return null
+
+$page.id = 8510
+$null = null
+$setup.array = $selected -> get local variable: name='anarkis.acc.setup'
+$ware.list =  array alloc: size=0
+$jump.range = 2
+$sector = $selected -> get sector
+
+while $menu.result != -1
+$menu =  create custom menu array
+$st =  read text: page=$page.id id=641
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=646
+add custom menu item to array $menu: text=$st returnvalue='add.ware'
+$cnt =  size of array $ware.list
+while $cnt
+dec $cnt =
+$v1 = $ware.list[$cnt]
+$v2 = $selected -> get amount of ware $v1 in cargo bay
+$st = sprintf: pageid=$page.id textid=650, $v1, $v2, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=$v1
+end
+$st =  read text: page=$page.id id=642
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=643
+add custom menu item to array $menu: text=$st returnvalue='rem.all'
+$st =  read text: page=$page.id id=644
+add custom menu item to array $menu: text=$st returnvalue='add.all'
+$st =  read text: page=$page.id id=663
+add custom menu item to array $menu: text=$st returnvalue='add.missile'
+$st =  read text: page=$page.id id=647
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=648, $jump.range, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='jump.range'
+$st =  read text: page=$page.id id=645
+add custom menu item to array $menu: text=$st returnvalue='proceed'
+
+$st = sprintf: pageid=$page.id textid=649, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=640
+$st = sprintf: pageid=$page.id textid=488, $selected, null, null, null, null
+$menu.result =  open custom menu: title=$v1 description=$st option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'rem.all'
+$ware.list =  array alloc: size=0
+
+else if $menu.result == 'jump.range'
+$st =  read text: page=$page.id id=651
+$jump.range = $selected -> get user input: type=Var/Number, title=$st
+
+else if $menu.result == 'add.ware'
+$st =  read text: page=$page.id id=652
+$v1 = $selected -> get user input: type=Var/Ware of Ship, title=$st
+$v1 = $v1[0]
+if $v1
+skip if  find $v1 in array: $ware.list
+append $v1 to array $ware.list
+end
+
+else if $menu.result == 'add.missile'
+$wares = $selected -> get tradeable ware array from ship
+$cnt =  size of array $wares
+while $cnt
+dec $cnt =
+$v1 = $wares[$cnt]
+$v2 =  get maintype of ware $v1
+if $v2 == 10
+skip if  find $v1 in array: $ware.list
+append $v1 to array $ware.list
+end
+end
+
+else if $menu.result == 'add.all'
+$wares = $selected -> get tradeable ware array from ship
+$cnt =  size of array $wares
+while $cnt
+dec $cnt =
+$v1 = $wares[$cnt]
+$v2 =  get maintype of ware $v1
+if $v2 != 10 AND $v2 != 8 AND $v2 != 9
+skip if  find $v1 in array: $ware.list
+append $v1 to array $ware.list
+end
+end
+
+else if  is datatyp[ $menu.result ] == DATATYP_WARE
+$v1 =  get index of $menu.result in array $ware.list offset=-1 + 1
+remove element from array $ware.list at index $v1
+
+else if $menu.result == 'proceed'
+$ok = [TRUE]
+
+while $ok == [TRUE]
+$ok = [FALSE]
+gosub cleanlist
+$proc.count =  size of array $ware.list
+while $proc.count
+dec $proc.count =
+$select.ware = $ware.list[$proc.count]
+gosub getbestship
+if $select.ship -> exists
+$ok = [TRUE]
+$dest.station = $select.ship -> call script !lib.get.bestsell :  Ware=$select.ware  Min Price=null  Max Jumps=$jump.range  Check for Property=[FALSE]  Find around sector=$selected
+$proc.warecount = $select.ship -> get max amount of ware $select.ware that can be stored in cargo bay
+START $select.ship -> call script anarkis.acc.cmd.sell.return :  ware=$select.ware  station=$dest.station  quantity=$proc.warecount  min price=null
+$st = sprintf: pageid=$page.id textid=653, $select.ship, $select.ware, $dest.station, null, null
+display subtitle text: text=$st duration=2000 ms
+= wait 2000 ms
+end
+end
+end
+$menu.result = -1
+end
+end
+
+return null
+
+
+cleanlist:
+$cnt =  size of array $ware.list
+while $cnt
+dec $cnt =
+$select.ware = $ware.list[$cnt]
+if not $selected -> get amount of ware $select.ware in cargo bay
+remove element from array $ware.list at index $cnt
+continue
+end
+gosub getbestship
+if not $select.ship -> exists
+remove element from array $ware.list at index $cnt
+$st = sprintf: pageid=$page.id textid=655, $select.ware, null, null, null, null
+display subtitle text: text=$st duration=2000 ms
+= wait 2000 ms
+continue
+end
+if not $select.ship -> call script !lib.get.bestsell :  Ware=$select.ware  Min Price=null  Max Jumps=$jump.range  Check for Property=[FALSE]  Find around sector=$selected
+remove element from array $ware.list at index $cnt
+$st = sprintf: pageid=$page.id textid=654, $select.ware, null, null, null, null
+display subtitle text: text=$st duration=2000 ms
+= wait 2000 ms
+continue
+end
+end
+
+endsub
+
+getstation:
+$dest.station = $selected -> find station: resource $select.ware with best price: min.price=null, amount=$ware.amount, max.jumps=$jump.range, startsector=$sector, trader=$select.ship, exclude array=null
+endsub
+
+
+getbestship:
+$select.ship = null
+$v2 = 0
+$id = null
+$ware.amount = $selected -> get amount of ware $select.ware in cargo bay
+$ship.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$ship.count =  size of array $ship.list
+while $ship.count
+dec $ship.count =
+$v1 = $ship.list[$ship.count]
+skip if not $v1 -> is task 0 in use
+continue
+$amt = $v1 -> get max amount of ware $select.ware that can be stored in cargo bay
+if $amt > $v2
+$v2 = $amt
+$id = $ship.count
+skip if not $amt >= $ware.amount
+break
+end
+end
+if $id != null
+$select.ship = $ship.list[$id]
+end
+endsub
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.setup.ships.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.ships.x3s
@@ -1,0 +1,169 @@
+#name: anarkis.acc.setup.ships
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.ships.xml
+
+$page.id = 8510
+* Retrieve setup, apply default if not found
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$cnt =  size of array $setup.array
+skip if $cnt == 19
+$setup.array = [THIS] -> call script anarkis.acc.setup.default :
+
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st = sprintf: pageid=$page.id textid=210, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$setup.missile = $setup.array[12]
+if not $setup.missile
+$v1 =  read text: page=$page.id id=205
+else
+$v1 = $setup.missile + '%'
+end
+$st = sprintf: pageid=$page.id textid=213, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='setup.missile'
+
+$setup.emergency = $setup.array[10]
+$v1 =  read text: page=$page.id id=205
+if $setup.emergency == [TRUE]
+$v1 =  read text: page=$page.id id=201
+else if $setup.emergency == [FALSE]
+$v1 =  read text: page=$page.id id=202
+end
+
+$setup.shieldlimit = $setup.array[11]
+if not $setup.shieldlimit
+$v2 =  read text: page=$page.id id=205
+else
+$v2 = $setup.shieldlimit + '%'
+end
+$st = sprintf: pageid=$page.id textid=214, $v1, $v2, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='setup.emergency'
+
+$autojump.enabled = $setup.array[7]
+$autojump.range = $setup.array[8]
+$v1 =  read text: page=$page.id id=205
+if $autojump.enabled == [TRUE]
+$v1 =  read text: page=$page.id id=201
+else if $autojump.enabled == [FALSE]
+$v1 =  read text: page=$page.id id=202
+end
+if not $autojump.range
+$v2 =  read text: page=$page.id id=205
+else
+$v2 = $autojump.range
+end
+$st = sprintf: pageid=$page.id textid=215, $v1, $v2, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='setup.autojump'
+
+$fuel.resupply = $setup.array[9]
+if not $fuel.resupply
+$v1 =  read text: page=$page.id id=205
+else
+$v1 = $fuel.resupply
+end
+$st = sprintf: pageid=$page.id textid=216, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='fuel.resupply'
+
+$turret.setup = $setup.array[14]
+$v1 =  read text: page=$page.id id=$turret.setup
+$st = sprintf: pageid=$page.id textid=244, $v1, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=245, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=245
+$st = sprintf: pageid=$page.id textid=246, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=246
+$st = sprintf: pageid=$page.id textid=247, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=247
+$mars.check = get global variable: name='GZ.MARS.CONFIG'
+if  is datatyp[ $mars.check ] == DATATYP_ARRAY
+$st = sprintf: pageid=$page.id textid=248, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=248
+$st = sprintf: pageid=$page.id textid=249, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=249
+
+end
+
+$st =  read text: page=$page.id id=230
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=231, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='set.all'
+$st = sprintf: pageid=$page.id textid=237, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='set.active'
+
+
+$v1 = [THIS] -> get object class
+$st = sprintf: pageid=$page.id textid=250, [THIS], $v1, null, null, null
+add custom menu info line to array $menu: text=$st
+$st = sprintf: pageid=$page.id textid=251, [SECTOR], null, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 = [THIS] -> get number of landed ships
+$v2 = [THIS] -> get dock bay size
+$v3 = [THIS] -> get owned ships: class/type=Ship
+$v3 =  size of array $v3
+$st = sprintf: pageid=$page.id textid=252, $v1, $v2, $v3, null, null
+add custom menu info line to array $menu: text=$st
+
+$st = sprintf: fmt='%s - Carrier Setup', [THIS], null, null, null, null
+$v1 =  read text: page=$page.id id=200
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'fuel.resupply'
+$st =  read text: page=$page.id id=308
+$fuel.resupply = [THIS] -> get user input: type=Var/Number, title=$st
+$setup.array[9] = $fuel.resupply
+
+else if $menu.result == 'setup.autojump'
+$st =  read text: page=$page.id id=309
+$autojump.enabled = [THIS] -> get user input: type=Var/Boolean, title=$st
+if $autojump.enabled == 1
+$autojump.enabled = [TRUE]
+$st =  read text: page=$page.id id=310
+$autojump.range = [THIS] -> get user input: type=Var/Number, title=$st
+$setup.array[8] = $autojump.range
+else
+$autojump.enabled = [FALSE]
+end
+$setup.array[7] = $autojump.enabled
+
+else if $menu.result == 'setup.emergency'
+$st =  read text: page=$page.id id=311
+$setup.emergency = [THIS] -> get user input: type=Var/Boolean, title=$st
+if $setup.emergency == 1
+$setup.emergency = [TRUE]
+$st =  read text: page=$page.id id=312
+$setup.shieldlimit = [THIS] -> get user input: type=Var/Number, title=$st
+$setup.array[11] = $setup.shieldlimit
+else
+$setup.emergency = [FALSE]
+end
+$setup.array[10] = $setup.emergency
+
+else if $menu.result == 'setup.missile'
+$st =  read text: page=$page.id id=313
+$setup.missile = [THIS] -> get user input: type=Var/Number, title=$st
+$setup.array[12] = $setup.missile
+
+else if $menu.result == 'set.active'
+= [THIS] -> call script anarkis.acc.apply.settings :  active ships only?=[TRUE]
+
+else if $menu.result == 'set.all'
+= [THIS] -> call script anarkis.acc.apply.settings :  active ships only?=[FALSE]
+
+else if $menu.result >= 245
+$setup.array[14] = $menu.result
+
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.setup.supplies.c2s.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.supplies.c2s.x3s
@@ -1,0 +1,172 @@
+#name: anarkis.acc.setup.supplies.c2s
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.supplies.c2s.xml
+
+$page.id = 8510
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$supply.setup = $setup.array[15]
+
+$trans.ship = 529
+$trans.mode = 525
+
+$ware.list =  array alloc: size=0
+$ware.limit =  array alloc: size=0
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=521
+add custom menu heading to array $menu: title=$st
+
+$st =  read text: page=$page.id id=522
+add custom menu item to array $menu: text=$st returnvalue='add'
+
+$v1 =  size of array $ware.list
+while $v1
+dec $v1 =
+$v2 = $ware.list[$v1]
+$v3 = $ware.limit[$v1]
+$st = sprintf: pageid=$page.id textid=523, $v2, $v3, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=$v2
+end
+
+$st =  read text: page=$page.id id=$trans.mode
+$st = sprintf: pageid=$page.id textid=524, $st, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=525
+add custom menu item to array $menu: text=$st returnvalue=525
+$st =  read text: page=$page.id id=526
+add custom menu item to array $menu: text=$st returnvalue=526
+
+$st =  read text: page=$page.id id=$trans.ship
+$st = sprintf: pageid=$page.id textid=527, $st, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=528
+add custom menu item to array $menu: text=$st returnvalue=528
+$st =  read text: page=$page.id id=529
+add custom menu item to array $menu: text=$st returnvalue=529
+
+$st =  read text: page=$page.id id=530
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=531
+add custom menu item to array $menu: text=$st returnvalue='proceed'
+
+$v1 =  read text: page=$page.id id=520
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result < 527
+$trans.mode = $menu.result
+
+else if $menu.result < 530
+$trans.ship = $menu.result
+
+else if  is datatyp[ $menu.result ] == DATATYP_WARE
+$v1 =  get index of $menu.result in array $ware.list offset=-1 + 1
+remove element from array $ware.list at index $v1
+remove element from array $ware.limit at index $v1
+
+else if $menu.result == 'add'
+$st =  read text: page=$page.id id=532
+if [THIS] -> is of class Station
+$v1 = [THIS] -> get user input: type=Var/Station and Ware, title=$st
+else
+$v1 = [THIS] -> get user input: type=Var/Ware of Ship, title=$st
+end
+$v1 = $v1[0]
+skip if not  find $v1 in array: $ware.list
+continue
+skip if not $v1 == null
+continue
+$st =  read text: page=$page.id id=533
+$v2 = [THIS] -> get user input: type=Var/Number, title=$st
+skip if $v2 > 0
+continue
+append $v1 to array $ware.list
+append $v2 to array $ware.limit
+
+else if $menu.result == 'proceed'
+* - - Proceed
+
+$report.menu =  create custom menu array
+$st =  read text: page=$page.id id=541
+add custom menu heading to array $report.menu: title=$st
+
+if $trans.ship == 528
+$array = [THIS] -> get ship array from sector/ship/station
+else
+$array = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[FALSE]
+end
+$total.ship =  size of array $array
+$cnt =  size of array $array
+* - - Mode : 525 - Same Quant
+if $trans.mode == 525
+$ware.count =  size of array $ware.list
+while $ware.count
+dec $ware.count =
+$ware = $ware.list[$ware.count]
+$ware.quant = $ware.limit[$ware.count]
+$curr.amt = [THIS] -> get amount of ware $ware in cargo bay
+$add.amt = $curr.amt / $total.ship
+skip if $add.amt
+inc $add.amt =
+skip if $add.amt <= $ware.quant
+$add.amt = $ware.quant
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$ship = $array[$cnt]
+$left = $ship -> add $add.amt units of $ware
+$st = sprintf: pageid=$page.id textid=542, $left, $ware, $ship, null, null
+add custom menu item to array $report.menu: text=$st returnvalue=0
+
+$rem = 0 - $add.amt
+= [THIS] -> add $rem units of $ware
+skip if [THIS] -> get amount of ware $ware in cargo bay
+break
+end
+end
+* - - Mode : 526 - At least
+else if $trans.mode == 526
+$ware.count =  size of array $ware.list
+while $ware.count
+dec $ware.count =
+$ware = $ware.list[$ware.count]
+$ware.quant = $ware.limit[$ware.count]
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$ship = $array[$cnt]
+$curr.amt = [THIS] -> get amount of ware $ware in cargo bay
+skip if $curr.amt >= $ware.quant
+$ware.quant = $curr.amt
+$left = $ship -> add $ware.quant units of $ware
+
+$st = sprintf: pageid=$page.id textid=542, $left, $ware, $ship, null, null
+add custom menu item to array $report.menu: text=$st returnvalue=0
+
+$rem = 0 - $ware.quant
+= [THIS] -> add $rem units of $ware
+
+
+
+skip if [THIS] -> get amount of ware $ware in cargo bay
+break
+end
+end
+end
+* - - And exit
+$v1 =  read text: page=$page.id id=540
+$v2 =  read text: page=$page.id id=260
+$x =  open custom menu: title=$v1 description=$v2 option array=$report.menu
+return null
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.setup.supplies.s2c.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.supplies.s2c.x3s
@@ -1,0 +1,111 @@
+#name: anarkis.acc.setup.supplies.s2c
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.supplies.s2c.xml
+
+$page.id = 8510
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$supply.setup = $setup.array[15]
+
+$trans.type = 451
+$trans.ship = 456
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=$trans.type
+$st = sprintf: pageid=$page.id textid=450, $st, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$st =  read text: page=$page.id id=451
+add custom menu item to array $menu: text=$st returnvalue=451
+$st =  read text: page=$page.id id=452
+add custom menu item to array $menu: text=$st returnvalue=452
+$st =  read text: page=$page.id id=453
+add custom menu item to array $menu: text=$st returnvalue=453
+$st =  read text: page=$page.id id=454
+add custom menu item to array $menu: text=$st returnvalue=454
+
+$st =  read text: page=$page.id id=$trans.ship
+$st = sprintf: pageid=$page.id textid=455, $st, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$st =  read text: page=$page.id id=456
+add custom menu item to array $menu: text=$st returnvalue=456
+$st =  read text: page=$page.id id=457
+add custom menu item to array $menu: text=$st returnvalue=457
+
+$st =  read text: page=$page.id id=458
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=459
+add custom menu item to array $menu: text=$st returnvalue='proceed'
+
+$st =  read text: page=$page.id id=449
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=440
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result < 456
+$trans.type = $menu.result
+
+else if $menu.result < 460
+$trans.ship = $menu.result
+
+else if $menu.result == 'proceed'
+if $trans.ship == 457
+$array = [THIS] -> get ship array from sector/ship/station
+else
+$array = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[FALSE]
+end
+$cnt =  size of array $array
+$report.menu =  create custom menu array
+$st =  read text: page=$page.id id=541
+add custom menu heading to array $report.menu: title=$st
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$wares = $select -> get tradeable ware array from ship
+$v1 =  size of array $wares
+while $v1
+dec $v1 =
+$cur.ware = $wares[$v1]
+$v2 =  get maintype of ware $cur.ware
+if $trans.type == 451 AND ( $v2 != 8 AND $v2 != 16 AND $v2 != 10 AND $v2 != 11 )
+$amt = $select -> get amount of ware $cur.ware in cargo bay
+$left = $select -> unload $amt units of $cur.ware
+$st = sprintf: pageid=$page.id textid=543, $left, $cur.ware, $select, null, null
+add custom menu item to array $report.menu: text=$st returnvalue=0
+else if $trans.type == 452 AND ( $v2 != 8 AND $v2 != 10 AND $v2 != 16 )
+$amt = $select -> get amount of ware $cur.ware in cargo bay
+$left = $select -> unload $amt units of $cur.ware
+$st = sprintf: pageid=$page.id textid=543, $left, $cur.ware, $select, null, null
+add custom menu item to array $report.menu: text=$st returnvalue=0
+else if $trans.type == 453 AND ( $v2 == 10 )
+$amt = $select -> get amount of ware $cur.ware in cargo bay
+$left = $select -> unload $amt units of $cur.ware
+$st = sprintf: pageid=$page.id textid=543, $left, $cur.ware, $select, null, null
+add custom menu item to array $report.menu: text=$st returnvalue=0
+else if $trans.type == 454
+$amt = $select -> get amount of ware $cur.ware in cargo bay
+$left = $select -> unload $amt units of $cur.ware
+$st = sprintf: pageid=$page.id textid=543, $left, $cur.ware, $select, null, null
+add custom menu item to array $report.menu: text=$st returnvalue=0
+end
+end
+end
+$v1 =  read text: page=$page.id id=540
+$v2 =  read text: page=$page.id id=260
+$x =  open custom menu: title=$v1 description=$v2 option array=$report.menu
+
+return null
+
+end
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.setup.supplies.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.supplies.x3s
@@ -1,0 +1,61 @@
+#name: anarkis.acc.setup.supplies
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.supplies.xml
+
+$page.id = 8510
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$supply.setup = $setup.array[15]
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=442
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=443
+add custom menu item to array $menu: text=$st returnvalue='c2s'
+$st =  read text: page=$page.id id=444
+add custom menu item to array $menu: text=$st returnvalue='s2c'
+
+$st =  read text: page=$page.id id=445
+add custom menu heading to array $menu: title=$st
+
+$replace.ship = $supply.setup[0]
+if $replace.ship == [TRUE]
+$v1 = 203
+else
+$v1 = 204
+end
+$st =  read text: page=$page.id id=$v1
+$st = sprintf: pageid=$page.id textid=446, $st, null, null, null, null
+*add custom menu item to array $menu: text=$st returnvalue='replace.ship'
+
+$keep.supply = $supply.setup[1]
+if $keep.supply == [TRUE]
+$v1 = 203
+else
+$v1 = 204
+end
+$st =  read text: page=$page.id id=$v1
+$st = sprintf: pageid=$page.id textid=447, $st, null, null, null, null
+*add custom menu item to array $menu: text=$st returnvalue='keep.supply'
+
+$st =  read text: page=$page.id id=441
+add custom menu info line to array $menu: text=$st
+$v1 =  read text: page=$page.id id=440
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 's2c'
+= [THIS] -> call script anarkis.acc.setup.supplies.s2c :
+else if $menu.result == 'c2s'
+= [THIS] -> call script anarkis.acc.setup.supplies.c2s :
+end
+
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.setup.threatsetup.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.threatsetup.x3s
@@ -1,0 +1,34 @@
+#name: anarkis.acc.setup.threatsetup
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.threatsetup.xml
+
+$page.id = 8510
+
+$menu.result = -1
+while $menu.result == -1
+$menu =  create custom menu array
+
+$st = sprintf: pageid=$page.id textid=307, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+add custom menu item to array $menu: text='1' returnvalue=1
+add custom menu item to array $menu: text='3' returnvalue=3
+add custom menu item to array $menu: text='5' returnvalue=5
+add custom menu item to array $menu: text='10' returnvalue=10
+add custom menu item to array $menu: text='15' returnvalue=15
+add custom menu item to array $menu: text='20' returnvalue=20
+add custom menu item to array $menu: text='25' returnvalue=25
+add custom menu item to array $menu: text='30' returnvalue=30
+add custom menu item to array $menu: text='35' returnvalue=35
+add custom menu item to array $menu: text='40' returnvalue=40
+
+$st = sprintf: pageid=$page.id textid=305, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+$st = sprintf: pageid=$page.id textid=306, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 = sprintf: pageid=$page.id textid=301, null, null, null, null, null
+$menu.result =  open custom menu: title=$v1 description=null option array=$menu
+end
+
+return $menu.result

--- a/tools/fixtures/known_good/anarkis.acc.setup.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.setup.x3s
@@ -1,0 +1,113 @@
+#name: anarkis.acc.setup
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.setup.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+
+
+* Retrieve setup, apply default if not found
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$cnt =  size of array $setup.array
+if not $cnt == 19
+$setup.array = [THIS] -> call script anarkis.ads.setup.createdefault :  ref.object=[THIS]
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup.array
+end
+
+*= [THIS] -> call script anarkis.acc.apply.active :
+
+skip if [THIS] -> is script anarkis.acc.task.repairs on stack of task=900
+[THIS] -> start task 900 with script anarkis.acc.task.repairs and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=240
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=211, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='setup.home'
+$st = sprintf: pageid=$page.id textid=242, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='repairbay'
+
+if [THIS] -> is of class Station
+$st = sprintf: pageid=$page.id textid=1086, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='barracks'
+else if [THIS] -> is of class M1
+$st = sprintf: pageid=$page.id textid=1086, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='barracks'
+end
+
+$st = sprintf: pageid=$page.id textid=241, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='autocarrier'
+
+
+$st = sprintf: pageid=$page.id textid=440, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=443, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='c2s'
+$st = sprintf: pageid=$page.id textid=444, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='s2c'
+
+$st = sprintf: pageid=$page.id textid=210, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=232, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='reset'
+
+$v1 = [THIS] -> get object class
+$v2 = [THIS] -> get name
+$st = sprintf: pageid=$page.id textid=250, $v2, $v1, null, null, null
+add custom menu info line to array $menu: text=$st
+$st = [THIS] -> call script anarkis.lib.sector.format :  sector=[SECTOR]
+$st = sprintf: pageid=$page.id textid=251, $st, null, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 = [THIS] -> get number of landed ships
+$v2 = [THIS] -> get dock bay size
+$v3 = [THIS] -> get owned ships: class/type=Ship
+$v3 =  size of array $v3
+$st = sprintf: pageid=$page.id textid=252, $v1, $v2, $v3, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=200
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'autocarrier'
+= [THIS] -> call script anarkis.acc.setup.autocarrier :
+
+else if $menu.result == 'c2s'
+= [THIS] -> call script anarkis.acc.setup.supplies.c2s :
+
+else if $menu.result == 's2c'
+= [THIS] -> call script anarkis.acc.setup.supplies.s2c :
+
+else if $menu.result == 'setup.home'
+= [THIS] -> call script anarkis.acc.setup.hangars :
+
+else if $menu.result == 'repairbay'
+= [THIS] -> call script anarkis.acc.setup.repair :
+
+else if $menu.result == 'supplies'
+= [THIS] -> call script anarkis.acc.setup.supplies :
+else if $menu.result == 'barracks'
+= [THIS] -> call script anarkis.ads.comm.barracks :  ship or station=[THIS]
+
+* dont loop here
+
+else if $menu.result == 'reset'
+$setup.array = [THIS] -> call script anarkis.acc.setup.default :
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup.array
+
+
+end
+
+end
+
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup.array
+return $setup.array

--- a/tools/fixtures/known_good/anarkis.acc.signal.killed.npc.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.signal.killed.npc.x3s
@@ -1,0 +1,11 @@
+#name: anarkis.acc.signal.killed.npc
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.signal.killed.npc.xml
+
+* Prevent ship respawn
+
+[THIS] -> set owner race to Neutral Race
+[THIS] -> set homebase to null
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.task.autocarrier.npc.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.task.autocarrier.npc.x3s
@@ -1,0 +1,363 @@
+#name: anarkis.acc.task.autocarrier.npc
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.task.autocarrier.npc.xml
+
+* ===========================================
+* Automated Carrier : Main Task
+* Can be run on NPC carriers without the ship respawning
+* ===========================================
+
+$null = null
+$fightinprogress = [FALSE]
+$page.id = 8510
+
+if [OWNER] == Player
+return null
+end
+
+$save.owner = [OWNER]
+
+while [OWNER] == $save.owner
+
+* - Reload setup
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$var1 =  size of array $setup.array
+if not $var1 == 19
+$setup.array = [THIS] -> call script anarkis.ads.setup.createdefault :  ref.object=[THIS]
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup.array
+= [THIS] -> call script anarkis.acc.apply.active :
+end
+
+* - Start Repair task if needed
+*skip if [THIS] -> is script anarkis.acc.task.repairs on stack of task=900
+*[THIS] -> start task 900 with script anarkis.acc.task.repairs and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+
+$display.warning = $setup.array[4]
+$alert.level = $setup.array[0]
+$defence.ships = $setup.array[2]
+$attack.mode = $setup.array[6]
+$autorename = $setup.array[15]
+$dock.delay = $setup.array[18]
+
+*$curr.threat = $null -> call script anarkis.acc.evalute.danger :  sector=[SECTOR]  checker=[THIS]
+$curr.threat = $null -> call script anarkis.acc.evalute.danger.npc :  sector=[SECTOR]  checker=[THIS]
+$shield = [THIS] -> get shield percent
+$attacker = [THIS] -> get attacker
+if $curr.threat > 3
+$strongest = $null -> call script anarkis.acc.evaluate.findstrong :  sector=[SECTOR]  checker=[THIS]
+end
+
+* - The carrier is attacked by an incoming
+if $attacker != null AND $shield <= 80 AND $fightinprogress == [FALSE]
+gosub alert
+gosub counterattack
+
+* - The threat level is reached
+else if $curr.threat >= $alert.level AND $fightinprogress == [FALSE]
+gosub alert
+gosub rename
+* - - Nearest First (usual command will work)
+if $attack.mode == 1
+gosub clearsector
+* - - Strongest First
+else if $attack.mode == 2
+gosub strongestfirst
+* - - Let ACC decide
+else
+gosub decide
+end
+
+* - Battle in progress, handle wings and deploy docked fighters
+else if $curr.threat > 0 AND $fightinprogress == [TRUE]
+gosub handlewings
+
+* - Threat eliminated, lets dock if no new enemies
+else if $curr.threat == 0 AND $fightinprogress == [TRUE]
+$pl.time = playing time
+$end.time = $pl.time + $dock.delay
+skip if not $dock.delay
+gosub protect.carrier
+while $pl.time < $end.time AND $curr.threat == 0
+= wait randomly from 1000 to 2000 ms
+$curr.threat = $null -> call script anarkis.acc.evalute.danger.npc :  sector=[SECTOR]  checker=[THIS]
+*$curr.threat = $null -> call script anarkis.acc.evalute.danger :  sector=[SECTOR]  checker=[THIS]
+$pl.time = playing time
+end
+if $curr.threat == 0
+$fightinprogress = [FALSE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=null
+= [THIS] -> call script anarkis.acc.cmd.alert.dock :
+gosub stoprename
+else
+gosub stop.protect
+end
+
+* - Not supposed to happen, but it happens :/ so we dock
+else if [THIS] -> call script anarkis.acc.lib.get.flyads :
+$fightinprogress = [FALSE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=null
+= [THIS] -> call script anarkis.acc.cmd.alert.dock :
+gosub stoprename
+end
+
+= wait 8000 ms
+end
+return null
+
+
+* ====================================
+* AutoRename v2
+* ====================================
+rename:
+if $autorename == [TRUE]
+if not [THIS] -> is script anarkis.acc.task.autoname.plus on stack of task=893
+= [THIS] -> call script anarkis.acc.lib.name.save :
+[THIS] -> start task 893 with script anarkis.acc.task.autoname.plus and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+end
+endsub
+* ====================================
+stoprename:
+if [THIS] -> is script anarkis.acc.task.autoname.plus on stack of task=893
+[THIS] -> start task 893 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+= [THIS] -> call script anarkis.acc.lib.name.load :
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Wings ordered to resume battle
+* ====================================
+stop.protect:
+$arr = [THIS] -> call script anarkis.acc.lib.get.leaderlist :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$leader = $arr[$cnt]
+START $leader -> call script !ship.cmd.killenemies.std :
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Wings ordered to protect carrier
+* ====================================
+protect.carrier:
+$arr = [THIS] -> call script anarkis.acc.lib.get.leaderlist :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$leader = $arr[$cnt]
+START $leader -> call script anarkis.acc.cmd.protect :  protect target=[THIS]
+end
+$arr = [THIS] -> call script anarkis.acc.lib.get.lonely :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$leader = $arr[$cnt]
+START $leader -> call script !ship.cmd.returnhome.std :
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Handle wings during battle
+* ====================================
+handlewings:
+if $attack.mode != 1
+$my.attacker = [THIS] -> get attacker
+$leader = [THIS] -> call script anarkis.acc.lib.get.leader.big :
+if $my.attacker -> is of class Big Ship
+if $leader
+$var1 = $leader -> get attack target
+skip if $var1 == $my.attacker
+START $leader -> call script anarkis.acc.cmd.attack.return :  victim=$my.attacker  dst=[THIS]
+end
+else
+$strongest = $null -> call script anarkis.acc.evaluate.findstrong :  sector=[SECTOR]  checker=[THIS]
+if $strongest AND $leader
+$var1 = $leader -> get attack target
+skip if $var1 == $strongest
+START $leader -> call script anarkis.acc.cmd.attack.return :  victim=$strongest  dst=[THIS]
+end
+end
+end
+= wait 100 ms
+= [THIS] -> call script anarkis.acc.lib.givetarget :
+= wait 100 ms
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+* ====================================
+* Display warning if needed
+* ====================================
+alert:
+skip if $display.warning == [TRUE]
+endsub
+$enemy.class = $strongest -> get object class
+$var1 = [THIS] -> call script anarkis.acc.get.all :  ship class=Moveable Ship  no damaged ships?=[TRUE]  active only?=[TRUE]
+$var1 =  size of array $var1
+if ( $var1 < $curr.threat AND $curr.threat > 40 ) OR ( $enemy.class == M2 ) OR ( $shield < 30 AND $attacker )
+
+$display.mode = $setup.array[5]
+if $display.mode == 1
+else if $display.mode == 1
+play sample [IncomingTransmission.SOS]
+$st = sprintf: pageid=$page.id textid=506, [THIS], [SECTOR], null, null, null
+display subtitle text: text=$st duration=15000 ms
+else if $display.mode == 2
+START $null -> call script anarkis.acc.audio.alert :  ship=[THIS]
+else if $display.mode == 3
+$st = sprintf: pageid=$page.id textid=500, [THIS], [SECTOR], null, null, null
+send incoming message $st to player: display it=[TRUE]
+end
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Will choose to attack the stronger if M6 or + found else will go for usual
+* ====================================
+decide:
+$enemy.class = $strongest -> get object class
+if $enemy.class == M1 OR $enemy.class == M2 OR $enemy.class == M7 OR $enemy.class == M6
+goto label advanced.mode
+*goto label strongestfirst
+else
+goto label clearsector
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Most efficient way
+* ====================================
+* - Each wing will be sent with a size according to the threat
+* ====================================
+advanced.mode:
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+$fightinprogress = [TRUE]
+$enemy.list = [THIS] -> call script anarkis.acc.lib.get.enemies :  sector=[SECTOR]  checker=[THIS]
+$enemy.count =  size of array $enemy.list
+$wing.id = 0
+while $enemy.count
+dec $enemy.count =
+$enemy.ship = $enemy.list[$enemy.count]
+$enemy.class = $enemy.ship -> get object class
+$min.fighter = [THIS] -> call script anarkis.lib.get.shipcount :  class=$enemy.class
+$dock.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$dock.count =  size of array $dock.list
+if $dock.count >= $min.fighter
+inc $wing.id =
+$wing.name = sprintf: fmt='A%s', $wing.id, null, null, null, null
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$enemy.ship  wing size=$min.fighter  wing ID=$wing.name
+end
+end
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+strongestfirst:
+* ====================================
+* Will attack the strongest enemy in range first
+* ====================================
+* - A defensive wing will be deployed
+* - An offensive wing against the strongest enemy will be deployed
+* - Other ships if any are ordered to clear sector
+* ====================================
+* No strong, fall back to clear sector
+skip if $strongest -> exists
+goto label clearsector
+$fightinprogress = [TRUE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+= [THIS] -> call script anarkis.acc.apply.relations :  active ships only?=[TRUE]
+* Repair Shields
+= [THIS] -> call script anarkis.acc.repairshields :
+* A defensive wing will be deployed
+if $defence.ships > 0
+= [THIS] -> call script anarkis.acc.wing.defence :  target=[THIS]  wing size=$defence.ships
+= wait 2000 ms
+end
+* An offensive wing against the strongest enemy will be deployed
+$enemy.class = $strongest -> get object class
+$min.fighter = [THIS] -> call script anarkis.lib.get.shipcount :  class=$enemy.class
+$dock.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$dock.count =  size of array $dock.list
+if $dock.count > $min.fighter
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$strongest  wing size=$min.fighter  wing ID='A'
+else
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$strongest  wing size=$dock.count  wing ID='A'
+end
+* Other ships if any are ordered to clear sector
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+clearsector:
+* ====================================
+* Used in non critical situation
+* ====================================
+* - A defensive wing will be deployed
+* - Other ships if any are ordered to clear sector
+* ====================================
+$fightinprogress = [TRUE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+= [THIS] -> call script anarkis.acc.apply.relations :  active ships only?=[TRUE]
+= [THIS] -> call script anarkis.acc.repairshields :
+if $defence.ships > 0
+= [THIS] -> call script anarkis.acc.wing.defence :  target=[THIS]  wing size=$defence.ships
+= wait 2000 ms
+end
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+counterattack:
+* ====================================
+* Used when the carrier is attacked by an incoming
+* ====================================
+* - A defensive wing will be deployed
+* - An offensive wing against the attacker will be deployed too
+* - Other ships if any are ordered to clear sector
+* ====================================
+skip if $attacker -> exists
+endsub
+$fightinprogress = [TRUE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+= [THIS] -> call script anarkis.acc.repairshields :
+= [THIS] -> call script anarkis.acc.apply.relations :  active ships only?=[TRUE]
+* A defensive wing will be deployed
+if $defence.ships > 0
+= [THIS] -> call script anarkis.acc.wing.defence :  target=[THIS]  wing size=$defence.ships
+= wait 2000 ms
+end
+* An offensive wing against the attacker will be deployed too
+$enemy.class = $attacker -> get object class
+$min.fighter = $null -> call script anarkis.lib.get.shipcount :  class=$enemy.class
+$dock.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$dock.count =  size of array $dock.list
+if $dock.count > $min.fighter
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$attacker  wing size=$min.fighter  wing ID='A'
+else
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$attacker  wing size=$dock.count  wing ID='A'
+end
+* Other ships if any are ordered to clear sector
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+
+return null
+

--- a/tools/fixtures/known_good/anarkis.acc.task.autocarrier.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.task.autocarrier.x3s
@@ -1,0 +1,371 @@
+#name: anarkis.acc.task.autocarrier
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.task.autocarrier.xml
+
+* ===========================================
+* Automated Carrier : Main Task
+* ===========================================
+
+$null = null
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+$fightinprogress = [FALSE]
+
+*if [THIS] == [PLAYERSHIP]
+*$st = sprintf: pageid=$page.id textid=105, [THIS], null, null, null, null
+*send incoming message $st to player: display it=[TRUE]
+*end
+
+while [TRUE]
+*while [THIS] != [PLAYERSHIP]
+
+* - Reload setup
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$var1 =  size of array $setup.array
+if not $var1 == 19
+$setup.array = [THIS] -> call script anarkis.ads.setup.createdefault :  ref.object=[THIS]
+[THIS] -> set local variable: name='anarkis.acc.setup' value=$setup.array
+= [THIS] -> call script anarkis.acc.apply.active :
+end
+
+* - Start Repair task if needed
+skip if [THIS] -> is script anarkis.acc.task.repairs on stack of task=900
+[THIS] -> start task 900 with script anarkis.acc.task.repairs and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+
+$display.warning = $setup.array[4]
+$alert.level = $setup.array[0]
+$defence.ships = $setup.array[2]
+$attack.mode = $setup.array[6]
+$autorename = $gl.setup[3]
+$dock.delay = $setup.array[18]
+
+$curr.threat = $null -> call script anarkis.acc.evalute.danger :  sector=[SECTOR]  checker=[THIS]
+$shield = [THIS] -> get shield percent
+$attacker = [THIS] -> get attacker
+if $curr.threat > 3
+$strongest = $null -> call script anarkis.acc.evaluate.findstrong :  sector=[SECTOR]  checker=[THIS]
+end
+
+* - The carrier is attacked by an incoming
+if $attacker != null AND $shield <= 80 AND $fightinprogress == [FALSE]
+gosub alert
+gosub counterattack
+
+* - The threat level is reached
+else if $curr.threat >= $alert.level AND $fightinprogress == [FALSE]
+
+* - - ECS - -
+if [OWNER] == Player
+$my.name = [THIS] -> get name
+$st = sprintf: pageid=$page.id textid=1031, $my.name, [SECTOR], null, null, null
+$v1 = [THIS] -> get object class
+$var1 = sprintf: pageid=$page.id textid=1032, $my.name, $v1, [SECTOR], $curr.threat, null
+= [THIS] -> call script plugin.sk.ecs.news.add :  Plugin ID='anarkis.acc.plugin'  News Title=$st  News Content=$var1  from=[THIS]
+end
+* - - ECS End - -
+
+gosub alert
+gosub rename
+* - - Nearest First (usual command will work)
+if $attack.mode == 1
+gosub clearsector
+* - - Strongest First
+else if $attack.mode == 2
+gosub strongestfirst
+* - - Let ACC decide
+else
+gosub decide
+end
+
+* - Battle in progress, handle wings and deploy docked fighters
+else if $curr.threat > 0 AND $fightinprogress == [TRUE]
+gosub handlewings
+
+* - Threat eliminated, lets dock if no new enemies
+else if $curr.threat == 0 AND $fightinprogress == [TRUE]
+$pl.time = playing time
+$end.time = $pl.time + $dock.delay
+skip if not $dock.delay
+gosub protect.carrier
+while $pl.time < $end.time AND $curr.threat == 0
+= wait randomly from 1000 to 2000 ms
+$curr.threat = $null -> call script anarkis.acc.evalute.danger :  sector=[SECTOR]  checker=[THIS]
+$pl.time = playing time
+end
+if $curr.threat == 0
+$fightinprogress = [FALSE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=null
+= [THIS] -> call script anarkis.acc.cmd.alert.dock :
+gosub stoprename
+else
+gosub stop.protect
+end
+
+* - Not supposed to happen, but it happens :/ so we dock
+else if [THIS] -> call script anarkis.acc.lib.get.flyads :
+$fightinprogress = [FALSE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=null
+= [THIS] -> call script anarkis.acc.cmd.alert.dock :
+gosub stoprename
+end
+
+= wait 8000 ms
+end
+return null
+
+
+* ====================================
+* AutoRename v2
+* ====================================
+rename:
+if $autorename == [TRUE]
+if not [THIS] -> is script anarkis.acc.task.autoname.plus on stack of task=893
+= [THIS] -> call script anarkis.acc.lib.name.save :
+[THIS] -> start task 893 with script anarkis.acc.task.autoname.plus and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+end
+endsub
+* ====================================
+stoprename:
+if [THIS] -> is script anarkis.acc.task.autoname.plus on stack of task=893
+[THIS] -> start task 893 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+= [THIS] -> call script anarkis.acc.lib.name.load :
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Wings ordered to resume battle
+* ====================================
+stop.protect:
+$arr = [THIS] -> call script anarkis.acc.lib.get.leaderlist :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$leader = $arr[$cnt]
+START $leader -> call script !ship.cmd.killenemies.std :
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Wings ordered to protect carrier
+* ====================================
+protect.carrier:
+$arr = [THIS] -> call script anarkis.acc.lib.get.leaderlist :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$leader = $arr[$cnt]
+START $leader -> call script anarkis.acc.cmd.protect :  protect target=[THIS]
+end
+$arr = [THIS] -> call script anarkis.acc.lib.get.lonely :
+$cnt =  size of array $arr
+while $cnt
+dec $cnt =
+$leader = $arr[$cnt]
+START $leader -> call script !ship.cmd.returnhome.std :
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Handle wings during battle
+* ====================================
+handlewings:
+if $attack.mode != 1
+$my.attacker = [THIS] -> get attacker
+$leader = [THIS] -> call script anarkis.acc.lib.get.leader.big :
+if $my.attacker -> is of class Big Ship
+if $leader
+$var1 = $leader -> get attack target
+skip if $var1 == $my.attacker
+START $leader -> call script anarkis.acc.cmd.attack.return :  victim=$my.attacker  dst=[THIS]
+end
+else
+$strongest = $null -> call script anarkis.acc.evaluate.findstrong :  sector=[SECTOR]  checker=[THIS]
+if $strongest AND $leader
+$var1 = $leader -> get attack target
+skip if $var1 == $strongest
+START $leader -> call script anarkis.acc.cmd.attack.return :  victim=$strongest  dst=[THIS]
+end
+end
+end
+= wait 100 ms
+= [THIS] -> call script anarkis.acc.lib.givetarget :
+= wait 100 ms
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+* ====================================
+* Display warning if needed
+* ====================================
+alert:
+skip if $display.warning == [TRUE]
+endsub
+$enemy.class = $strongest -> get object class
+$var1 = [THIS] -> call script anarkis.acc.get.all :  ship class=Moveable Ship  no damaged ships?=[TRUE]  active only?=[TRUE]
+$var1 =  size of array $var1
+if ( $var1 < $curr.threat AND $curr.threat > 40 ) OR ( $enemy.class == M2 ) OR ( $shield < 30 AND $attacker )
+$display.mode = $setup.array[5]
+if $display.mode == 1
+else if $display.mode == 1
+play sample [IncomingTransmission.SOS]
+$st = sprintf: pageid=$page.id textid=506, [THIS], [SECTOR], null, null, null
+display subtitle text: text=$st duration=15000 ms
+else if $display.mode == 2
+START $null -> call script anarkis.acc.audio.alert :  ship=[THIS]
+else if $display.mode == 3
+$st = sprintf: pageid=$page.id textid=500, [THIS], [SECTOR], null, null, null
+send incoming message $st to player: display it=[TRUE]
+end
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Will choose to attack the stronger if M6 or + found else will go for usual
+* ====================================
+decide:
+$enemy.class = $strongest -> get object class
+if $enemy.class == M1 OR $enemy.class == M2 OR $enemy.class == M7 OR $enemy.class == M6
+goto label advanced.mode
+*goto label strongestfirst
+else
+goto label clearsector
+end
+endsub
+* ====================================
+
+
+* ====================================
+* Most efficient way
+* ====================================
+* - Each wing will be sent with a size according to the threat
+* ====================================
+advanced.mode:
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+$fightinprogress = [TRUE]
+$enemy.list = [THIS] -> call script anarkis.acc.lib.get.enemies :  sector=[SECTOR]  checker=[THIS]
+$enemy.count =  size of array $enemy.list
+$wing.id = 0
+while $enemy.count
+dec $enemy.count =
+$enemy.ship = $enemy.list[$enemy.count]
+$enemy.class = $enemy.ship -> get object class
+$min.fighter = [THIS] -> call script anarkis.lib.get.shipcount :  class=$enemy.class
+$dock.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$dock.count =  size of array $dock.list
+if $dock.count >= $min.fighter
+inc $wing.id =
+$wing.name = sprintf: fmt='A%s', $wing.id, null, null, null, null
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$enemy.ship  wing size=$min.fighter  wing ID=$wing.name
+end
+end
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+strongestfirst:
+* ====================================
+* Will attack the strongest enemy in range first
+* ====================================
+* - A defensive wing will be deployed
+* - An offensive wing against the strongest enemy will be deployed
+* - Other ships if any are ordered to clear sector
+* ====================================
+* No strong, fall back to clear sector
+skip if $strongest -> exists
+goto label clearsector
+$fightinprogress = [TRUE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+= [THIS] -> call script anarkis.acc.apply.relations :  active ships only?=[TRUE]
+* Repair Shields
+= [THIS] -> call script anarkis.acc.repairshields :
+* A defensive wing will be deployed
+if $defence.ships > 0
+= [THIS] -> call script anarkis.acc.wing.defence :  target=[THIS]  wing size=$defence.ships
+= wait 2000 ms
+end
+* An offensive wing against the strongest enemy will be deployed
+$enemy.class = $strongest -> get object class
+$min.fighter = [THIS] -> call script anarkis.lib.get.shipcount :  class=$enemy.class
+$dock.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$dock.count =  size of array $dock.list
+if $dock.count > $min.fighter
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$strongest  wing size=$min.fighter  wing ID='A'
+else
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$strongest  wing size=$dock.count  wing ID='A'
+end
+* Other ships if any are ordered to clear sector
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+clearsector:
+* ====================================
+* Used in non critical situation
+* ====================================
+* - A defensive wing will be deployed
+* - Other ships if any are ordered to clear sector
+* ====================================
+$fightinprogress = [TRUE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+= [THIS] -> call script anarkis.acc.apply.relations :  active ships only?=[TRUE]
+= [THIS] -> call script anarkis.acc.repairshields :
+if $defence.ships > 0
+= [THIS] -> call script anarkis.acc.wing.defence :  target=[THIS]  wing size=$defence.ships
+= wait 2000 ms
+end
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+counterattack:
+* ====================================
+* Used when the carrier is attacked by an incoming
+* ====================================
+* - A defensive wing will be deployed
+* - An offensive wing against the attacker will be deployed too
+* - Other ships if any are ordered to clear sector
+* ====================================
+skip if $attacker -> exists
+endsub
+$fightinprogress = [TRUE]
+[THIS] -> set local variable: name='anarkis.acc.battle' value=[TRUE]
+= [THIS] -> call script anarkis.acc.repairshields :
+= [THIS] -> call script anarkis.acc.apply.relations :  active ships only?=[TRUE]
+* A defensive wing will be deployed
+if $defence.ships > 0
+= [THIS] -> call script anarkis.acc.wing.defence :  target=[THIS]  wing size=$defence.ships
+= wait 2000 ms
+end
+* An offensive wing against the attacker will be deployed too
+$enemy.class = $attacker -> get object class
+$min.fighter = $null -> call script anarkis.lib.get.shipcount :  class=$enemy.class
+$dock.list = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$dock.count =  size of array $dock.list
+if $dock.count > $min.fighter
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$attacker  wing size=$min.fighter  wing ID='A'
+else
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$attacker  wing size=$dock.count  wing ID='A'
+end
+* Other ships if any are ordered to clear sector
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+endsub
+* ====================================
+
+
+
+return null
+

--- a/tools/fixtures/known_good/anarkis.acc.task.autoname.plus.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.task.autoname.plus.x3s
@@ -1,0 +1,97 @@
+#name: anarkis.acc.task.autoname.plus
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.task.autoname.plus.xml
+
+$page.id = 8510
+
+while [TRUE]
+$task = [THIS] -> is script anarkis.acc.task.autocarrier on stack of task=10
+skip if $task
+$task = [THIS] -> is script anarkis.acc.task.autocarrier on stack of task=11
+skip if $task
+$task = [THIS] -> is script anarkis.acc.task.autocarrier on stack of task=894
+
+if not $task
+= [THIS] -> call script anarkis.acc.lib.name.load :
+return null
+end
+
+$leader.list = [THIS] -> call script anarkis.acc.lib.get.leaderlist :
+$leader.count =  size of array $leader.list
+$wing.id = 0
+while $leader.count
+dec $leader.count =
+inc $wing.id =
+$leader = $leader.list[$leader.count]
+$wing = [THIS] -> call script anarkis.lib.wing.getall :  ship=$leader
+$wing.size =  size of array $wing
+while $wing.size
+dec $wing.size =
+$curr.ship = $wing[$wing.size]
+$ship.type = $curr.ship -> get ware type code of object
+* - - - Leader
+if $curr.ship -> has formation ships
+if $curr.ship -> is script !ship.cmd.protect.std on stack of task=0
+$main.id = 715
+$target = $curr.ship -> get command target
+else if $curr.ship -> is script anarkis.acc.cmd.protect on stack of task=0
+$main.id = 715
+$target = $curr.ship -> get command target
+else
+$main.id = 714
+$target = $curr.ship -> get attack target
+end
+if $target -> exists
+$target = $target -> get ware type code of object
+$target = sprintf: pageid=$page.id textid=$main.id, $target, null, null, null, null
+else
+$target =  read text: page=$page.id id=713
+end
+$formation =  read text: page=$page.id id=710
+$new.name = sprintf: pageid=$page.id textid=700, $wing.id, $formation, $target, null, null
+* - - - Follower
+else if $curr.ship -> is script !ship.cmd.attacksame.std on stack of task=0
+$target = $curr.ship -> get formation leader
+$target = $curr.ship -> get attack target
+if $target -> exists
+$target = $target -> get ware type code of object
+$target = sprintf: pageid=$page.id textid=714, $target, null, null, null, null
+else
+$target =  read text: page=$page.id id=712
+end
+$formation =  read text: page=$page.id id=711
+$new.name = sprintf: pageid=$page.id textid=700, $wing.id, $formation, $target, null, null
+* - - - Flee
+else if $curr.ship -> is script !move.movetostation on stack of task=0
+$main.id = 702
+$new.name = sprintf: pageid=$page.id textid=$main.id, $ship.type, null, null, null, null
+* - - - Others
+else
+$main.id = 703
+$new.name = sprintf: pageid=$page.id textid=$main.id, $ship.type, null, null, null, null
+end
+$curr.ship -> set name to $new.name
+end
+end
+= wait 1000 ms
+* - Ships without wing
+$leader.list = [THIS] -> call script anarkis.acc.lib.get.lonely :
+$leader.count =  size of array $leader.list
+while $leader.count
+dec $leader.count =
+$curr.ship = $leader.list[$leader.count]
+$ship.type = $curr.ship -> get ware type code of object
+if $curr.ship -> is script !move.movetostation on stack of task=0
+$main.id = 702
+$new.name = sprintf: pageid=$page.id textid=$main.id, $ship.type, null, null, null, null
+else
+$main.id = 703
+$new.name = sprintf: pageid=$page.id textid=$main.id, $ship.type, null, null, null, null
+end
+$curr.ship -> set name to $new.name
+end
+= wait 1000 ms
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.task.hullcheck.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.task.hullcheck.x3s
@@ -1,0 +1,56 @@
+#name: anarkis.acc.task.hullcheck
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.task.hullcheck.xml
+
+while [ENVIRONMENT] == [HOMEBASE]
+= wait 4000 ms
+end
+
+$newleader = [THIS] -> get formation leader
+
+while [ENVIRONMENT] != [HOMEBASE]
+= wait 1000 ms
+
+skip if [HOMEBASE] -> exists
+return null
+*skip if [HOMEBASE] -> get local variable: name='anarkis.acc.battle'
+*return null
+
+$shield = [THIS] -> get shield percent
+$hull = [THIS] -> get hull percent
+
+if [THIS] -> is script !ship.cmd.retreat.std on stack of task=0
+$leader.ok = $newleader -> exists
+$lead.env = $newleader -> get environment
+if $shield > 80 AND $hull >= 100 AND $newleader != [THIS] AND $leader.ok == [TRUE] AND $lead.env != [HOMEBASE]
+[THIS] -> start task 0 with script !ship.cmd.attacksame.std and prio 0: arg1=$newleader arg2=[TRUE] arg3=null arg4=null arg5=null
+else
+if [THIS] -> get true amount of ware Transporter Device in cargo bay
+$v1 = get distance between [THIS] and [HOMEBASE]
+if $v1 < 5000
+[THIS] -> put into environment [HOMEBASE] ->
+[THIS] -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+[THIS] -> set command: COMMAND_NONE
+[THIS] -> set destination to null
+[THIS] -> set command target: null
+[THIS] -> set command target2: null
+end
+end
+end
+continue
+end
+
+if $hull < 100 OR $shield < 20
+if [THIS] -> has formation ships
+$newleader = [THIS] -> call script anarkis.lib.wing.changeleader :
+else
+$newleader = null
+end
+[THIS] -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=[HOMEBASE] arg2=null arg3=null arg4=null arg5=null
+end
+
+end
+
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.upgrade.disable.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.upgrade.disable.x3s
@@ -1,0 +1,36 @@
+#name: anarkis.acc.upgrade.disable
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.upgrade.disable.xml
+
+$array = [THIS] -> call script anarkis.acc.get.acc.carriers :  active only?=[FALSE]
+$cnt =  size of array $array
+
+while $cnt
+
+dec $cnt =
+$curr.ship = $array[$cnt]
+
+$repairs = null
+if $curr.ship -> is script anarkis.acc.task.repairs on stack of task=900
+$repairs = [TRUE]
+$curr.ship -> start task 900 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+
+$task.id = null
+if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=10
+$task.id = 10
+else if $curr.ship -> is script anarkis.acc.task.autocarrier on stack of task=11
+$task.id = 11
+end
+if $task.id
+$curr.ship -> start task $task.id with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+
+$curr.ship -> set local variable: name='anarkis.acc.task' value=$task.id
+$curr.ship -> set local variable: name='anarkis.acc.repair' value=$repairs
+
+end
+
+set global variable: name='anarkis.ads.grid.mode' value=null
+return null

--- a/tools/fixtures/known_good/anarkis.acc.upgrade.enable.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.upgrade.enable.x3s
@@ -1,0 +1,29 @@
+#name: anarkis.acc.upgrade.enable
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.upgrade.enable.xml
+
+
+$array = [THIS] -> call script anarkis.acc.get.acc.carriers :  active only?=[FALSE]
+$cnt =  size of array $array
+
+while $cnt
+
+dec $cnt =
+$curr.ship = $array[$cnt]
+
+$repairs = $curr.ship -> get local variable: name='anarkis.acc.repair'
+if $repairs
+$curr.ship -> start task 900 with script anarkis.acc.task.repairs and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$curr.ship -> set local variable: name='anarkis.acc.repair' value=null
+end
+
+$task.id = $curr.ship -> get local variable: name='anarkis.acc.task'
+if $task.id
+$curr.ship -> start task $task.id with script anarkis.acc.task.autocarrier and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$curr.ship -> set local variable: name='anarkis.acc.task' value=null
+end
+
+end
+
+return null

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -407,6 +407,13 @@
             ]
         },
         {
+            "name": "play.sample.named",
+            "regex": "^play sample \\[[A-Za-z0-9_.]+\\]$",
+            "examples": [
+                "play sample [IncomingTransmission.SOS]"
+            ]
+        },
+        {
             "name": "send.message.literal",
             "regex": "^send incoming message '[^']+' to player: display it=\\[(TRUE|FALSE)\\]$",
             "examples": [
@@ -488,6 +495,13 @@
             "regex": "^add custom menu item to array\\s+\\$[A-Za-z0-9_.]+:\\s*text=\\$[A-Za-z0-9_.]+\\s+returnvalue=-?\\d+$",
             "examples": [
                 "add custom menu item to array $menu: text=$dialog.yes returnvalue=1"
+            ]
+        },
+        {
+            "name": "menu.item.textnum",
+            "regex": "^add custom menu item to array\\s+\\$[A-Za-z0-9_.]+:\\s*text='[^']+'\\s+returnvalue=-?\\d+$",
+            "examples": [
+                "add custom menu item to array $menu: text='1' returnvalue=1"
             ]
         },
         {


### PR DESCRIPTION
## Plan
- add 20 more ADS scripts as lint fixtures and list them in README
- teach linter about new statement shapes from those scripts
- document the new statements

## Changes
- add ADS fixtures and README entries
- extend `tools/x3s_rules.json` for `play sample [Name]` and literal menu items
- document new patterns in `docs/x3s-language.md`

## Test Results
- `python tools/x3s_lint.py`: OK
- `python tools/x3s_lint.py tools/fixtures/known_good`: OK
- `python tools/test_x3s.py`: error on should_fail as expected

## Pattern List
- `play.sample.named`
- `menu.item.textnum`

## Safety Checks
- `tools/fixtures/should_fail/missing_wait.x3s` still fails lint (missing wait)

------
https://chatgpt.com/codex/tasks/task_e_68c69400869c8326827e78ed605b08bc