### PR TITLE
Learn from known-good .x3s and update our linter (no XML build)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 SLX is a lightweight station-to-station logistics mod for X3TC: Terran Conflict. Moves wares between enrolled player stations (same- or cross-sector) — no NPC trade or scanning — via per-ware roles (Producer, Consumer, Store) with Min/Max/Chunk thresholds and a priority-based transfer loop.
 
 ## ADS Sample Files
-The linter is validated against these 100 known-good ADS scripts:
+The linter is validated against these 120 known-good ADS scripts:
 
 - !init.anarkis.modified.x3s
 - al.plugin.sk.ecs.x3s
@@ -104,3 +104,23 @@ The linter is validated against these 100 known-good ADS scripts:
 - anarkis.acc.task.hullcheck.x3s
 - anarkis.acc.upgrade.disable.x3s
 - anarkis.acc.upgrade.enable.x3s
+- anarkis.acc.task.repairs.x3s
+- anarkis.acc.wing.attack.pl.x3s
+- anarkis.acc.wing.attack.x3s
+- anarkis.acc.wing.clearsector.pl.x3s
+- anarkis.acc.wing.clearsector.x3s
+- anarkis.acc.wing.defence.pl.x3s
+- anarkis.acc.wing.defence.x3s
+- anarkis.ads.al.init.x3s
+- anarkis.ads.al.register.x3s
+- anarkis.ads.al.stop.x3s
+- anarkis.ads.cmd.protectgrid.x3s
+- anarkis.ads.comm.barracks.x3s
+- anarkis.ads.comm.hangars.x3s
+- anarkis.ads.comm.manage.call.x3s
+- anarkis.ads.comm.manage.menu.x3s
+- anarkis.ads.comm.wingmenu.x3s
+- anarkis.ads.crew.getcost.x3s
+- anarkis.ads.crew.sleep.x3s
+- anarkis.ads.crew.train.x3s
+- anarkis.ads.lib.enemy.strongest.x3s

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -81,6 +81,11 @@
 - **play.sample.named**: `play sample [IncomingTransmission.SOS]`
 - **menu.item.textnum**: `add custom menu item to array $menu: text='1' returnvalue=1`
 
+### New Statements Recognized
+- **remove.array.elem.num**: `remove element from array $wing.array at index 0`
+- **set.player.tracking.aim**: `set player tracking aim to $m.selected ->`
+- **menu.item.enum**: `add custom menu item to array $menu: text=$st returnvalue=Carrier`
+
 ## Fixtures
 
 Known-good mod fixtures live under `tools/fixtures/known_good/<mod_name>`. Each mod

--- a/tools/test_x3s.py
+++ b/tools/test_x3s.py
@@ -21,12 +21,9 @@ def run_fail(cmd: list[str]):
 
 
 if __name__ == '__main__':
-  src_files = sorted((ROOT / 'src/scripts').glob('*.x3s'))
-  good_files = sorted((ROOT / 'tools/fixtures/known_good').glob('*.x3s'))
-  fail_files = sorted((ROOT / 'tools/fixtures/should_fail').rglob('*.x3s'))
+  run([sys.executable, 'tools/x3s_lint.py', 'src/scripts', 'tools/fixtures/known_good'])
 
-  ok_files = src_files + good_files
-  run([sys.executable, 'tools/x3s_lint.py', *[str(p.relative_to(ROOT)) for p in ok_files]])
-  if fail_files:
-    run_fail([sys.executable, 'tools/x3s_lint.py', *[str(p.relative_to(ROOT)) for p in fail_files]])
+  fail_dir = ROOT / 'tools/fixtures/should_fail'
+  if list(fail_dir.rglob('*.x3s')):
+    run_fail([sys.executable, 'tools/x3s_lint.py', str(fail_dir.relative_to(ROOT))])
 

--- a/tools/x3s_lint.py
+++ b/tools/x3s_lint.py
@@ -105,7 +105,8 @@ def lint_file(path: Path, patterns: list[re.Pattern[str]] | None = None) -> list
         if blk.kind == "while" and not (blk.has_wait or blk.has_progress):
           errors.append(f"{path.name}:{blk.line_no}: while-block has no 'wait' before 'end'")
     # mark waits inside while
-    if re.search(r'\bwait(\s+\d+\s*ms| randomly from (\d+|\$[A-Za-z0-9_.]+) to (\d+|\$[A-Za-z0-9_.]+) ms)\b', low):
+    if re.search(r'\bwait(\s+\d+\s*ms| randomly from (\d+|\$[A-Za-z0-9_.]+) to (\d+|\$[A-Za-z0-9_.]+) ms)\b', low) or (
+      "call script" in low and ("wait" in low or "timeout" in low)):
       for b in reversed(stack):
         if b.kind == "while":
           b.has_wait = True

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -538,6 +538,27 @@
             "examples": [
                 "add value selection to menu: $menu, text=$st, value array=$sel.threat, default=$sel.threat.selection, return id=$sel.threat.id"
             ]
+        },
+        {
+            "name": "remove.array.elem.num",
+            "regex": "^remove element from array \\$[A-Za-z0-9_.]+ at index -?\\d+$",
+            "examples": [
+                "remove element from array $wing.array at index 0"
+            ]
+        },
+        {
+            "name": "set.player.tracking.aim",
+            "regex": "^set player tracking aim to \\$[A-Za-z0-9_.]+ ->$",
+            "examples": [
+                "set player tracking aim to $m.selected ->"
+            ]
+        },
+        {
+            "name": "menu.item.enum",
+            "regex": "^add custom menu item to array \\$[A-Za-z0-9_.]+: text=\\$[A-Za-z0-9_.]+ returnvalue=[A-Za-z0-9_]+$",
+            "examples": [
+                "add custom menu item to array $menu: text=$st returnvalue=Carrier"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Plan
- import 20 more ADS scripts and document them in README
- let `x3s_lint.py` load regex allowlist from `x3s_rules.json`
- add minimal patterns for new ADS statements and treat wait/timeout scripts as waits
- expand tests to lint ADS fixtures and ensure failing cases still fail

## Changes
- noted 20 additional ADS scripts in README
- taught linter to count `call script` lines containing `wait` or `timeout` as waits
- added patterns `remove.array.elem.num`, `set.player.tracking.aim`, and `menu.item.enum`
- updated docs with new statement list and broadened test runner to scan fixture directories

## Test Results
- `python tools/x3s_lint.py` → `OK`
- `python tools/test_x3s.py` (lints known_good, ensures should_fail errors)

## Pattern List
- `remove.array.elem.num` – `remove element from array $wing.array at index 0`
- `set.player.tracking.aim` – `set player tracking aim to $m.selected ->`
- `menu.item.enum` – `add custom menu item to array $menu: text=$st returnvalue=Carrier`

## Safety Checks
- while loops still require waits or progress
- setup scripts still require `load text` calls
- line regexes remain anchored and case-insensitive

------
https://chatgpt.com/codex/tasks/task_e_68c696fba7e48326a7c0d3025626b1bb