### PR TITLE
Add ADS samples and append-array lint patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 SLX is a lightweight station-to-station logistics mod for X3TC: Terran Conflict. Moves wares between enrolled player stations (same- or cross-sector) — no NPC trade or scanning — via per-ware roles (Producer, Consumer, Store) with Min/Max/Chunk thresholds and a priority-based transfer loop.
 
 ## ADS Sample Files
-The linter is validated against these 120 known-good ADS scripts:
+The linter is validated against these 140 known-good ADS scripts:
 
 - !init.anarkis.modified.x3s
 - al.plugin.sk.ecs.x3s
@@ -124,3 +124,23 @@ The linter is validated against these 120 known-good ADS scripts:
 - anarkis.ads.crew.sleep.x3s
 - anarkis.ads.crew.train.x3s
 - anarkis.ads.lib.enemy.strongest.x3s
+- anarkis.ads.lib.get.gridships.x3s
+- anarkis.ads.lib.get.plsectors.x3s
+- anarkis.ads.lib.get.racesectors.x3s
+- anarkis.ads.lib.get.sectorthreat.x3s
+- anarkis.ads.lib.get.shipthreat.x3s
+- anarkis.ads.lib.shiptostring.x3s
+- anarkis.ads.settings.default.app.x3s
+- anarkis.ads.settings.default.get.x3s
+- anarkis.ads.settings.default.ini.x3s
+- anarkis.ads.settings.default.shi.x3s
+- anarkis.ads.settings.default.sta.x3s
+- anarkis.ads.setup.createdefault.x3s
+- anarkis.ads.setup.editdefault.x3s
+- anarkis.ads.setup.global.x3s
+- anarkis.ads.setup.init.x3s
+- anarkis.ads.task.maingrid.x3s
+- anarkis.ads.task.sectorgrid.x3s
+- anarkis.ads.toggle.task.x3s
+- anarkis.ads.wing.attack.pl.x3s
+- anarkis.ads.wing.defense.pl.x3s

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -86,6 +86,10 @@
 - **set.player.tracking.aim**: `set player tracking aim to $m.selected ->`
 - **menu.item.enum**: `add custom menu item to array $menu: text=$st returnvalue=Carrier`
 
+### New Statements Recognized
+- **append.player**: `append Player to array $ignore`
+- **append.null**: `append null to array $setup`
+
 ## Fixtures
 
 Known-good mod fixtures live under `tools/fixtures/known_good/<mod_name>`. Each mod

--- a/tools/fixtures/known_good/anarkis.ads.lib.get.gridships.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.lib.get.gridships.x3s
@@ -1,0 +1,37 @@
+#name: anarkis.ads.lib.get.gridships
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.lib.get.gridships.xml
+
+$arr =  get ship array: of race $race class/type=Big Ship
+$cnt =  size of array $arr
+
+while $cnt
+dec $cnt =
+$select = $arr[$cnt]
+if $select == [PLAYERSHIP]
+remove element from array $arr at index $cnt
+continue
+end
+if not $select -> get local variable: name='anarkis.ads.grid'
+remove element from array $arr at index $cnt
+continue
+end
+$grid.state = $select -> get local variable: name='anarkis.ads.grid.busy'
+if $grid.state == [TRUE] AND $avail == [TRUE]
+remove element from array $arr at index $cnt
+continue
+end
+
+
+if $sector.base -> exists
+$select.sector = $select -> get sector
+$distance = get jumps from sector $select.sector to sector $sector.base
+if $distance > $sector.dist
+remove element from array $arr at index $cnt
+continue
+end
+end
+end
+
+return $arr

--- a/tools/fixtures/known_good/anarkis.ads.lib.get.plsectors.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.lib.get.plsectors.x3s
@@ -1,0 +1,23 @@
+#name: anarkis.ads.lib.get.plsectors
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.lib.get.plsectors.xml
+
+* ===========================================
+* Retrieve an array of sectors 'owned' by the player
+* ===========================================
+
+$station.array =  get station array: of race Player class/type=Station
+$station.count =  size of array $station.array
+$sector.array =  array alloc: size=0
+
+while $station.count
+dec $station.count =
+$station = $station.array[$station.count]
+$station.sector = $station -> get sector
+$sector.already =  find $station.sector in array: $sector.array
+skip if $sector.already == [TRUE]
+append $station.sector to array $sector.array
+end
+
+return $sector.array

--- a/tools/fixtures/known_good/anarkis.ads.lib.get.racesectors.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.lib.get.racesectors.x3s
@@ -1,0 +1,32 @@
+#name: anarkis.ads.lib.get.racesectors
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.lib.get.racesectors.xml
+
+* ===========================================
+* Retrieve an array of sectors 'owned' by a race
+* ===========================================
+
+if $race == Player
+
+$station.array =  get station array: of race $race class/type=Station
+
+$station.count =  size of array $station.array
+$sector.array =  array alloc: size=0
+
+while $station.count
+dec $station.count =
+$station = $station.array[$station.count]
+$station.sector = $station -> get sector
+$sector.already =  find $station.sector in array: $sector.array
+skip if $sector.already == [TRUE]
+append $station.sector to array $sector.array
+end
+
+else
+
+$sector.array = [THIS] -> call script anarkis.lib.get.racesectors :  race=$race
+
+end
+
+return $sector.array

--- a/tools/fixtures/known_good/anarkis.ads.lib.get.sectorthreat.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.lib.get.sectorthreat.x3s
@@ -1,0 +1,47 @@
+#name: anarkis.ads.lib.get.sectorthreat
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.lib.get.sectorthreat.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$ignore.list = $gl.setup[7]
+
+
+if $race == Player
+$flags = [Find.Enemy] | [Find.Multiple]
+$ship.list =  find ship: sector=$sector class or type=Ship race=null flags=$flags refobj=[PLAYERSHIP] maxdist=null maxnum=50 refpos=null
+else
+$ship.list = $sector -> get ship array from sector/ship/station
+end
+$ship.count =  size of array $ship.list
+
+$threat.level = 0
+
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$class = $ship -> get object class
+$owner = $ship -> get owner race
+if $owner == Neutral Race OR $owner == Unknown
+remove element from array $ship.list at index $ship.count
+continue
+end
+$rel = $ship -> get relation to race $race
+if  find $owner in array: $ignore.list
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $rel != Foe
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $ship -> is civilian ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+$ship.threat = [THIS] -> call script anarkis.ads.lib.get.shipthreat :  ship/class=$ship
+$threat.level = $threat.level + $ship.threat
+end
+
+return $threat.level

--- a/tools/fixtures/known_good/anarkis.ads.lib.get.shipthreat.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.lib.get.shipthreat.x3s
@@ -1,0 +1,35 @@
+#name: anarkis.ads.lib.get.shipthreat
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.lib.get.shipthreat.xml
+
+skip if  is datatyp[ $class ] == DATATYP_OBJCLASS
+$class = $class -> get object class
+
+if $class == M5
+$threat.level = 1
+else if $class == M4
+$threat.level = 2
+else if $class == M3
+$threat.level = 5
+else if $class == M6
+$threat.level = 14
+else if $class == M7
+$threat.level = 35
+else if $class == M8
+$threat.level = 10
+else if $class == M2
+$threat.level = 50
+else if $class == M1
+$threat.level = 30
+else if $class == TL
+$threat.level = 15
+else if $class == TM
+$threat.level = 2
+else if $class == TP OR $class == TS
+$threat.level = 1
+else
+$threat.level = 0
+end
+
+return $threat.level

--- a/tools/fixtures/known_good/anarkis.ads.lib.shiptostring.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.lib.shiptostring.x3s
@@ -1,0 +1,59 @@
+#name: anarkis.ads.lib.shiptostring
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.lib.shiptostring.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+
+$isadscompat = [THIS] -> call script anarkis.acc.is.compatible :  target=$ship
+$isadsactive = [THIS] -> call script anarkis.acc.lib.isadsactive :  target=$ship
+
+$class = $ship -> get object class
+$sector = $ship -> get sector
+$sector.x = $sector -> get universe x index
+$sector.y = $sector -> get universe y index
+skip if not $sector.x < 10
+$sector.x = sprintf: fmt='0%s', $sector.x, null, null, null, null
+skip if not $sector.y < 10
+$sector.y = sprintf: fmt='0%s', $sector.y, null, null, null, null
+$ship.name = $ship -> get name
+if $ship -> is of class Station
+$class = Dock
+end
+
+if not $ship -> get local variable: name='anarkis.ads.grid'
+$beginning = sprintf: pageid=$page.id textid=1122, $sector.x, $sector.y, $sector, $ship.name, null
+else
+if $ship -> get local variable: name='anarkis.ads.grid.busy'
+$beginning = sprintf: pageid=$page.id textid=1121, $sector.x, $sector.y, $sector, $ship.name, null
+else
+$beginning = sprintf: pageid=$page.id textid=1114, $sector.x, $sector.y, $sector, $ship.name, null
+end
+end
+
+
+
+
+if $isadscompat
+if $isadsactive
+$beginning = [THIS] -> call script anarkis.lib.shortstring :  string=$beginning  max=63
+$count = [THIS] -> call script anarkis.acc.lib.get.adsonly.from :  from=$ship
+$count =  size of array $count
+if $ship -> get local variable: name='anarkis.acc.battle'
+$end = sprintf: pageid=$page.id textid=1120, $beginning, $class, $count, null, null
+else
+$end = sprintf: pageid=$page.id textid=1115, $beginning, $class, $count, null, null
+end
+else
+$beginning = [THIS] -> call script anarkis.lib.shortstring :  string=$beginning  max=60
+$count = $ship -> get owned ships: class/type=Moveable Ship
+$count =  size of array $count
+$end = sprintf: pageid=$page.id textid=1116, $beginning, $class, $count, null, null
+end
+else
+$beginning = [THIS] -> call script anarkis.lib.shortstring :  string=$beginning  max=75
+$end = sprintf: pageid=$page.id textid=1117, $beginning, $class, $count, null, null
+end
+
+return $end

--- a/tools/fixtures/known_good/anarkis.ads.settings.default.app.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.settings.default.app.x3s
@@ -1,0 +1,10 @@
+#name: anarkis.ads.settings.default.app
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.settings.default.app.xml
+
+$setup = [THIS] -> call script anarkis.ads.settings.default.get :
+
+$tg -> set local variable: name='anarkis.acc.setup' value=$setup
+
+return $setup

--- a/tools/fixtures/known_good/anarkis.ads.settings.default.get.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.settings.default.get.x3s
@@ -1,0 +1,11 @@
+#name: anarkis.ads.settings.default.get
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.settings.default.get.xml
+
+
+$setup = get global variable: name='anarkis.ads.default'
+skip if $setup
+$setup = [THIS] -> call script anarkis.ads.settings.default.ini :
+
+return $setup

--- a/tools/fixtures/known_good/anarkis.ads.settings.default.ini.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.settings.default.ini.x3s
@@ -1,0 +1,60 @@
+#name: anarkis.ads.settings.default.ini
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.settings.default.ini.xml
+
+$setup =  array alloc: size=0
+
+* 0 threat level
+append 15 to array $setup
+* 1 Radar Range
+append 20000 to array $setup
+* 2 Defense Ship count
+append 5 to array $setup
+* 3 Damaged ships retreat
+append [TRUE] to array $setup
+* 4 Display warning
+append [TRUE] to array $setup
+* 5 warning type (0 subtitle, 1 audio, 2 text)
+append 2 to array $setup
+* 6 attack mode (3 auto, 1 nearest first, 2 strongest first)
+append 3 to array $setup
+* 7 docked ship autojump on / off
+append [TRUE] to array $setup
+* 8 docked ship autojump distance
+append 1 to array $setup
+* 9 docked ship fuel resupply (jumps)
+append 10 to array $setup
+* 10 docked ship emergency jump/escape
+append [TRUE] to array $setup
+* 11 docked ship shield threshold (in percent)
+append 10 to array $setup
+* 12 docked ship missile usage
+append 15 to array $setup
+* 13 use logfile
+append [FALSE] to array $setup
+* 14 turret settings
+append 246 to array $setup
+* 15 enable auto rename
+append [TRUE] to array $setup
+
+* 16 Ignore List (array)
+$ignore =  array alloc: size=0
+append $ignore to array $setup
+
+* 17 Mechanics
+$mechanists =  array alloc: size=0
+* - 0 Count
+append 0 to array $mechanists
+* - 1 Allow ship repairs
+append [FALSE] to array $mechanists
+* - 2 Allow carrier repairs
+append [FALSE] to array $mechanists
+append $mechanists to array $setup
+
+* 18 Delay before the autocarrier docks its ships
+append 300 to array $setup
+
+set global variable: name='anarkis.ads.default' value=$setup
+
+return $setup

--- a/tools/fixtures/known_good/anarkis.ads.settings.default.shi.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.settings.default.shi.x3s
@@ -1,0 +1,58 @@
+#name: anarkis.ads.settings.default.shi
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.settings.default.shi.xml
+
+$setup =  array alloc: size=0
+
+* 0 threat level
+append 15 to array $setup
+* 1 Radar Range
+append 20000 to array $setup
+* 2 Defense Ship count
+append 5 to array $setup
+* 3 Damaged ships retreat
+append [TRUE] to array $setup
+* 4 Display warning
+append [TRUE] to array $setup
+* 5 warning type (0 subtitle, 1 audio, 2 text)
+append 2 to array $setup
+* 6 attack mode (3 auto, 1 nearest first, 2 strongest first)
+append 3 to array $setup
+* 7 docked ship autojump on / off
+append [TRUE] to array $setup
+* 8 docked ship autojump distance
+append 1 to array $setup
+* 9 docked ship fuel resupply (jumps)
+append 10 to array $setup
+* 10 docked ship emergency jump/escape
+append [TRUE] to array $setup
+* 11 docked ship shield threshold (in percent)
+append 10 to array $setup
+* 12 docked ship missile usage
+append 15 to array $setup
+* 13 use logfile
+append [FALSE] to array $setup
+* 14 turret settings
+append 246 to array $setup
+* 15 enable auto rename
+append [TRUE] to array $setup
+
+* 16 Ignore List (array)
+$ignore =  array alloc: size=0
+append $ignore to array $setup
+
+* 17 Mechanics
+$mechanists =  array alloc: size=0
+* - 0 Count
+append 0 to array $mechanists
+* - 1 Allow ship repairs
+append [FALSE] to array $mechanists
+* - 2 Allow carrier repairs
+append [FALSE] to array $mechanists
+append $mechanists to array $setup
+
+* 18 Delay before the autocarrier docks its ships
+append 300 to array $setup
+
+return $setup

--- a/tools/fixtures/known_good/anarkis.ads.settings.default.sta.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.settings.default.sta.x3s
@@ -1,0 +1,59 @@
+#name: anarkis.ads.settings.default.sta
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.settings.default.sta.xml
+
+$setup =  array alloc: size=0
+
+* 0 threat level
+append 5 to array $setup
+* 1 Radar Range
+append 100000 to array $setup
+* 2 Defense Ship count
+append 5 to array $setup
+* 3 Damaged ships retreat
+append [TRUE] to array $setup
+* 4 Display warning
+append [TRUE] to array $setup
+* 5 warning type (0 subtitle, 1 audio, 2 text)
+append 2 to array $setup
+* 6 attack mode (3 auto, 1 nearest first, 2 strongest first)
+append 3 to array $setup
+* 7 docked ship autojump on / off
+append [TRUE] to array $setup
+* 8 docked ship autojump distance
+append 1 to array $setup
+* 9 docked ship fuel resupply (jumps)
+append 10 to array $setup
+* 10 docked ship emergency jump/escape
+append [TRUE] to array $setup
+* 11 docked ship shield threshold (in percent)
+append 10 to array $setup
+* 12 docked ship missile usage
+append 15 to array $setup
+* 13 use logfile
+append [FALSE] to array $setup
+* 14 turret settings
+append 246 to array $setup
+* 15 enable auto rename
+append [TRUE] to array $setup
+
+* 16 Ignore List (array)
+$ignore =  array alloc: size=0
+append $ignore to array $setup
+
+* 17 Mechanics
+$mechanists =  array alloc: size=0
+* - 0 Count
+append 0 to array $mechanists
+* - 1 Allow ship repairs
+append [FALSE] to array $mechanists
+* - 2 Allow carrier repairs
+append [FALSE] to array $mechanists
+append $mechanists to array $setup
+
+* 18 Delay before the autocarrier docks its ships
+append 300 to array $setup
+
+
+return $setup

--- a/tools/fixtures/known_good/anarkis.ads.setup.createdefault.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.setup.createdefault.x3s
@@ -1,0 +1,22 @@
+#name: anarkis.ads.setup.createdefault
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.setup.createdefault.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+
+if $refobj -> is of class Ship
+$setup = $gl.setup[1]
+else
+$setup = $gl.setup[2]
+end
+
+$cnt =  size of array $setup
+$result =  array alloc: size=$cnt
+
+while $cnt
+dec $cnt =
+$result[$cnt] = $setup[$cnt]
+end
+
+return $result

--- a/tools/fixtures/known_good/anarkis.ads.setup.editdefault.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.setup.editdefault.x3s
@@ -1,0 +1,212 @@
+#name: anarkis.ads.setup.editdefault
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.setup.editdefault.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+
+* ====
+* Init selection arrays
+* - Alert Level
+$threat.level = $setup.array[0]
+$sel.threat =  array alloc: size=0
+append 1 to array $sel.threat
+append 3 to array $sel.threat
+append 5 to array $sel.threat
+append 8 to array $sel.threat
+append 10 to array $sel.threat
+append 15 to array $sel.threat
+append 20 to array $sel.threat
+append 25 to array $sel.threat
+append 30 to array $sel.threat
+append 35 to array $sel.threat
+append 40 to array $sel.threat
+$sel.threat.selection =  get index of $threat.level in array $sel.threat offset=-1 + 1
+$sel.threat.id = 'threat'
+* - Radar Range
+$radar.range = $setup.array[1]
+$sel.radar =  array alloc: size=0
+$v1 = 0
+while $v1 < 100000
+$v1 = $v1 + 5000
+append $v1 to array $sel.radar
+end
+$sel.radar.selection =  get index of $radar.range in array $sel.radar offset=-1 + 1
+$sel.radar.id = 'radar'
+* - Retreat Yes/No
+$retreat = $setup.array[3]
+$sel.yesno =  array alloc: size=0
+$v1 =  read text: page=$page.id id=820
+append $v1 to array $sel.yesno
+$v1 =  read text: page=$page.id id=821
+append $v1 to array $sel.yesno
+if $retreat == [TRUE]
+$sel.retreat.selection = 0
+else
+$sel.retreat.selection = 1
+end
+$sel.retreat.id = 'retreat'
+* - Attack Mode
+$sel.attack =  array alloc: size=0
+$v1 =  read text: page=$page.id id=206
+append $v1 to array $sel.attack
+$v1 =  read text: page=$page.id id=207
+append $v1 to array $sel.attack
+$v1 =  read text: page=$page.id id=208
+append $v1 to array $sel.attack
+$sel.attack.selection = $setup.array[6]
+skip if $sel.attack.selection != 3
+$sel.attack.selection = 0
+$sel.attack.id = 'attack'
+* - Defense ship count
+$defence = $setup.array[2]
+$sel.defense =  array alloc: size=0
+append 0 to array $sel.defense
+append 1 to array $sel.defense
+append 3 to array $sel.defense
+append 5 to array $sel.defense
+append 8 to array $sel.defense
+append 10 to array $sel.defense
+append 15 to array $sel.defense
+$sel.defense.selection =  get index of $defence in array $sel.defense offset=-1 + 1
+$sel.defense.id = 'defense'
+* - Delay before docking ships
+$delay = $setup.array[18]
+$sel.delay =  array alloc: size=0
+append 0 to array $sel.delay
+$v1 = 0
+while $v1 < 600
+$v1 = $v1 + 30
+append $v1 to array $sel.delay
+end
+$sel.delay.selection =  get index of $delay in array $sel.delay offset=-1 + 1
+$sel.delay.id = 'delay'
+* - Display Warning message Yes/No
+$warning = $setup.array[4]
+if $warning == [TRUE]
+$sel.warning.selection = 0
+else
+$sel.warning.selection = 1
+end
+$sel.warning.id = 'warning'
+* - Alert Type
+$sel.alert =  array alloc: size=0
+$v1 =  read text: page=$page.id id=233
+append $v1 to array $sel.alert
+$v1 =  read text: page=$page.id id=234
+append $v1 to array $sel.alert
+$v1 =  read text: page=$page.id id=235
+append $v1 to array $sel.alert
+$sel.alert.selection = $setup.array[5]
+skip if $sel.alert.selection != 3
+$sel.alert.selection = 0
+$sel.alert.id = 'warning.type'
+* End of init selection arrays
+* ====
+
+
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=220
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=221, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.threat, default=$sel.threat.selection, return id=$sel.threat.id
+
+$st = sprintf: pageid=$page.id textid=226, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.radar, default=$sel.radar.selection, return id=$sel.radar.id
+
+$st = sprintf: pageid=$page.id textid=223, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.yesno, default=$sel.retreat.selection, return id=$sel.retreat.id
+
+$st = sprintf: pageid=$page.id textid=224, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.attack, default=$sel.attack.selection, return id=$sel.attack.id
+
+$st = sprintf: pageid=$page.id textid=225, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.defense, default=$sel.defense.selection, return id=$sel.defense.id
+
+$st = sprintf: pageid=$page.id textid=238, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.delay, default=$sel.delay.selection, return id=$sel.delay.id
+
+$st =  read text: page=$page.id id=228
+add custom menu heading to array $menu: title=$st
+
+$st = sprintf: pageid=$page.id textid=222, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.yesno, default=$sel.warning.selection, return id=$sel.warning.id
+
+$st = sprintf: pageid=$page.id textid=229, null, null, null, null, null
+add value selection to menu: $menu, text=$st, value array=$sel.alert, default=$sel.alert.selection, return id=$sel.alert.id
+
+$st =  read text: page=$page.id id=403
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=1087
+add custom menu item to array $menu: text=$st returnvalue='save'
+
+$st = sprintf: pageid=$page.id textid=1088, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=200
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if  is datatyp[ $menu.result ] == DATATYP_ARRAY
+$cnt =  size of array $menu.result
+while $cnt
+dec $cnt =
+$r.id = $menu.result[$cnt][0]
+$r.val = $menu.result[$cnt][1]
+* - - - Defense Ships
+if $r.id == $sel.defense.id
+$setup.array[2] = $sel.defense[$r.val]
+$sel.defense.selection = $r.val
+* - - - Radar Range
+else if $r.id == $sel.radar.id
+$setup.array[1] = $sel.radar[$r.val]
+$sel.radar.selection = $r.val
+* - - - Warning Type
+else if $r.id == $sel.alert.id
+$setup.array[5] = $r.val
+$sel.alert.selection = $r.val
+* - - - Attack Mode
+else if $r.id == $sel.attack.id
+skip if not $r.val == 0
+$r.val = 0
+$setup.array[6] = $r.val
+$sel.attack.selection = $r.val
+* - - - Retreat Mode
+else if $r.id == $sel.retreat.id
+if $r.val == 0
+$setup.array[3] = [TRUE]
+else
+$setup.array[3] = [FALSE]
+end
+$sel.retreat.selection = $r.val
+* - - - Delay before dock
+else if $r.id == $sel.delay.id
+$setup.array[18] = $sel.delay[$r.val]
+$sel.delay.selection = $r.val
+* - - - Warning Toggle
+else if $r.id == $sel.warning.id
+if $r.val == 0
+$setup.array[4] = [TRUE]
+else
+$setup.array[4] = [FALSE]
+end
+$sel.warning.selection = $r.val
+* - - - Threat Setting
+else if $r.id == $sel.threat.id
+$setup.array[0] = $sel.threat[$r.val]
+$sel.threat.selection = $r.val
+
+end
+end
+
+end
+
+
+return $setup.array

--- a/tools/fixtures/known_good/anarkis.ads.setup.global.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.setup.global.x3s
@@ -1,0 +1,181 @@
+#name: anarkis.ads.setup.global
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.setup.global.xml
+
+* Get Global Setup
+$gl.setup = get global variable: name='anarkis.ads.setup'
+skip if $gl.setup
+$gl.setup = [THIS] -> call script anarkis.ads.setup.init :
+
+$page.id = $gl.setup[0]
+
+* Init selection arrays
+* - Init Yes / No type
+$v1 =  read text: page=$page.id id=820
+$v2 =  read text: page=$page.id id=821
+$sel.yesno =  create new array, arguments=$v1, $v2, null, null, null
+* - Grid Max Jump
+$grid.maxjump = $gl.setup[4]
+$sel.grid.jump =  array alloc: size=0
+$v1 = 0
+while $v1 < 15
+inc $v1 =
+append $v1 to array $sel.grid.jump
+end
+$sel.grid.jump.select =  get index of $grid.maxjump in array $sel.grid.jump offset=-1 + 1
+$sel.grid.jump.id = 'grid.jump'
+* - Grid Min Threat
+$grid.threat = $gl.setup[5]
+$sel.grid.threat =  array alloc: size=0
+$v1 = 0
+while $v1 < 20
+inc $v1 =
+append $v1 to array $sel.grid.threat
+end
+$sel.grid.threat.select =  get index of $grid.threat in array $sel.grid.threat offset=-1 + 1
+$sel.grid.threat.id = 'grid.threat'
+* - Grid Display Alert
+$grid.alert = $gl.setup[6]
+if $grid.alert == [TRUE]
+$sel.grid.alert.select = 0
+else
+$sel.grid.alert.select = 1
+end
+$sel.grid.alert.id = 'grid.alert'
+* - Auto Rename
+$auto.rename = $gl.setup[3]
+if $auto.rename == [TRUE]
+$sel.rename.select = 0
+else
+$sel.rename.select = 1
+end
+$sel.rename.id = 'rename'
+
+while $menu.result != -1
+
+* - Ignore Factions
+$race.array = [THIS] -> call script anarkis.lib.get.race.array :
+$v1 =  size of array $race.array
+$sel.ignore.select =  array alloc: size=$v1
+$ignore.list = $gl.setup[7]
+while $v1
+dec $v1 =
+$v2 = $race.array[$v1]
+if  find $v2 in array: $ignore.list
+$sel.ignore.select[$v1] = 0
+else
+$sel.ignore.select[$v1] = 1
+end
+end
+
+$menu =  create custom menu array
+
+* - Default Setup
+$st =  read text: page=$page.id id=1090
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=1091
+add custom menu item to array $menu: text=$st returnvalue='def.carrier'
+$st =  read text: page=$page.id id=1092
+add custom menu item to array $menu: text=$st returnvalue='def.station'
+* - Defense Grid
+$st =  read text: page=$page.id id=1093
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=1094
+add value selection to menu: $menu, text=$st, value array=$sel.grid.jump, default=$sel.grid.jump.select, return id=$sel.grid.jump.id
+$st =  read text: page=$page.id id=1095
+add value selection to menu: $menu, text=$st, value array=$sel.grid.threat, default=$sel.grid.threat.select, return id=$sel.grid.threat.id
+$st =  read text: page=$page.id id=1096
+add value selection to menu: $menu, text=$st, value array=$sel.yesno, default=$sel.grid.alert.select, return id=$sel.grid.alert.id
+* - Ignore Factions
+$st =  read text: page=$page.id id=1097
+add custom menu heading to array $menu: title=$st
+$v1 =  size of array $race.array
+while $v1
+dec $v1 =
+$st = $race.array[$v1]
+$v2 = $sel.ignore.select[$v1]
+add value selection to menu: $menu, text=$st, value array=$sel.yesno, default=$v2, return id=$st
+end
+
+* - General Settings
+$st =  read text: page=$page.id id=1098
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=1099
+add value selection to menu: $menu, text=$st, value array=$sel.yesno, default=$sel.rename.select, return id=$sel.rename.id
+
+$st =  read text: page=$page.id id=1100
+add custom menu item to array $menu: text=$st returnvalue='reset'
+
+$st =  read text: page=$page.id id=1087
+add custom menu item to array $menu: text=$st returnvalue='save'
+
+$v1 =  read text: page=$page.id id=200
+
+$v1 =  read text: page=$page.id id=1089
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+
+* - Handle Results
+if  is datatyp[ $menu.result ] == DATATYP_ARRAY
+$cnt =  size of array $menu.result
+while $cnt
+dec $cnt =
+$r.id = $menu.result[$cnt][0]
+$r.val = $menu.result[$cnt][1]
+
+if $r.id == $sel.grid.alert.id
+if $r.val == 0
+$gl.setup[6] = [TRUE]
+else
+$gl.setup[6] = [FALSE]
+end
+$sel.grid.alert.select = $r.val
+else if $r.id == $sel.grid.jump.id
+$gl.setup[4] = $sel.grid.jump[$r.val]
+$sel.grid.jump.select = $r.val
+else if $r.id == $sel.grid.threat.id
+$gl.setup[5] = $sel.grid.threat[$r.val]
+$sel.grid.threat.select = $r.val
+else if $r.id == $sel.rename.id
+if $r.val == 0
+$gl.setup[3] = [TRUE]
+else
+$gl.setup[3] = [FALSE]
+end
+$sel.rename.select = $r.val
+else if  is datatyp[ $r.id ] == DATATYP_RACE
+if $r.val == 0
+if not  find $r.id in array: $ignore.list
+append $r.id to array $ignore.list
+end
+else
+if  find $r.id in array: $ignore.list
+$v1 =  get index of $r.id in array $ignore.list offset=-1 + 1
+remove element from array $ignore.list at index $v1
+end
+end
+end
+end
+$v2 = $menu.result[0]
+$menu.result[0] = 'noclose'
+if $v2 == 'def.carrier'
+$v1 = $gl.setup[1]
+$v1 = [THIS] -> call script anarkis.ads.setup.editdefault :  setup=$v1
+$gl.setup[1] = $v1
+else if $v2 == 'def.station'
+$v1 = $gl.setup[2]
+$v1 = [THIS] -> call script anarkis.ads.setup.editdefault :  setup=$v1
+$gl.setup[2] = $v1
+else if $v2 == 'reset'
+$gl.setup = [THIS] -> call script anarkis.ads.setup.init :
+else if $v2 == 'save'
+$menu.result = -1
+end
+
+end
+end
+
+
+return null

--- a/tools/fixtures/known_good/anarkis.ads.setup.init.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.setup.init.x3s
@@ -1,0 +1,34 @@
+#name: anarkis.ads.setup.init
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.setup.init.xml
+
+$setup =  array alloc: size=0
+$v1 = [THIS] -> call script anarkis.ads.settings.default.shi :
+$v2 = [THIS] -> call script anarkis.ads.settings.default.sta :
+* 0 - Text ID
+append 8510 to array $setup
+* 1 - Default Carrier Setup
+append $v1 to array $setup
+* 2 - Default Station  Setup
+append $v2 to array $setup
+* 3 - AutoRename automated ships
+append [TRUE] to array $setup
+* 4 - Grid Setup : Jump Range
+append 6 to array $setup
+* 5 - Grid Setup : Minimal Threat
+append 3 to array $setup
+* 6 - Grid Setup : Alert Player
+append [TRUE] to array $setup
+* 7 - Ignore List
+$ignore =  array alloc: size=0
+append Player to array $ignore
+append $ignore to array $setup
+* 8 - Unused
+append null to array $setup
+* 9 - Unused
+append null to array $setup
+
+set global variable: name='anarkis.ads.setup' value=$setup
+
+return $setup

--- a/tools/fixtures/known_good/anarkis.ads.task.maingrid.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.task.maingrid.x3s
@@ -1,0 +1,70 @@
+#name: anarkis.ads.task.maingrid
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.task.maingrid.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+
+while get global variable: name='anarkis.ads.grid.mode'
+
+$page.id = $gl.setup[0]
+$max.dist = $gl.setup[4]
+$min.threat = $gl.setup[5]
+$show.mess = $gl.setup[6]
+
+
+if $race == Player
+$arr = [THIS] -> call script anarkis.ads.lib.get.plsectors :
+else
+$arr = [THIS] -> call script anarkis.lib.get.sector.plus :  ref object=[PLAYERSHIP]  max jump=100  race=$race  remove border sectors=[FALSE]  remove core=[FALSE]  remove xenon/khaak sectors=[FALSE]  remove unknown=[TRUE]  ignore pirate/yaki=[FALSE]
+end
+$cnt =  size of array $arr
+
+while $cnt
+dec $cnt =
+skip if get global variable: name='anarkis.ads.grid.mode'
+return null
+$sector = $arr[$cnt]
+$threat = [THIS] -> call script anarkis.ads.lib.get.sectorthreat :  sector=$sector  race=$race
+if $threat > $min.threat
+$needed.strength = $threat * 3
+$gridships = [THIS] -> call script anarkis.ads.lib.get.gridships :  Race=$race  available only=[TRUE]  base sector (or null)=$sector  max.dist=$max.dist
+$enemy = [THIS] -> call script anarkis.ads.lib.enemy.strongest :  sector=$sector  race=$race
+$gridships.cnt =  size of array $gridships
+
+if $show.mess == [TRUE]
+$v1 = [THIS] -> call script anarkis.lib.sector.format :  sector=$sector
+$st = sprintf: pageid=$page.id textid=1113, $sector, $threat, null, null, null
+display subtitle text: text=$st duration=10000 ms
+end
+
+while $gridships.cnt AND ( $needed.strength > 0 )
+skip if get global variable: name='anarkis.ads.grid.mode'
+return null
+dec $gridships.cnt =
+$grid.select = $gridships[$gridships.cnt]
+skip if not $grid.select == [PLAYERSHIP]
+continue
+skip if not $grid.select -> get local variable: name='anarkis.acc.battle'
+continue
+$grid.select.sector = $grid.select -> get sector
+skip if not $grid.select.sector == $sector
+continue
+$grid.threat = [THIS] -> call script anarkis.ads.lib.get.shipthreat :  ship/class=$grid.select
+$needed.strength = $needed.strength - $grid.threat
+if not $grid.select -> is task 0 in use
+START $grid.select -> call script !ship.cmd.idle.std :
+= wait randomly from 500 to 600 ms
+end
+$grid.select -> interrupt with script anarkis.ads.cmd.protectgrid and prio 10: arg1=$enemy arg2=$sector arg3=null arg4=null
+= wait randomly from 1000 to 2000 ms
+end
+
+end
+= [THIS] -> call script anarkis.lib.wait.not :  wait time (in sec)=15  global to check='anarkis.ads.grid.mode'
+end
+= [THIS] -> call script anarkis.lib.wait.not :  wait time (in sec)=20  global to check='anarkis.ads.grid.mode'
+end
+
+
+return null

--- a/tools/fixtures/known_good/anarkis.ads.task.sectorgrid.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.task.sectorgrid.x3s
@@ -1,0 +1,37 @@
+#name: anarkis.ads.task.sectorgrid
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.task.sectorgrid.xml
+
+if [THIS] -> exists
+$race = [THIS] -> get owner race
+$sector = [THIS] -> get sector
+end
+
+$alert.level = 3
+
+while [TRUE]
+= [THIS] -> call script anarkis.lib.wait :  wait time (in sec)=30  global to check=null
+
+$threat = [THIS] -> call script anarkis.ads.lib.get.sectorthreat :  sector=$sector  race=$race
+if $threat >= $alert.level
+$gridships = [THIS] -> call script anarkis.ads.lib.get.gridships :  Race=$race  available only=[TRUE]  base sector (or null)=$sector
+$gridships.cnt =  size of array $gridships
+$enemy = [THIS] -> call script anarkis.ads.lib.enemy.strongest :  sector=$sector  race=$race
+$needed.strength = $threat * 3
+while $gridships.cnt AND ( $needed.strength > 0 )
+dec $gridships.cnt =
+$grid.select = $gridships[$gridships.cnt]
+$grid.threat = [THIS] -> call script anarkis.ads.lib.get.shipthreat :  ship/class=$grid.select
+$needed.strength = $needed.strength - $grid.threat
+$grid.select -> interrupt with script anarkis.ads.cmd.protectgrid and prio 10: arg1=$enemy arg2=$sector arg3=null arg4=null
+end
+= [THIS] -> call script anarkis.lib.wait :  wait time (in sec)=300  global to check=null
+end
+
+end
+
+
+
+
+return null

--- a/tools/fixtures/known_good/anarkis.ads.toggle.task.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.toggle.task.x3s
@@ -1,0 +1,46 @@
+#name: anarkis.ads.toggle.task
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.toggle.task.xml
+
+$npc = [FALSE]
+if $target -> is script anarkis.acc.task.autocarrier on stack of task=10
+$task.id = 10
+else if $target -> is script anarkis.acc.task.autocarrier on stack of task=11
+$task.id = 11
+else if $target -> is script anarkis.acc.task.autocarrier on stack of task=894
+$task.id = 894
+else if $target -> is script anarkis.acc.task.autocarrier.npc on stack of task=894
+$npc = [TRUE]
+$task.id = 894
+end
+$target -> start task 900 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+skip if not $task.id
+$target -> start task $task.id with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+= wait 200 ms
+
+if $active
+
+if not $task.id
+$owner = $target -> get owner race
+if $owner != Player
+$npc = [TRUE]
+$task.id = 894
+else
+$npc = [FALSE]
+if $target -> is task 10 in use
+$task.id = 11
+else
+$task.id = 10
+end
+end
+end
+
+if $npc
+$target -> start task $task.id with script anarkis.acc.task.autocarrier.npc and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+else
+$target -> start task $task.id with script anarkis.acc.task.autocarrier and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.ads.wing.attack.pl.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.wing.attack.pl.x3s
@@ -1,0 +1,53 @@
+#name: anarkis.ads.wing.attack.pl
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.wing.attack.pl.xml
+
+* ===========================================
+* Wing : Send a wing to attack a given target
+* ===========================================
+
+$title =  read text: page=2010 id=834
+$obj.class = $target -> get object class
+$wing.size = 5
+if $target -> is of class Fighter
+$wing.size = 5
+else if $target -> is of class Freighter
+$wing.size = 3
+else if $obj.class == TL
+$wing.size = 10
+else if $obj.class == M8
+$wing.size = 7
+else if $obj.class == M6
+$wing.size = 12
+else if $obj.class == M7
+$wing.size = 15
+else if $obj.class == M2
+$wing.size = 30
+else if $obj.class == M1
+$wing.size = 25
+end
+
+$res = [THIS] -> call script anarkis.lib.get.dockedowned :  ship class=Moveable Ship  local to check='anarkis.acc.ship'
+$res =  size of array $res
+skip if not $res < $wing.size
+$wing.size = $res
+
+skip if [THIS] -> call script anarkis.ads.comm.wingmenu :  title=$title  target=$target  default count=$wing.size
+return null
+
+$res = [THIS] -> get local variable: name='anarkis.menu.result'
+$target = $res[0]
+$wing.size = $res[1]
+$wing.list = $res[2]
+
+$wing.count =  size of array $wing.list
+[THIS] -> set command: ANARKIS_ATTACKWING  target=$target target2=$wing.size par1=null par2=null
+if $wing.count > 0
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$target  wing size=$wing.list  wing ID='A'
+else
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$target  wing size=$wing.size  wing ID='A'
+end
+[THIS] -> set local variable: name='anarkis.menu.result' value=null
+
+return [TRUE]

--- a/tools/fixtures/known_good/anarkis.ads.wing.defense.pl.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.wing.defense.pl.x3s
@@ -1,0 +1,53 @@
+#name: anarkis.ads.wing.defense.pl
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.wing.defense.pl.xml
+
+* ===========================================
+* Wing : Send a wing to attack a given target
+* ===========================================
+
+$title =  read text: page=2010 id=833
+$obj.class = $target -> get object class
+$wing.size = 5
+if $target -> is of class Fighter
+$wing.size = 5
+else if $target -> is of class Freighter
+$wing.size = 3
+else if $obj.class == TL
+$wing.size = 10
+else if $obj.class == M8
+$wing.size = 7
+else if $obj.class == M6
+$wing.size = 12
+else if $obj.class == M7
+$wing.size = 15
+else if $obj.class == M2
+$wing.size = 30
+else if $obj.class == M1
+$wing.size = 25
+end
+
+$res = [THIS] -> call script anarkis.lib.get.dockedowned :  ship class=Moveable Ship  local to check='anarkis.acc.ship'
+$res =  size of array $res
+skip if not $res < $wing.size
+$wing.size = $res
+
+skip if [THIS] -> call script anarkis.ads.comm.wingmenu :  title=$title  target=$target  default count=$wing.size
+return null
+
+$res = [THIS] -> get local variable: name='anarkis.menu.result'
+$target = $res[0]
+$wing.size = $res[1]
+$wing.list = $res[2]
+
+$wing.count =  size of array $wing.list
+[THIS] -> set command: ANARKIS_DEFENSIVEWING  target=$target target2=$wing.size par1=null par2=null
+if $wing.count > 0
+= [THIS] -> call script anarkis.acc.wing.defence :  target=$target  wing size=$wing.list
+else
+= [THIS] -> call script anarkis.acc.wing.defence :  target=$target  wing size=$wing.size
+end
+[THIS] -> set local variable: name='anarkis.menu.result' value=null
+
+return [TRUE]

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -559,6 +559,20 @@
             "examples": [
                 "add custom menu item to array $menu: text=$st returnvalue=Carrier"
             ]
+        },
+        {
+            "name": "append.player",
+            "regex": "^append Player to array \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "append Player to array $ignore"
+            ]
+        },
+        {
+            "name": "append.null",
+            "regex": "^append null to array \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "append null to array $setup"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Plan
- Expand ADS fixture coverage and list new sample files.
- Teach linter to recognize additional `append` statements.
- Document new syntax patterns.

## Changes
- Added 20 ADS scripts to `tools/fixtures/known_good` and referenced them in the README.
- Extended `tools/x3s_rules.json` with `append.player` and `append.null` regex patterns.
- Documented the new statements in `docs/x3s-language.md`.

## Test Results
- `python tools/x3s_lint.py src/scripts tools/fixtures/known_good`
- `python tools/test_x3s.py`

## Pattern List
- `append.player` — `append Player to array $ignore`
- `append.null` — `append null to array $setup`

## Safety Checks
- Control-flow and `wait` enforcement unchanged.
- Setup scripts still require `load text` headers.


------
https://chatgpt.com/codex/tasks/task_e_68c699c253348326b63554a823cec5c6