### PR TITLE
Expand ADS fixtures and linter rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 SLX is a lightweight station-to-station logistics mod for X3TC: Terran Conflict. Moves wares between enrolled player stations (same- or cross-sector) — no NPC trade or scanning — via per-ware roles (Producer, Consumer, Store) with Min/Max/Chunk thresholds and a priority-based transfer loop.
 
 ## ADS Sample Files
-The linter is validated against these 140 known-good ADS scripts:
+The linter is validated against these 160 known-good ADS scripts:
 
 - !init.anarkis.modified.x3s
 - al.plugin.sk.ecs.x3s
@@ -144,3 +144,23 @@ The linter is validated against these 140 known-good ADS scripts:
 - anarkis.ads.toggle.task.x3s
 - anarkis.ads.wing.attack.pl.x3s
 - anarkis.ads.wing.defense.pl.x3s
+- anarkis.debug.off.x3s
+- anarkis.debug.on.x3s
+- anarkis.debug.output.x3s
+- anarkis.ecs.al.init.x3s
+- anarkis.lib.add.software.x3s
+- anarkis.lib.armship.x3s
+- anarkis.lib.armturret.x3s
+- anarkis.lib.array.append.x3s
+- anarkis.lib.build.ships.x3s
+- anarkis.lib.change.race.x3s
+- anarkis.lib.clear.shiparray.x3s
+- anarkis.lib.cmd.attackland.x3s
+- anarkis.lib.cmd.attacksame.x3s
+- anarkis.lib.cmd.dock.all.x3s
+- anarkis.lib.cmd.dock.custom.x3s
+- anarkis.lib.cmd.donothing.x3s
+- anarkis.lib.cmd.jumpnearobject.x3s
+- anarkis.lib.cmd.jumptobeacon.x3s
+- anarkis.lib.cmd.killandland.timeout.x3s
+- anarkis.lib.create.marine.x3s

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -96,3 +96,7 @@ Known-good mod fixtures live under `tools/fixtures/known_good/<mod_name>`. Each 
 provides `src/scripts/*.x3s` as the canonical source along with any `t/` text pages
 or optional `director/` XML. These fixtures are generated from `tools/fixtures/mods/<mod_name>`
 via `python tools/convert_mods.py` and are used by the test suite.
+
+### New Statements Recognized
+- **write.log.num**: `write to log file #8513  append=1  value=$m`
+- **append.string**: `append 'anarkis.lib.cmd.attackland' to array $cmd`

--- a/tools/fixtures/known_good/anarkis.debug.off.x3s
+++ b/tools/fixtures/known_good/anarkis.debug.off.x3s
@@ -1,0 +1,7 @@
+#name: anarkis.debug.off
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.debug.off.xml
+
+set global variable: name='anarkis.debug' value=null
+return null

--- a/tools/fixtures/known_good/anarkis.debug.on.x3s
+++ b/tools/fixtures/known_good/anarkis.debug.on.x3s
@@ -1,0 +1,7 @@
+#name: anarkis.debug.on
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.debug.on.xml
+
+set global variable: name='anarkis.debug' value=[TRUE]
+return null

--- a/tools/fixtures/known_good/anarkis.debug.output.x3s
+++ b/tools/fixtures/known_good/anarkis.debug.output.x3s
@@ -1,0 +1,17 @@
+#name: anarkis.debug.output
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.debug.output.xml
+
+$debug.on = get global variable: name='anarkis.debug'
+if $debug.on
+*write to player logbook $message
+$playtime = playing time
+$playtime =  format time: $playtime
+*$playtime = $playtime / 60
+
+$m = '(' + $playtime + ') ' + $message
+write to log file #8513  append=1  value=$m
+display subtitle text: text=$m duration=5000 ms
+end
+return null

--- a/tools/fixtures/known_good/anarkis.ecs.al.init.x3s
+++ b/tools/fixtures/known_good/anarkis.ecs.al.init.x3s
@@ -1,0 +1,29 @@
+#name: anarkis.ecs.al.init
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ecs.al.init.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+if  is datatyp[ $ecs.setup ] == DATATYP_ARRAY
+$ecs.setup[3] = [TRUE]
+else
+$ecs.setup =  array alloc: size=6
+$ecs.installed =  array alloc: size=0
+$ecs.configs =  array alloc: size=0
+$ecs.news =  array alloc: size=0
+$ecs.guilds =  array alloc: size=0
+$ecs.setup[0] = 250
+$ecs.setup[1] = $ecs.installed
+$ecs.setup[2] = $ecs.configs
+$ecs.setup[3] = [TRUE]
+$ecs.setup[4] = null
+$ecs.setup[5] = $ecs.news
+$ecs.setup[6] = $ecs.guilds
+end
+set global variable: name='plugin.ecs.setup' value=$ecs.setup
+= [THIS] -> call script plugin.sk.ecs.hotkey.install :
+return null

--- a/tools/fixtures/known_good/anarkis.lib.add.software.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.add.software.x3s
@@ -1,0 +1,77 @@
+#name: anarkis.lib.add.software
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.add.software.xml
+
+$r = [THIS]
+
+= $r -> install 1 units of Docking Computer
+= $r -> install 1 units of Boost Extension
+
+$rnd =  = random value from 0 to 2 - 1
+if $rnd == 1
+= $r -> install 1 units of Triplex Scanner
+else
+= $r -> install 1 units of Duplex Scanner
+end
+
+= $r -> install 1 units of Jumpdrive
+= $r -> install 1 units of Fight Command Software MK1
+= $r -> install 1 units of SETA Boost Extension
+= $r -> install 1 units of Singularity Engine Time Accelerator
+= $r -> install 1 units of Strafe Drive Extension
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Special Command Software MK1
+= $r -> install 1 units of Trade Command Software MK1
+= $r -> install 1 units of Navigation Command Software MK1
+
+if $r -> is of class Fighter
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Transporter Device
+= $r -> install 1 units of Fight Command Software MK2
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Explorer Command Software
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Patrol Command Software
+= $r -> install 1 units of Freight Scanner
+end
+
+if $r -> is of class Freighter
+= $r -> install 1 units of Trade Command Software MK2
+= $r -> install 1 units of Cargo Lifesupport System
+= $r -> install 1 units of Transporter Device
+= $r -> install 1 units of Trading System Extension
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Mineral Scanner
+end
+
+if $r -> is of class Big Ship
+= $r -> install 1 units of Carrier Command Software
+= $r -> install 1 units of Cargo Lifesupport System
+= $r -> install 1 units of Patrol Command Software
+end
+if $r -> is of class Huge Ship
+= $r -> install 1 units of Cargo Lifesupport System
+= $r -> install 1 units of Carrier Command Software
+= $r -> install 1 units of Patrol Command Software
+= $r -> install 1 units of Transporter Device
+end
+
+if $r -> is of class TS
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Best Buys Locator
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Best Selling Price Locator
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+= $r -> install 1 units of Trade Command Software MK3
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.armship.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.armship.x3s
@@ -1,0 +1,13 @@
+#name: anarkis.lib.armship
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.armship.xml
+
+$turret.cnt = [THIS] -> get number of turrets
+while $turret.cnt
+dec $turret.cnt =
+$r =  = random value from 0 to 7 - 1
+= [THIS] -> call script anarkis.lib.armturret :  turret ID=$turret.cnt  weapon selection mode=$r  no ion=[FALSE]  no ammo weapons=[FALSE]
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.armturret.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.armturret.x3s
@@ -1,0 +1,222 @@
+#name: anarkis.lib.armturret
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.armturret.xml
+
+* ===========================================
+* Custom Weapon Installation Script v1.1.1
+* ===========================================
+* weapon.select :
+* - 0 : Fully Random Setup
+* - 1 : Favor Shield Damage
+* - 2 : Favor Hull Damage
+* - 3 : Favor Weapon Range
+* - 4 : Favor Weapon Speed
+* - 5 : Overall Weapon Performances
+* - 6 : Most Expensive Weapon
+* ===========================================
+* disable.ion = Disable ion disruptors
+* disable.ammo = Disable all weapons using ammunitions
+* ===========================================
+* Fix 1 : No ammo weapon in turret 0 (avoid defenceless ships)
+* Fix 2 : Default "attack enemies" turret settings
+* Fix 3 : Dual weapon in slot 0
+* Fix 4 : No turret script on OOS NPC ships
+* Fix 4 : Replaced disable all ion by ion disruptor only
+* Fix 5 : Reduced ion probability to 1/3
+* ===========================================
+* TODO : Better Missile turrets handling
+* ===========================================
+
+* Get all compatible laser types
+$weap.array = [THIS] -> get compatible laser array: turret=$turret.nb
+$turret.laser.cnt = [THIS] -> get max. number of lasers in turret $turret.nb
+$weap.size =  size of array $weap.array
+skip if $turret.laser.cnt
+return [FALSE]
+
+* Remove crappy and forbidden laser types
+while $weap.size
+*= wait randomly from 10 to 50 ms
+dec $weap.size =
+$test = $weap.array[$weap.size]
+* - Remove useless laser types
+if $test == Tractor Beam OR $test == Repair Laser OR $test == Mobile Drilling System OR $test == Impulse Ray Emitter
+remove element from array $weap.array at index $weap.size
+continue
+end
+* - Remove Ammo weapons
+* - Fix 1 : No ammo weapon in turret 0 (avoid defenseless ships)
+if $disable.ammo == [TRUE] OR $turret.nb == 0
+$ammo.type =  get ammunition of laser $test
+if $ammo.type
+remove element from array $weap.array at index $weap.size
+continue
+end
+end
+* - Remove Ion weapons
+* - Fix 5 : Reduced ion probability to 1/3
+$third =  = random value from 0 to 3 - 1
+if $disable.ion == [TRUE] OR ( $disable.ion == [FALSE] AND $third != 1 )
+if $test == Ion Disruptor
+remove element from array $weap.array at index $weap.size
+continue
+end
+end
+end
+
+$weap.size =  size of array $weap.array
+skip if $weap.size
+return [FALSE]
+
+* Random selection
+if $weapon.select == 0
+$weap.id =  = random value from 0 to $weap.size - 1
+$weap.selected = $weap.array[$weap.id]
+* Favor Shield Damage
+else if $weapon.select == 1
+$x = $weap.size
+$dmg.last = 0
+$weap.id = 0
+while $x
+dec $x =
+$weap.selected = $weap.array[$x]
+$dmg.tot =  get shield damage of laser $weap.selected
+if $dmg.tot > $dmg.last
+$weap.id = $x
+$dmg.last = $dmg.tot
+end
+end
+$weap.selected = $weap.array[$weap.id]
+* Favor Hull Damage
+else if $weapon.select == 2
+$x = $weap.size
+$dmg.last = 0
+$weap.id = 0
+while $x
+dec $x =
+$weap.selected = $weap.array[$x]
+$dmg.tot =  get hull damage of laser $weap.selected
+if $dmg.tot > $dmg.last
+$weap.id = $x
+$dmg.last = $dmg.tot
+end
+end
+* Favor Weapon Range
+else if $weapon.select == 3
+$x = $weap.size
+$dmg.last = 0
+$weap.id = 0
+while $x
+dec $x =
+$weap.selected = $weap.array[$x]
+$dmg.tot =  get range of laser $weap.selected
+if $dmg.tot > $dmg.last
+$weap.id = $x
+$dmg.last = $dmg.tot
+end
+end
+* Favor Weapon Bullet Speed
+else if $weapon.select == 4
+$x = $weap.size
+$dmg.last = 0
+$weap.id = 0
+while $x
+*= wait randomly from 10 to 50 ms
+dec $x =
+$weap.selected = $weap.array[$x]
+$dmg.tot =  get bullet speed of laser $weap.selected
+if $dmg.tot > $dmg.last
+$weap.id = $x
+$dmg.last = $dmg.tot
+end
+end
+* Overal Weapon Strength
+else if $weapon.select == 5
+$x = $weap.size
+$dmg.last = 0
+$weap.id = 0
+while $x
+*= wait randomly from 10 to 50 ms
+dec $x =
+$weap.selected = $weap.array[$x]
+$w.shield =  get shield damage of laser $weap.selected
+$w.hull =  get hull damage of laser $weap.selected
+$w.range =  get range of laser $weap.selected
+$w.speed =  get bullet speed of laser $weap.selected
+$dmg.tot = 5 * $w.hull + $w.shield + 2 * $w.speed + 2 * $w.range
+if $dmg.tot > $dmg.last
+$weap.id = $x
+$dmg.last = $dmg.tot
+end
+end
+* Weapon Price
+else if $weapon.select == 6
+$x = $weap.size
+$dmg.last = 0
+$weap.id = 0
+while $x
+dec $x =
+$weap.selected = $weap.array[$x]
+$dmg.tot = get average price of ware $weap.selected
+if $dmg.tot > $dmg.last
+$weap.id = $x
+$dmg.last = $dmg.tot
+end
+end
+end
+
+* Add and install
+
+* Fix 3 : Dual weapon in slot 0
+if $turret.laser.cnt >= 6 AND $turret.nb == 0
+$fix = $turret.laser.cnt / 2
+$weap.selected = $weap.array[$weap.id]
+= [THIS] -> add $fix units of $weap.selected
+$rnd =  = random value from 0 to $weap.size - 1
+$fix.weapon = $weap.array[$rnd]
+= [THIS] -> add $fix units of $fix.weapon
+$x = $fix
+while $x
+dec $x =
+[THIS] -> switch laser in turret $turret.nb gun $x to $weap.selected
+end
+$x = $fix
+while $x
+dec $x =
+$rnd = $fix + $x
+[THIS] -> switch laser in turret $turret.nb gun $rnd to $fix.weapon
+end
+else
+$weap.selected = $weap.array[$weap.id]
+= [THIS] -> add $turret.laser.cnt units of $weap.selected
+$x = $turret.laser.cnt
+while $x
+dec $x =
+[THIS] -> switch laser in turret $turret.nb gun $x to $weap.selected
+end
+end
+
+* Check for ammo
+$ammo.type =  get ammunition of laser $weap.selected
+if $ammo.type
+$test = 5 * $turret.laser.cnt
+= [THIS] -> add $test units of $ammo.type
+[THIS] -> set ammo resupply: ammo=$ammo.type amount=20
+end
+
+skip if not $turret.nb == 0
+return $weap.selected
+
+* Fix 4 : No turret script on OOS NPC ships
+$pl.sector = [PLAYERSHIP] -> get sector
+$owner = [THIS] -> get owner race
+if $owner != Player AND [SECTOR] != $pl.sector
+return $weap.selected
+end
+
+* Fix 2 : Default "attack enemies" turret settings
+[THIS] -> start task $turret.nb with script !turret.killenemies.std and prio 0: arg1=$turret.nb arg2=null arg3=null arg4=null arg5=null
+
+
+return $weap.selected

--- a/tools/fixtures/known_good/anarkis.lib.array.append.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.array.append.x3s
@@ -1,0 +1,14 @@
+#name: anarkis.lib.array.append
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.array.append.xml
+
+$append.size =  size of array $append.array
+
+while $append.size
+dec $append.size =
+$val = $append.array[$append.size]
+append $val to array $base.array
+end
+
+return $base.array

--- a/tools/fixtures/known_good/anarkis.lib.build.ships.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.build.ships.x3s
@@ -1,0 +1,39 @@
+#name: anarkis.lib.build.ships
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.build.ships.xml
+
+* ===========================================
+* Build a given amount of ships
+* ===========================================
+
+$null = null
+
+$class.list =  get ship type array: maker race=$race class=Fighter
+$class.cnt =  size of array $class.list
+
+$result =  array alloc: size=0
+while $ship.count
+dec $ship.count =
+if $shiptype == null
+$rnd =  = random value from 0 to $class.cnt - 1
+$new.class = $class.list[$rnd]
+else
+$new.class = $shiptype
+end
+
+$rnd =  = random value from 0 to 7 - 1
+$ship = $null -> call script anarkis.lib.createship :  Ship Type=$new.class  location=$sector  race=$race  best weapon ?=$rnd  no.ion=[FALSE]  no ammo=[FALSE]
+append $ship to array $result
+= $ship -> install 1 units of Jumpdrive
+= $ship -> install 1 units of Transporter Device
+
+$ship -> set homebase to $ship.homebase
+
+if $Put.in.Home == [TRUE]
+$ship -> put into environment $ship.homebase ->
+end
+
+end
+
+return $result

--- a/tools/fixtures/known_good/anarkis.lib.change.race.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.change.race.x3s
@@ -1,0 +1,14 @@
+#name: anarkis.lib.change.race
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.change.race.xml
+
+$l = $tg -> get ship array from sector/ship/station
+$c =  size of array $l
+while $c
+dec $c =
+$s = $l[$c]
+$s -> set owner race to $race
+end
+$tg -> set owner race to $race
+return null

--- a/tools/fixtures/known_good/anarkis.lib.clear.shiparray.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.clear.shiparray.x3s
@@ -1,0 +1,16 @@
+#name: anarkis.lib.clear.shiparray
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.clear.shiparray.xml
+
+*$result =  array alloc: size=0
+$cnt =  size of array $ship.list
+while $cnt
+dec $cnt =
+$ship = $ship.list[$cnt]
+if not $ship -> exists
+remove element from array $ship.list at index $cnt
+end
+end
+
+return $ship.list

--- a/tools/fixtures/known_good/anarkis.lib.cmd.attackland.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.cmd.attackland.x3s
@@ -1,0 +1,92 @@
+#name: anarkis.lib.cmd.attackland
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.attackland.xml
+
+* ===========================================
+* CMD : Tell a ship to attack a ship and land (with sector follow)
+* ===========================================
+
+* Init Command
+[THIS] -> set command: COMMAND_ATTACK_RETURN  target=$victim target2=$dst par1=null par2=null
+
+$cmd =  array alloc: size=0
+append 'anarkis.lib.cmd.attackland' to array $cmd
+append $victim to array $cmd
+append $dst to array $cmd
+[THIS] -> set local variable: name='anarkis.acc.skipme' value=[TRUE]
+[THIS] -> set local variable: name='anarkis.lib.cmd' value=$cmd
+$autojump = [THIS] -> is autojump activated
+$victim.sector = $victim -> get sector
+[THIS] -> set destination to $victim.sector
+[THIS] -> set attack target to $victim
+
+while $victim -> exists
+* - If the victim is of a weird race, cancel
+$victim.race = $victim -> get true owner
+skip if $victim.race
+$victim.race = $victim -> get owner race
+if $victim.race == Neutral Race OR $victim.race == Unknown OR $victim.race == Friendly Race OR $victim.race == [OWNER]
+goto label exit
+end
+* - If the victim is player owned, check if enemy
+$pl.rel = [THIS] -> get relation to race Player
+if $victim.race == Player AND $pl.rel != Foe
+goto label exit
+end
+
+* - If in different sector, we have to go there
+while $victim.sector != [SECTOR]
+skip if $victim -> exists
+goto label exit
+
+$res = FLRET_ERROR
+* - - Try jumping ?
+if [THIS] -> is autojump activated
+$victim.dest = $victim -> get destination
+if $victim.dest == null
+$victim.leader = $victim -> get formation leader
+skip if not $victim.leader
+$victim.dest = $victim.leader -> get destination
+end
+
+if $victim.dest != null
+skip if  is datatyp[ $victim.dest ] == DATATYP_SECTOR
+$victim.dest = $victim.dest -> get sector
+$gate =  get next gate on route from $victim.sector to $victim.dest
+else
+$gate =  get next gate on route from $victim.sector to [SECTOR]
+end
+$res = [THIS] -> call script !move.jump :  gate or sector=$gate  followers should jump too=[TRUE]
+end
+* - - Else move to
+if $res == FLRET_ERROR
+$next.sector = get next sector on route from sector [SECTOR] to sector $victim.sector
+= [THIS] -> call script !move.movetosector :  sector=$next.sector
+end
+= wait 250 ms
+skip if $victim -> exists
+goto label exit
+$victim.sector = $victim -> get sector
+end
+
+* - Here we go i guess
+[THIS] -> set command: COMMAND_ATTACK_RETURN  target=$victim target2=$dst par1=null par2=null
+= [THIS] -> call script !fight.attack.object :  the victim=$victim  follow in new sector=[TRUE]  Only attack shields=[FALSE]
+= wait 250 ms
+end
+
+exit:
+[THIS] -> set local variable: name='anarkis.job' value=0
+[THIS] -> set local variable: name='anarkis.lib.cmd' value=null
+
+if not $dst -> exists
+[THIS] -> jump out of existence
+return null
+end
+
+[THIS] -> set destination to $dst
+= [THIS] -> call script !ship.cmd.jumpstation.std :  object to land on=$dst  Should followers jump too=[TRUE]
+[THIS] -> set local variable: name='anarkis.acc.skipme' value=null
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.cmd.attacksame.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.cmd.attacksame.x3s
@@ -1,0 +1,18 @@
+#name: anarkis.lib.cmd.attacksame
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.attacksame.xml
+
+* ===========================================
+* CMD : Wingmates will resume the cmd now
+* ===========================================
+= wait 2000 ms
+
+$a = $leader -> get attack target
+
+[THIS] -> set attack target to $a
+[THIS] -> set local variable: name='anarkis.acc.skipme' value=[TRUE]
+= [THIS] -> call script !ship.cmd.attacksame.std :  the target=$leader  stop if leader is docked=[TRUE]
+[THIS] -> set local variable: name='anarkis.acc.skipme' value=null
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.cmd.dock.all.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.cmd.dock.all.x3s
@@ -1,0 +1,13 @@
+#name: anarkis.lib.cmd.dock.all
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.dock.all.xml
+
+[THIS] -> start task 896 with script anarkis.lib.dockall.secure and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+while [TRUE]
+= wait 1000 ms
+skip if [THIS] -> is script anarkis.lib.dockall.secure on stack of task=896
+break
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.cmd.dock.custom.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.cmd.dock.custom.x3s
@@ -1,0 +1,14 @@
+#name: anarkis.lib.cmd.dock.custom
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.dock.custom.xml
+
+[THIS] -> start task 896 with script anarkis.lib.dockcustom.secure and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+
+while [TRUE]
+= wait 1000 ms
+skip if [THIS] -> is script anarkis.lib.dockcustom.secure on stack of task=896
+break
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.cmd.donothing.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.cmd.donothing.x3s
@@ -1,0 +1,7 @@
+#name: anarkis.lib.cmd.donothing
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.donothing.xml
+
+= wait 20 ms
+return null

--- a/tools/fixtures/known_good/anarkis.lib.cmd.jumpnearobject.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.cmd.jumpnearobject.x3s
@@ -1,0 +1,32 @@
+#name: anarkis.lib.cmd.jumpnearobject
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.jumpnearobject.xml
+
+* ===========================================
+* This command allows a ship to jump to an object. To the contrary of
+* move.jumptoposition, it will stop if the object get destroyed
+* ===========================================
+
+skip if $object -> exists
+return null
+
+$object.sector = $object -> get sector
+$pos.array = $object -> get position as array
+$p.x = $pos.array[0]
+$p.y = $pos.array[1]
+$p.z = $pos.array[2]
+append $object.sector to array $pos.array
+
+= [THIS] -> call script !move.jumptogate.nearest :  targetpos=$pos.array  should followers jump too=[TRUE]
+= [THIS] -> call script !move.movetosector :  sector=$object.sector
+
+while $object -> exists
+$flt.ret = [THIS] -> move to position: x=$p.x y=$p.y z=$p.z with precision 5000 m
+if $flt.ret != FLRET_INTERRUPTED
+break
+end
+= wait randomly from 100 to 200 ms
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.cmd.jumptobeacon.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.cmd.jumptobeacon.x3s
@@ -1,0 +1,22 @@
+#name: anarkis.lib.cmd.jumptobeacon
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.jumptobeacon.xml
+
+
+skip if $beacon -> exists
+return null
+
+$object.sector = $beacon -> get sector
+$pos.array = $beacon -> get position as array
+$p.x = $pos.array[0]
+$p.y = $pos.array[1]
+$p.z = $pos.array[2]
+append $object.sector to array $pos.array
+
+= [THIS] -> use jump drive: target=$object.sector
+if [SECTOR] == $object.sector
+[THIS] -> set position: x=$p.x y=$p.y z=$p.z
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.cmd.killandland.timeout.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.cmd.killandland.timeout.x3s
@@ -1,0 +1,111 @@
+#name: anarkis.lib.cmd.killandland.timeout
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.cmd.killandland.timeout.xml
+
+* ===========================================
+* Altered 2.0a official script to allow a timeout
+* ===========================================
+* Added :
+* - Timeout
+* - Runaway code if damaged
+* - Uses jumptostation instead of movetostation
+* ===========================================
+* Removed : OWP, resupply, player code
+* ===========================================
+
+skip if [THIS] -> is of class Ship
+return null
+
+skip if not [THIS] -> is docked
+= [THIS] -> call script !move.undock :
+
+$returntostation = [FALSE]
+
+$isBig = [THIS] -> is of class M2
+skip if $isBig
+$isBig = [THIS] -> is of class M1
+
+
+* pirate fighter in pirate sector..
+$secowner = [SECTOR] -> get owner race
+$ispirate = $secowner == Pirates AND [OWNER] == Pirates
+
+skip if $range
+$range = [THIS] -> get scanner range
+$halfrange = $range / 2
+$refuel.runs = 0
+
+* Added : timeout
+$pltime = playing time
+$endtime = $pltime + $timeout
+
+while $pltime < $endtime
+= wait 10 ms
+$pltime = playing time
+
+* -------------------------------------------------------------------------
+* Targeting
+* -------------------------------------------------------------------------
+* find enemy in range.
+$enemy = [THIS] -> call script !fight.targeting :  the max scan range=$range  refpos array   x y z=$arefpos  Target Class=null
+
+* Pirates target a station nearby if no other target
+if ! $enemy AND $ispirate
+if not  = random value from 0 to 20 - 1
+$enemy = [THIS] -> call script !fight.targeting :  the max scan range=5000  refpos array   x y z=$arefpos  Target Class=Station
+end
+end
+
+* -------------------------------------------------------------------------
+* engage enemy if found
+* -------------------------------------------------------------------------
+$hull = [THIS] -> get hull percent
+$enemy.exists = $enemy -> exists
+if $hull > 92 AND $enemy.exists
+= [THIS] -> call script !fight.attack.object :  the victim=$enemy  follow in new sector=null
+$returntostation = [FALSE]
+inc $refuel.runs =
+else
+$stok = $station -> exists
+if not ( $stok AND $returntostation )
+$returntostation = [TRUE]
+if $arefpos AND $range
+$dist = [THIS] -> get distance to: position array=$arefpos
+if $dist > $range AND $moveable.ship
+$x = $arefpos[0]
+$y = $arefpos[1]
+$z = $arefpos[2]
+= [THIS] -> move to position: x=$x y=$y z=$z with precision $halfrange m
+continue
+end
+end
+if [THIS] -> is in active sector
+$time =  = random value from 10000 to 20000 - 1
+else
+$time =  = random value from 50000 to 59000 - 1
+end
+if $noidle
+= wait $time ms
+else
+$time = $time / 1000
+= [THIS] -> call script !move.idle.timeout :  timeout in sec=$time  wait while docked=[FALSE]
+end
+else if [ENVIRONMENT] != $station AND $moveable.ship
+$station.sector = $station -> get sector
+if $station.sector != [SECTOR]
+= [THIS] -> call script !move.jumptostation :  station=$station  should followers jump too=[TRUE]
+else
+= [THIS] -> call script !move.movetostation :  station=$station
+end
+skip if not [ENVIRONMENT] == $station
+return null
+= wait randomly from 1000 to 3000 ms
+else
+return null
+end
+end
+
+$pltime = playing time
+end
+return null

--- a/tools/fixtures/known_good/anarkis.lib.create.marine.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.create.marine.x3s
@@ -1,0 +1,21 @@
+#name: anarkis.lib.create.marine
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.create.marine.xml
+
+skip if $ship -> exists
+return null
+
+$pass = [THIS] -> call script anarkis.lib.create.passenger :  ship=$ship  race=$race
+$pass -> train passenger to marine
+
+$skill =  = random value from 20 to 80 - 1
+$pass -> set marine skill: fighting=$skill
+$skill =  = random value from 20 to 80 - 1
+$pass -> set marine skill: hacking=$skill
+$skill =  = random value from 20 to 80 - 1
+$pass -> set marine skill: mechanical=$skill
+$skill =  = random value from 20 to 80 - 1
+$ship -> set marine skill: engineering=$skill
+
+return $pass

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -573,6 +573,20 @@
             "examples": [
                 "append null to array $setup"
             ]
+        },
+        {
+            "name": "write.log.num",
+            "regex": "^write to log file #\\d+\\s+append=(0|1)\\s+value=\\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "write to log file #8513  append=1  value=$m"
+            ]
+        },
+        {
+            "name": "append.string",
+            "regex": "^append '[^']+' to array \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "append 'anarkis.lib.cmd.attackland' to array $cmd"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Plan
- incorporate 20 additional ADS scripts into fixture set
- extend linter allowlist for new log and array-append statements
- document newly recognized statements

## Changes
- added 20 ADS `.x3s` samples and updated README
- expanded `x3s_rules.json` with `write.log.num` and `append.string` patterns
- documented new patterns in `docs/x3s-language.md`

## Test Results
- `python tools/x3s_lint.py src/scripts tools/fixtures/known_good`
- `python tools/test_x3s.py`

## Pattern List
- `write.log.num` – `write to log file #8513  append=1  value=$m`
- `append.string` – `append 'anarkis.lib.cmd.attackland' to array $cmd`

## Safety Checks
- control-flow stack, wait-in-while, and setup load-text rules remain enforced

------
https://chatgpt.com/codex/tasks/task_e_68c69b5106a48326a4c73e115cba6077