### PR TITLE
feat: expand linter patterns for ADS scripts

### DIFF
--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -100,3 +100,9 @@ via `python tools/convert_mods.py` and are used by the test suite.
 ### New Statements Recognized
 - **write.log.num**: `write to log file #8513  append=1  value=$m`
 - **append.string**: `append 'anarkis.lib.cmd.attackland' to array $cmd`
+
+### New Statements Recognized
+- **append.race**: `append Argon to array $res`
+- **append.station**: `append Military Outpost to array $military.types`
+- **set.discovered.status**: `set discovered status: type=$race status=$show`
+- **set.notoriety**: `set notoriety of $base.race -> $target.race to $new.noto points`

--- a/tools/test_x3s.py
+++ b/tools/test_x3s.py
@@ -21,7 +21,13 @@ def run_fail(cmd: list[str]):
 
 
 if __name__ == '__main__':
-  run([sys.executable, 'tools/x3s_lint.py', 'src/scripts', 'tools/fixtures/known_good'])
+  run([
+      sys.executable,
+      'tools/x3s_lint.py',
+      'src/scripts',
+      'tools/fixtures/known_good',
+      'tools/fixtures/known_good/ADS/src/scripts',
+  ])
 
   fail_dir = ROOT / 'tools/fixtures/should_fail'
   if list(fail_dir.rglob('*.x3s')):

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -587,6 +587,34 @@
             "examples": [
                 "append 'anarkis.lib.cmd.attackland' to array $cmd"
             ]
+        },
+        {
+            "name": "append.race",
+            "regex": "^append (Argon|Boron|Split|Paranid|Teladi|Xenon|Kha'ak|Pirates|Goner|Unknown|Race 1|Race 2|ATF|Terran|Yaki) to array \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "append Argon to array $res"
+            ]
+        },
+        {
+            "name": "append.station",
+            "regex": "^append (Military Outpost|OTAS HQ|Terracorp HQ|Jonferco Headquarters|Plutarch Mining Corporation HQ|Atreus Headquarters|Strong Arms HQ|NMMC Headquarters|Duke's Haven|Orbital Defence Station|Military Base|Orbital Patrol Base|Headquarters) to array \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "append Military Outpost to array $military.types"
+            ]
+        },
+        {
+            "name": "set.discovered.status",
+            "regex": "^set discovered status: type=\\$[A-Za-z0-9_.]+ status=\\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "set discovered status: type=$race status=$show"
+            ]
+        },
+        {
+            "name": "set.notoriety",
+            "regex": "^set notoriety of \\$[A-Za-z0-9_.]+ -> \\$[A-Za-z0-9_.]+ to \\$[A-Za-z0-9_.]+ points$",
+            "examples": [
+                "set notoriety of $base.race -> $target.race to $new.noto points"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Plan
- analyze additional ADS scripts and capture line shapes that produced warnings
- extend regex allowlist and document new statements
- ensure test suite lints ADS fixtures and guards against unsafe scripts

## Changes
- added allowlist patterns for race/station appends, discovered status, and notoriety changes
- documented new statements and updated tests to lint ADS fixtures

## Test Results
- `python tools/x3s_lint.py src/scripts tools/fixtures/known_good tools/fixtures/known_good/ADS/src/scripts`
- `python tools/test_x3s.py`

## Pattern List
- append.race
- append.station
- set.discovered.status
- set.notoriety

## Safety Checks
- while blocks must contain waits or progress
- control-flow stack for if/else/while/end
- setup scripts require `load text: id=<...>`


------
https://chatgpt.com/codex/tasks/task_e_68c69c914a608326bf02cedaa6714202