### PR TITLE
Learn from known-good .x3s and update our linter (no XML build)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 SLX is a lightweight station-to-station logistics mod for X3TC: Terran Conflict. Moves wares between enrolled player stations (same- or cross-sector) — no NPC trade or scanning — via per-ware roles (Producer, Consumer, Store) with Min/Max/Chunk thresholds and a priority-based transfer loop.
 
 ## ADS Sample Files
-The linter is validated against these 160 known-good ADS scripts:
+The linter is validated against these 180 known-good ADS scripts:
 
 - !init.anarkis.modified.x3s
 - al.plugin.sk.ecs.x3s
@@ -164,3 +164,23 @@ The linter is validated against these 160 known-good ADS scripts:
 - anarkis.lib.cmd.jumptobeacon.x3s
 - anarkis.lib.cmd.killandland.timeout.x3s
 - anarkis.lib.create.marine.x3s
+- anarkis.lib.create.passenger.x3s
+- anarkis.lib.createfactory.x3s
+- anarkis.lib.createship.x3s
+- anarkis.lib.custowned.addship.x3s
+- anarkis.lib.custowned.cleanarr.f.x3s
+- anarkis.lib.custowned.cleanarray.x3s
+- anarkis.lib.custowned.getarray.f.x3s
+- anarkis.lib.custowned.getarray.x3s
+- anarkis.lib.custowned.getdocked.x3s
+- anarkis.lib.custowned.kill.x3s
+- anarkis.lib.disable.ai.x3s
+- anarkis.lib.display.message.x3s
+- anarkis.lib.dockall.adsonly.x3s
+- anarkis.lib.dockall.full.x3s
+- anarkis.lib.dockall.insector.x3s
+- anarkis.lib.dockall.secure.x3s
+- anarkis.lib.dockcustom.secure.x3s
+- anarkis.lib.encyclopedia.chapter.x3s
+- anarkis.lib.encyclopedia.x3s
+- anarkis.lib.get.bycargovalue.fro.x3s

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -106,3 +106,10 @@ via `python tools/convert_mods.py` and are used by the test suite.
 - **append.station**: `append Military Outpost to array $military.types`
 - **set.discovered.status**: `set discovered status: type=$race status=$show`
 - **set.notoriety**: `set notoriety of $base.race -> $target.race to $new.noto points`
+
+### New Statements Recognized
+- **find.station**: `$refobject = find station: sector=$sector class or type=Station race=$race flags=[Find.Random] refobj=null maxdist=null maxnum=1 refpos=null`
+- **find.ship**: `$ship.list = find ship: sector=$sector class or type=Moveable Ship race=null flags=$flags refobj=$refobject maxdist=null maxnum=50 refpos=null`
+- **size.of.array**: `$ship.count = size of array $ship.list`
+- **create.station**: `$select = create station: type=$station.type owner=$race addto=$sector x=$x y=$y z=$z`
+- **random.value**: `$p.face = = random value from 0 to 4 - 1`

--- a/tools/fixtures/known_good/anarkis.lib.create.passenger.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.create.passenger.x3s
@@ -1,0 +1,16 @@
+#name: anarkis.lib.create.passenger
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.create.passenger.xml
+
+skip if $ship -> exists
+return null
+skip if $race
+$race = $ship -> get true owner
+
+$p.name = get random name: race=$race
+$p.face =  = random value from 0 to 4 - 1
+$p.voice =  = random value from 0 to 4 - 1
+$pass = $ship -> create passenger in ship: name=$p.name race=$race voice=$p.voice face=$p.face
+
+return $pass

--- a/tools/fixtures/known_good/anarkis.lib.createfactory.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.createfactory.x3s
@@ -1,0 +1,41 @@
+#name: anarkis.lib.createfactory
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.createfactory.xml
+
+* ===========================================
+* Build a factory according to params
+* ===========================================
+
+$x = $location[0]
+$y = $location[1]
+$z = $location[2]
+$sector = $location[3]
+$select =  create station: type=$station.type owner=$race addto=$sector x=$x y=$y z=$z
+$select -> add default wares to station/dock
+$v1 = $select -> get maximum shield strength
+$select -> set current shield strength to $v1
+
+$select -> factory production task: on=[FALSE]
+$arr = $select -> get tradeable ware array from station
+$v1 =  size of array $arr
+while $v1
+dec $v1 =
+$v2 = $arr[$v1]
+if $select -> uses ware $v2 as product
+$select -> remove product from factory or dock: $v2
+else if $select -> uses ware $v2 as primary resource
+$select -> remove primary resource from factory: $v2
+else
+$select -> remove second resource from factory: $v2
+end
+end
+skip if not $product
+$select -> add product to factory or dock: $product
+skip if not $ressource1
+$select -> add primary resource to factory: $ressource1
+skip if not $ressource2
+$select -> add primary resource to factory: $ressource2
+$select -> factory production task: on=[TRUE]
+
+return $select

--- a/tools/fixtures/known_good/anarkis.lib.createship.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.createship.x3s
@@ -1,0 +1,54 @@
+#name: anarkis.lib.createship
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.createship.xml
+
+* Create ship
+$x =  = random value from -10000 to 10001 - 1
+$y =  = random value from -10000 to 10001 - 1
+$z =  = random value from -10000 to 10001 - 1
+$r =  create ship: type=$shiptype owner=$owner.race addto=$location x=$x y=$y z=$z
+$r -> set pirate cover state to [FALSE]
+* Add max shields
+$nb.shield = $r -> get number of shield bays
+$type.shield = $r -> get max. shield type that can be installed
+= $r -> install $nb.shield units of $type.shield
+* Extensions
+$x = $r -> get max upgrades for upgrade Cargo Bay Extension
+= $r -> install $x units of Cargo Bay Extension
+$x = $r -> get max upgrades for upgrade Engine Tuning
+= $r -> install $x units of Engine Tuning
+$x = $r -> get max upgrades for upgrade Rudder Optimisation
+= $r -> install $x units of Rudder Optimisation
+* Softwares
+= $r -> call script anarkis.lib.add.software :
+* Weapons
+$turret.cnt = $r -> get number of turrets
+while $turret.cnt
+dec $turret.cnt =
+= $r -> call script anarkis.lib.armturret :  turret ID=$turret.cnt  weapon selection mode=$weapon.type  no ion=$no.ion  no ammo weapons=$no.ammo
+end
+
+* Missiles
+$array = $r -> get compatible missile array
+$cnt =  size of array $array
+if $cnt
+$id =  = random value from 0 to $cnt - 1
+$select.a = $array[$id]
+$id =  = random value from 0 to $cnt - 1
+$select.b = $array[$id]
+if $r -> is of class M8
+$x =  = random value from 15 to 25 - 1
+$y =  = random value from 15 to 25 - 1
+else if $r -> is missile boat
+$x =  = random value from 25 to 60 - 1
+$y =  = random value from 25 to 60 - 1
+else
+$x =  = random value from 2 to 5 - 1
+$y =  = random value from 2 to 5 - 1
+end
+= $r -> install $x units of $select.a
+= $r -> install $y units of $select.b
+end
+
+return $r

--- a/tools/fixtures/known_good/anarkis.lib.custowned.addship.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.custowned.addship.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.lib.custowned.addship
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.addship.xml
+
+$var = [THIS] -> get local variable: name='anarkis.owned'
+append $ship to array $var
+[THIS] -> set local variable: name='anarkis.owned' value=$var
+return $var

--- a/tools/fixtures/known_good/anarkis.lib.custowned.cleanarr.f.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.custowned.cleanarr.f.x3s
@@ -1,0 +1,15 @@
+#name: anarkis.lib.custowned.cleanarr.f
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.cleanarr.f.xml
+
+$var = $from -> get local variable: name='anarkis.owned'
+$cnt =  size of array $var
+while $cnt
+dec $cnt =
+$ship = $var[$cnt]
+skip if $ship -> exists
+remove element from array $var at index $cnt
+end
+$from -> set local variable: name='anarkis.owned' value=$var
+return $var

--- a/tools/fixtures/known_good/anarkis.lib.custowned.cleanarray.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.custowned.cleanarray.x3s
@@ -1,0 +1,15 @@
+#name: anarkis.lib.custowned.cleanarray
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.cleanarray.xml
+
+$var = [THIS] -> get local variable: name='anarkis.owned'
+$cnt =  size of array $var
+while $cnt
+dec $cnt =
+$ship = $var[$cnt]
+skip if $ship -> exists
+remove element from array $var at index $cnt
+end
+[THIS] -> set local variable: name='anarkis.owned' value=$var
+return $var

--- a/tools/fixtures/known_good/anarkis.lib.custowned.getarray.f.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.custowned.getarray.f.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.lib.custowned.getarray.f
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.getarray.f.xml
+
+
+= [THIS] -> call script anarkis.lib.custowned.cleanarr.f :  from=$from
+$var = $from -> get local variable: name='anarkis.owned'
+return $var

--- a/tools/fixtures/known_good/anarkis.lib.custowned.getarray.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.custowned.getarray.x3s
@@ -1,0 +1,8 @@
+#name: anarkis.lib.custowned.getarray
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.getarray.xml
+
+= [THIS] -> call script anarkis.lib.custowned.cleanarray :
+$var = [THIS] -> get local variable: name='anarkis.owned'
+return $var

--- a/tools/fixtures/known_good/anarkis.lib.custowned.getdocked.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.custowned.getdocked.x3s
@@ -1,0 +1,20 @@
+#name: anarkis.lib.custowned.getdocked
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.getdocked.xml
+
+$docked =  array alloc: size=0
+
+= [THIS] -> call script anarkis.lib.custowned.cleanarray :
+$array = [THIS] -> get local variable: name='anarkis.owned'
+$cnt =  size of array $array
+
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$env = $select -> get environment
+skip if not $env == [THIS]
+append $select to array $docked
+end
+
+return $docked

--- a/tools/fixtures/known_good/anarkis.lib.custowned.kill.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.custowned.kill.x3s
@@ -1,0 +1,7 @@
+#name: anarkis.lib.custowned.kill
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.custowned.kill.xml
+
+[THIS] -> set local variable: name='anarkis.owned' value=null
+return $var

--- a/tools/fixtures/known_good/anarkis.lib.disable.ai.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.disable.ai.x3s
@@ -1,0 +1,9 @@
+#name: anarkis.lib.disable.ai
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.disable.ai.xml
+
+[THIS] -> set race logic control enabled to [FALSE]
+[THIS] -> disable ship rebuild
+[THIS] -> set StartAction enabled to [FALSE]
+return null

--- a/tools/fixtures/known_good/anarkis.lib.display.message.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.display.message.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.lib.display.message
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.display.message.xml
+
+$menu =  create custom menu array
+$message = sprintf: pageid=$page.id textid=$text.id, $v1, $v2, $v3, null, null
+add custom menu heading to array $menu: title='-'
+add custom menu item to array $menu: text='OK' returnvalue=-1
+add custom menu info line to array $menu: text=$message
+$res =  open custom menu: title=$title description=null option array=$menu
+return $res

--- a/tools/fixtures/known_good/anarkis.lib.dockall.adsonly.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.dockall.adsonly.x3s
@@ -1,0 +1,127 @@
+#name: anarkis.lib.dockall.adsonly
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.dockall.adsonly.xml
+
+* ===========================================
+* Securely Dock All Ships to a Carrier / Station
+* ===========================================
+
+$ship.list = $carrier -> call script anarkis.acc.lib.get.adsonly :
+$global =  size of array $ship.list
+$myowner = $carrier -> get owner race
+
+* 1st Pass
+while $global
+$ship.count =  size of array $ship.list
+
+$pl.sec = [PLAYERSHIP] -> get sector
+$carrier.sector = $carrier -> get sector
+if $pl.sec == $carrier.sector
+$OOS = [FALSE]
+else
+$OOS = [TRUE]
+end
+
+while $ship.count
+= wait 10 ms
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$env = $ship -> get environment
+if not $carrier -> is docking possible of $ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $env == $carrier
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> exists
+remove element from array $ship.list at index $ship.count
+continue
+end
+$ship.owner = $ship -> get owner race
+if not $ship.owner == $myowner
+remove element from array $ship.list at index $ship.count
+continue
+end
+skip if not $ship -> is script anarkis.acc.task.hullcheck on stack of task=900
+$ship -> start task 900 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+if not $ship -> is task 0 in use
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=$carrier arg2=null arg3=null arg4=null arg5=null
+continue
+end
+
+$runthis = [FALSE]
+skip if not $ship -> is script !move.movetostation on stack of task=0
+$runthis = [TRUE]
+skip if not $ship -> is script !ship.cmd.retreat.std on stack of task=0
+$runthis = [TRUE]
+$isjump = $ship -> is script !move.jumptosector on stack of task=0
+
+if $runthis == [TRUE]
+
+$ship.sec = $ship -> get sector
+* - - Don't touch ships in different sector or they'll go sluggish
+skip if [SECTOR] == $ship.sec
+continue
+
+$transport.device = $ship -> get true amount of ware Transporter Device in cargo bay
+$distance = get distance between $ship and $carrier
+
+* - - Teleport ships with transporter device (or when OOS)
+if $distance <= 5000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+* - - Same for OOS at smaller distance to avoid rare bug
+if $distance <= 2000 AND $OOS == [TRUE]
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+* - Check for buggy ships
+$speed = $ship -> get current speed
+if $speed == 0 AND $isjump != [TRUE]
+* - - Transporter Device Teleportation possible ?
+if $distance <= 6000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+* - - - Go Idle and hope it'll work next try
+else
+START $ship -> call script !ship.cmd.idle.std :
+= wait 5000 ms
+end
+end
+else
+$env = $ship -> get environment
+if $env != [THIS]
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=$carrier arg2=null arg3=null arg4=null arg5=null
+else if $env == [THIS]
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+end
+end
+$global =  size of array $ship.list
+= wait 5000 ms
+end
+
+return null
+
+dodock:
+$ship -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$ship -> set destination to null
+$ship -> set command: COMMAND_NONE  target=null target2=null par1=null par2=null
+$v1 = $ship -> get maximum shield strength
+$ship -> set current shield strength to $v1
+endsub
+return null

--- a/tools/fixtures/known_good/anarkis.lib.dockall.full.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.dockall.full.x3s
@@ -1,0 +1,129 @@
+#name: anarkis.lib.dockall.full
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.dockall.full.xml
+
+* ===========================================
+* Securely Dock All Ships to a Carrier / Station
+* ===========================================
+
+
+if $ads.only
+$owned.list = $carrier -> call script anarkis.acc.lib.get.adsonly :
+else
+$owned.list = $carrier -> get owned ships: class/type=Moveable Ship
+end
+$owned.cnt =  size of array $owned.list
+while $owned.cnt
+dec $owned.cnt =
+$ship = $owned.list[$owned.cnt]
+end
+
+$myowner = $carrier -> get owner race
+
+
+* 1st Pass
+while $global
+$ship.count =  size of array $ship.list
+
+while $ship.count
+
+= wait 10 ms
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$env = $ship -> get environment
+if not $carrier -> is docking possible of $ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $env == $carrier
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> exists
+remove element from array $ship.list at index $ship.count
+continue
+end
+$ship.owner = $ship -> get owner race
+if not $ship.owner == $myowner
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> is task 0 in use
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=$carrier arg2=null arg3=null arg4=null arg5=null
+continue
+end
+
+$runthis = [FALSE]
+skip if not $ship -> is script !move.movetostation on stack of task=0
+$runthis = [TRUE]
+skip if not $ship -> is script !ship.cmd.retreat.std on stack of task=0
+$runthis = [TRUE]
+$isjump = $ship -> is script !move.jumptosector on stack of task=0
+
+if $runthis == [TRUE]
+
+$ship.sec = $ship -> get sector
+* - - Don't touch ships in different sector or they'll go sluggish
+skip if [SECTOR] == $ship.sec
+continue
+
+$transport.device = $ship -> get true amount of ware Transporter Device in cargo bay
+$distance = get distance between $ship and $carrier
+
+* - - Teleport ships with transporter device (or when OOS)
+if $distance <= 5000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+* - - Same for OOS at smaller distance to avoid rare bug
+if $distance <= 2000 AND $OOS == [TRUE]
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+* - Check for buggy ships
+$speed = $ship -> get current speed
+if $speed == 0 AND $isjump != [TRUE]
+* - - Transporter Device Teleportation possible ?
+if $distance <= 6000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+* - - - Go Idle and hope it'll work next try
+else
+START $ship -> call script !ship.cmd.idle.std :
+= wait 5000 ms
+end
+end
+else
+$env = $ship -> get environment
+if $env != [THIS]
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=$carrier arg2=null arg3=null arg4=null arg5=null
+else if $env == [THIS]
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+end
+end
+$global =  size of array $ship.list
+= wait 5000 ms
+end
+
+return null
+
+dodock:
+$ship -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$ship -> set destination to null
+$ship -> set command: COMMAND_NONE  target=null target2=null par1=null par2=null
+$v1 = $ship -> get maximum shield strength
+$ship -> set current shield strength to $v1
+endsub
+return null

--- a/tools/fixtures/known_good/anarkis.lib.dockall.insector.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.dockall.insector.x3s
@@ -1,0 +1,91 @@
+#name: anarkis.lib.dockall.insector
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.dockall.insector.xml
+
+* ===========================================
+* Securely Dock All Ships to a Carrier / Station
+* ===========================================
+
+$ship.list = $carrier -> get owned ships: class/type=Moveable Ship
+$global =  size of array $ship.list
+$my.owner = $carrier -> get owner race
+* 1st Pass
+while $global
+$ship.count =  size of array $ship.list
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$env = $ship -> get environment
+if not $carrier -> is docking possible of $ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $env == $carrier
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> exists
+remove element from array $ship.list at index $ship.count
+continue
+end
+$ship.owner = $ship -> get owner race
+if not $ship.owner == $my.owner
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+if $ship -> is script !move.movetostation on stack of task=0
+$distance = get distance between $ship and $carrier
+$transport.device = $ship -> get true amount of ware Transporter Device in cargo bay
+
+* - - Teleport ships with transporter device
+if $distance <= 5000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+* - Check for buggy ships
+$speed = $ship -> get current speed
+if $speed == 0
+* - - Transporter Device Teleportation possible ?
+$distance = get distance between $ship and $carrier
+if $distance <= 6000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+* - - - Go Idle and hope it'll work next try
+else
+START $ship -> call script !ship.cmd.idle.std :
+= wait 5000 ms
+end
+end
+else
+$env = $ship -> get environment
+if $env != [THIS]
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=$carrier arg2=null arg3=null arg4=null arg5=null
+else if $env == [THIS]
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+end
+end
+$global =  size of array $ship.list
+= wait 5000 ms
+end
+
+return null
+
+dodock:
+$ship -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$ship -> set command: COMMAND_NONE  target=null target2=null par1=null par2=null
+$ship -> set destination to null
+$v1 = $ship -> get maximum shield strength
+$ship -> set current shield strength to $v1
+endsub
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.dockall.secure.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.dockall.secure.x3s
@@ -1,0 +1,92 @@
+#name: anarkis.lib.dockall.secure
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.dockall.secure.xml
+
+* ===========================================
+* Securely Dock All Ships to a Carrier / Station
+* ===========================================
+
+$ship.list = $carrier -> get owned ships: class/type=Moveable Ship
+$global =  size of array $ship.list
+
+* 1st Pass
+while $global
+$ship.count =  size of array $ship.list
+while $ship.count
+= wait 50 ms
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$env = $ship -> get environment
+if not $carrier -> is docking possible of $ship
+remove element from array $ship.list at index $ship.count
+continue
+end
+if $env == $carrier
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> exists
+remove element from array $ship.list at index $ship.count
+continue
+end
+skip if not $ship -> is script anarkis.acc.task.hullcheck on stack of task=900
+$ship -> start task 900 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+
+if $ship -> is script !move.movetostation on stack of task=0
+
+$distance = get distance between $ship and $carrier
+$transport.device = $ship -> get true amount of ware Transporter Device in cargo bay
+
+* - - Teleport ships with transporter device
+if $distance <= 5000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+
+* - Check for buggy ships
+$speed = $ship -> get current speed
+if $speed == 0
+* - - Transporter Device Teleportation possible ?
+$distance = get distance between $ship and $carrier
+if $distance <= 6000 AND $transport.device >= 1
+$ship -> put into environment $carrier ->
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+* - - - Go Idle and hope it'll work next try
+else
+START $ship -> call script !ship.cmd.idle.std :
+= wait 1000 ms
+end
+end
+else
+$env = $ship -> get environment
+if $env != [THIS]
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=$carrier arg2=null arg3=null arg4=null arg5=null
+else if $env == [THIS]
+gosub dodock
+remove element from array $ship.list at index $ship.count
+continue
+end
+end
+end
+$global =  size of array $ship.list
+= wait 4000 ms
+end
+
+return null
+
+dodock:
+$ship -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$ship -> set command: COMMAND_NONE  target=null target2=null par1=null par2=null
+$ship -> set destination to null
+$v1 = $ship -> get maximum shield strength
+$ship -> set current shield strength to $v1
+
+endsub
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.dockcustom.secure.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.dockcustom.secure.x3s
@@ -1,0 +1,68 @@
+#name: anarkis.lib.dockcustom.secure
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.dockcustom.secure.xml
+
+* ===========================================
+* Securely Dock All Ships to a Carrier / Station
+* ===========================================
+
+$test.arr = [THIS] -> call script anarkis.lib.custowned.getarray :
+$glb.cnt =  size of array $test.arr
+dec $glb.cnt =
+
+* Arrays are POINTER type so we must make a real copy before doing something on it
+$ship.list =  clone array $test.arr : index 0 ... $glb.cnt
+$glb.cnt =  size of array $ship.list
+
+* 1st Pass
+while $glb.cnt
+$ship.count =  size of array $ship.list
+
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+$env = $ship -> get environment
+if $env == [THIS]
+remove element from array $ship.list at index $ship.count
+continue
+end
+if not $ship -> exists
+remove element from array $ship.list at index $ship.count
+continue
+end
+* - Check for buggy ships
+if $ship -> is script !move.movetostation on stack of task=0
+$speed = $ship -> get current speed
+if $speed == 0
+* - - Transporter Device Teleportation possible ?
+$transport.device = $ship -> get amount of ware Transporter Device in cargo bay
+$distance = get distance between $ship and [THIS]
+if $distance <= 5000 AND $transport.device == 1
+
+$ship -> start task 0 with script anarkis.lib.cmd.donothing and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+$ship -> put into environment [THIS] ->
+$ship -> set command: COMMAND_NONE  target=null target2=null par1=null par2=null
+$ship -> set destination to null
+remove element from array $ship.list at index $ship.count
+continue
+* - - Go Idle and hope it'll work next try
+else
+START $ship -> call script !ship.cmd.idle.std :
+= wait 5000 ms
+end
+end
+else
+$ship -> start task 0 with script !ship.cmd.retreat.std and prio 0: arg1=[THIS] arg2=null arg3=null arg4=null arg5=null
+end
+end
+$glb.cnt =  size of array $ship.list
+* - Cancel if no dock bay free
+$test.dockbaysize = [THIS] -> get dock bay size
+$test.landedcount = [THIS] -> get number of landed ships
+skip if not $test.dockbaysize <= $test.landedcount
+break
+= wait 5000 ms
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.encyclopedia.chapter.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.encyclopedia.chapter.x3s
@@ -1,0 +1,43 @@
+#name: anarkis.lib.encyclopedia.chapter
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.encyclopedia.chapter.xml
+
+$race.arr = [THIS] -> call script anarkis.lib.get.race.array :
+$race.cnt =  size of array $race.arr
+while $race.cnt
+dec $race.cnt =
+$race = $race.arr[$race.cnt]
+set discovered status: type=$race status=$show
+
+if $include.ships
+$ship.arr =  get ship type array: maker race=$race class=Ship
+$ship.cnt =  size of array $ship.arr
+while $ship.cnt
+dec $ship.cnt =
+$ship = $ship.arr[$ship.cnt]
+set discovered status: type=$ship status=$show
+end
+end
+
+if $include.stations
+$st.arr =  get station array: of race $race class/type=Station
+$st.cnt =  size of array $st.arr
+while $st.cnt
+dec $st.cnt =
+$st = $st.arr[$st.cnt]
+$st = $st -> get ware type code of object
+set discovered status: type=$st status=$show
+end
+end
+
+end
+
+$cnt =  get number of subtypes of maintype $chapter
+while $cnt
+dec $cnt =
+$ware =  get ware from maintype $chapter and subtype $cnt
+set discovered status: type=$ware status=$show
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.encyclopedia.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.encyclopedia.x3s
@@ -1,0 +1,42 @@
+#name: anarkis.lib.encyclopedia
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.encyclopedia.xml
+
+$race.arr = [THIS] -> call script anarkis.lib.get.race.array :
+$race.cnt =  size of array $race.arr
+while $race.cnt
+dec $race.cnt =
+$race = $race.arr[$race.cnt]
+set discovered status: type=$race status=$show
+
+$ship.arr =  get ship type array: maker race=$race class=Ship
+$ship.cnt =  size of array $ship.arr
+while $ship.cnt
+dec $ship.cnt =
+$ship = $ship.arr[$ship.cnt]
+set discovered status: type=$ship status=$show
+end
+
+$st.arr =  get station array: of race $race class/type=Station
+$st.cnt =  size of array $st.arr
+while $st.cnt
+dec $st.cnt =
+$st = $st.arr[$st.cnt]
+$st = $st -> get ware type code of object
+set discovered status: type=$st status=$show
+end
+end
+
+$m.cnt = 20
+while $m.cnt
+dec $m.cnt =
+$cnt =  get number of subtypes of maintype $m.cnt
+while $cnt
+dec $cnt =
+$ware =  get ware from maintype $m.cnt and subtype $cnt
+set discovered status: type=$ware status=$show
+end
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.lib.get.bycargovalue.fro.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.bycargovalue.fro.x3s
@@ -1,0 +1,17 @@
+#name: anarkis.lib.get.bycargovalue.fro
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.bycargovalue.fro.xml
+
+$class =  array alloc: size=2
+$class[0] = TS
+$class[1] = TP
+$rel = $from -> get relation to race Player
+if $rel == Foe
+$include = [FALSE]
+else
+$include = [TRUE]
+end
+$array = [THIS] -> call script anarkis.lib.get.bycargovalue.adv :  ref obj=$from  jumprange=$jump.range  min cargo=$mincargo  ignore pirate/yaki=[FALSE]  ignore player ?=$include
+
+return $array

--- a/tools/test_x3s.py
+++ b/tools/test_x3s.py
@@ -20,14 +20,16 @@ def run_fail(cmd: list[str]):
     sys.exit(1)
 
 
+def known_good_dirs() -> list[str]:
+  base = ROOT / 'tools/fixtures/known_good'
+  dirs = {base}
+  for p in base.rglob('*.x3s'):
+    dirs.add(p.parent)
+  return [str(d.relative_to(ROOT)) for d in sorted(dirs)]
+
+
 if __name__ == '__main__':
-  run([
-      sys.executable,
-      'tools/x3s_lint.py',
-      'src/scripts',
-      'tools/fixtures/known_good',
-      'tools/fixtures/known_good/ADS/src/scripts',
-  ])
+  run([sys.executable, 'tools/x3s_lint.py', 'src/scripts', *known_good_dirs()])
 
   fail_dir = ROOT / 'tools/fixtures/should_fail'
   if list(fail_dir.rglob('*.x3s')):

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -615,6 +615,41 @@
             "examples": [
                 "set notoriety of $base.race -> $target.race to $new.noto points"
             ]
+        },
+        {
+            "name": "find.station",
+            "regex": "^\\$[A-Za-z0-9_.]+\\s*=\\s*find station:\\s*sector=\\$[A-Za-z0-9_.]+\\s+class or type=[A-Za-z0-9 ]+\\s+race=\\$[A-Za-z0-9_.]+\\s+flags=\\[[A-Za-z0-9_.|]+\\]\\s+refobj=(\\$[A-Za-z0-9_.]+|null)\\s+maxdist=(\\$[A-Za-z0-9_.]+|null)\\s+maxnum=\\d+\\s+refpos=(\\$[A-Za-z0-9_.]+|null)$",
+            "examples": [
+                "$refobject = find station: sector=$sector class or type=Station race=$race flags=[Find.Random] refobj=null maxdist=null maxnum=1 refpos=null"
+            ]
+        },
+        {
+            "name": "find.ship",
+            "regex": "^\\$[A-Za-z0-9_.]+\\s*=\\s*find ship:\\s*sector=\\$[A-Za-z0-9_.]+\\s+class or type=[A-Za-z0-9 ]+\\s+race=(\\$[A-Za-z0-9_.]+|null)\\s+flags=(\\$[A-Za-z0-9_.]+|\\[[A-Za-z0-9_.|]+\\])\\s+refobj=(\\$[A-Za-z0-9_.]+|null)\\s+maxdist=(\\$[A-Za-z0-9_.]+|null)\\s+maxnum=\\d+\\s+refpos=(\\$[A-Za-z0-9_.]+|null)$",
+            "examples": [
+                "$ship.list = find ship: sector=$sector class or type=Moveable Ship race=null flags=$flags refobj=$refobject maxdist=null maxnum=50 refpos=null"
+            ]
+        },
+        {
+            "name": "size.of.array",
+            "regex": "^\\$[A-Za-z0-9_.]+\\s*=\\s*size of array \\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "$ship.count = size of array $ship.list"
+            ]
+        },
+        {
+            "name": "create.station",
+            "regex": "^\\$[A-Za-z0-9_.]+\\s*=\\s*create station:\\s*type=\\$[A-Za-z0-9_.]+\\s+owner=\\$[A-Za-z0-9_.]+\\s+addto=\\$[A-Za-z0-9_.]+\\s+x=\\$[A-Za-z0-9_.]+\\s+y=\\$[A-Za-z0-9_.]+\\s+z=\\$[A-Za-z0-9_.]+$",
+            "examples": [
+                "$select = create station: type=$station.type owner=$race addto=$sector x=$x y=$y z=$z"
+            ]
+        },
+        {
+            "name": "random.value",
+            "regex": "^\\$[A-Za-z0-9_.]+\\s*=\\s*=\\s*random value from \\d+ to \\d+ - \\d+$",
+            "examples": [
+                "$p.face = = random value from 0 to 4 - 1"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Plan
- Expand ADS fixture set with additional scripts and update README
- Extend linter allowlist with patterns learned from new ADS scripts
- Document newly recognized statements and ensure tests cover fixtures

## Changes
- Added 20 ADS scripts to `tools/fixtures/known_good` and listed them in README
- Introduced regex patterns for `find station`, `find ship`, `size of array`, `create station`, and `random value` lines
- Updated `docs/x3s-language.md` with examples of the new statements
- Enhanced `tools/test_x3s.py` to lint all known-good fixture directories automatically

## Test Results
- `python tools/x3s_lint.py src/scripts tools/fixtures/known_good tools/fixtures/known_good/ADS/src/scripts tools/fixtures/known_good/FDN/src/scripts tools/fixtures/known_good/OKTraders1_7_1/src/scripts`
- `python tools/test_x3s.py`

## Pattern List
- find.station: `$refobject = find station: sector=$sector class or type=Station race=$race flags=[Find.Random] refobj=null maxdist=null maxnum=1 refpos=null`
- find.ship: `$ship.list = find ship: sector=$sector class or type=Moveable Ship race=null flags=$flags refobj=$refobject maxdist=null maxnum=50 refpos=null`
- size.of.array: `$ship.count = size of array $ship.list`
- create.station: `$select = create station: type=$station.type owner=$race addto=$sector x=$x y=$y z=$z`
- random.value: `$p.face = = random value from 0 to 4 - 1`

## Safety Checks
- Control-flow stack (if/while/end) maintained
- Wait required in while loops
- Setup scripts still require `load text: id=<page>`

------
https://chatgpt.com/codex/tasks/task_e_68c69f562df08326a769eef629d13492