### PR TITLE
Add additional ADS fixtures and document new patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 SLX is a lightweight station-to-station logistics mod for X3TC: Terran Conflict. Moves wares between enrolled player stations (same- or cross-sector) — no NPC trade or scanning — via per-ware roles (Producer, Consumer, Store) with Min/Max/Chunk thresholds and a priority-based transfer loop.
 
 ## ADS Sample Files
-The linter is validated against these 180 known-good ADS scripts:
+The linter is validated against these 180 known-good ADS scripts (20 newly added from ADS):
 
 - !init.anarkis.modified.x3s
 - al.plugin.sk.ecs.x3s

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -113,3 +113,7 @@ via `python tools/convert_mods.py` and are used by the test suite.
 - **size.of.array**: `$ship.count = size of array $ship.list`
 - **create.station**: `$select = create station: type=$station.type owner=$race addto=$sector x=$x y=$y z=$z`
 - **random.value**: `$p.face = = random value from 0 to 4 - 1`
+
+### New Statements Recognized
+- **array.alloc**: `$sel.role = array alloc: size=0`
+- **menu.create**: `$menu = create custom menu array`

--- a/tools/fixtures/known_good/anarkis.acc.task.repairs.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.task.repairs.x3s
@@ -1,0 +1,99 @@
+#name: anarkis.acc.task.repairs
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.task.repairs.xml
+
+
+$owner = [OWNER]
+$timer.training = 0
+while [OWNER] == $owner
+
+= [THIS] -> call script anarkis.lib.wait :  wait time (in sec)=60  global to check=null
+inc $timer.training =
+if $timer.training >= 60
+$timer.training = 0
+$cost = [THIS] -> call script anarkis.ads.crew.getcost :  ref object=[THIS]
+$pl.money = get player money
+if $pl.money >= $cost
+$cost = 0 - $cost
+add money to player: $cost
+= [THIS] -> call script anarkis.ads.crew.train :  ref object=[THIS]
+else
+= [THIS] -> call script anarkis.ads.crew.sleep :  ref object=[THIS]
+end
+end
+
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+$repair.setup = $setup.array[17]
+
+$mecha.count = $repair.setup[0]
+skip if $mecha.count > 0
+continue
+
+$allow.docked = $repair.setup[1]
+$allow.carrier = $repair.setup[2]
+
+$repair.ratio = [THIS] -> call script anarkis.ads.crew.getrepair :  ref object=[THIS]
+$repair.ratio = $mecha.count * 25 + $repair.ratio
+$onduty = [FALSE]
+
+if $allow.carrier == [TRUE]
+$c.hull = [THIS] -> get hull
+$m.hull = [THIS] -> get max hull
+$need = $m.hull - $c.hull
+if $need
+$onduty = [TRUE]
+$c.hull = $c.hull + $repair.ratio
+[THIS] -> set hull to $c.hull
+$repair.ratio = 0
+end
+end
+
+if $allow.docked == [TRUE]
+$ship.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $ship.list
+while $cnt AND $repair.ratio
+dec $cnt =
+$select = $ship.list[$cnt]
+$c.hull = $select -> get hull
+$m.hull = $select -> get max hull
+$need = $m.hull - $c.hull
+if $need > 0
+$onduty = [TRUE]
+if $need >= $repair.ratio
+$c.hull = $c.hull + $repair.ratio
+$repair.ratio = 0
+else
+$repair.ratio = $repair.ratio - $need
+$c.hull = $c.hull + $need
+end
+*$msg = sprintf: fmt='Repair : %s (%s)', $select, $need, null, null, null
+*display subtitle text: text=$msg duration=2000 ms
+if $c.hull > $m.hull
+$select -> set hull to $m.hull
+else
+$select -> set hull to $c.hull
+end
+end
+end
+end
+
+if [OWNER] == Player
+if $onduty == [TRUE]
+$cost = $mecha.count * 5000 / 60
+else
+$cost = $mecha.count * 1000 / 60
+end
+$money = get player money
+if $cost > $money
+$repair.setup[0] = 0
+else
+$cost = 0 - $cost
+add money to player: $cost
+end
+end
+
+end
+
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.wing.attack.pl.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.wing.attack.pl.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.acc.wing.attack.pl
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.wing.attack.pl.xml
+
+* ===========================================
+* Wing : Send a wing to attack a given target
+* ===========================================
+[THIS] -> set command: ANARKIS_ATTACKWING  target=$target target2=$wing.size par1=null par2=null
+= [THIS] -> call script anarkis.acc.wing.attack :  target=$target  wing size=$wing.size  wing ID='A'
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.wing.attack.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.wing.attack.x3s
@@ -1,0 +1,77 @@
+#name: anarkis.acc.wing.attack
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.wing.attack.xml
+
+* ===========================================
+* Wing : Send a wing to attack a given target
+* ===========================================
+
+skip if $target -> exists
+return null
+if  is datatyp[ $wing.size ] == DATATYP_ARRAY
+$v1 =  size of array $wing.size
+dec $v1 =
+$wing.array =  clone array $wing.size : index 0 ... $v1
+$wing.size =  size of array $wing.array
+
+else
+$wing.array = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$cnt =  size of array $wing.array
+while $cnt
+dec $cnt =
+$v1 = $wing.array[$cnt]
+skip if not $v1 -> is of class Freighter
+remove element from array $wing.array at index $cnt
+end
+$cnt =  size of array $wing.array
+
+if $cnt > $wing.size
+resize array $wing.array to $wing.size
+end
+$wing.size =  size of array $wing.array
+end
+
+$setup = [THIS] -> get local variable: name='anarkis.acc.setup'
+$callback = $setup[3]
+$autorename = $setup[15]
+
+$leader = $wing.array[0]
+skip if $leader -> exists
+return null
+= [THIS] -> call script anarkis.acc.repairshields.single :  ship=$leader
+
+if $target -> is of class Big Ship
+$leader -> set command target: Big Ship
+else
+$leader -> set command target: null
+end
+START $leader -> call script anarkis.acc.cmd.attack.return :  victim=$target  dst=[THIS]
+$leader -> set local variable: name='anarkis.acc.wing' value=$name
+if $callback == [TRUE]
+$leader -> start task 900 with script anarkis.acc.task.hullcheck and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+*if $autorename == [TRUE]
+*$leader -> start task 893 with script anarkis.acc.task.autoname and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+*end
+remove element from array $wing.array at index 0
+
+
+= wait randomly from 500 to 1000 ms
+
+$cnt =  size of array $wing.array
+while $cnt
+dec $cnt =
+$wingmate = $wing.array[$cnt]
+$wingmate -> set local variable: name='anarkis.acc.wing' value=$name
+= [THIS] -> call script anarkis.acc.repairshields.single :  ship=$wingmate
+START $wingmate -> call script !ship.cmd.attacksame.std :  the target=$leader  stop if leader is docked=[TRUE]
+if $callback == [TRUE]
+$wingmate -> start task 900 with script anarkis.acc.task.hullcheck and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+*if $autorename == [TRUE]
+*$wingmate -> start task 893 with script anarkis.acc.task.autoname and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+*end
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.wing.clearsector.pl.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.wing.clearsector.pl.x3s
@@ -1,0 +1,13 @@
+#name: anarkis.acc.wing.clearsector.pl
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.wing.clearsector.pl.xml
+
+* ===========================================
+* Wing : Send all ships in wings
+* ===========================================
+* Ships will be dispatched in 5 ship wings
+[THIS] -> set command: ANARKIS_CLEANSECTOR  target=null target2=null par1=null par2=null
+= [THIS] -> call script anarkis.acc.wing.clearsector :
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.wing.clearsector.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.wing.clearsector.x3s
@@ -1,0 +1,63 @@
+#name: anarkis.acc.wing.clearsector
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.wing.clearsector.xml
+
+* ===========================================
+* Wing : Send all ships in wings
+* ===========================================
+* Ships will be dispatched in 5 ship wings
+
+$wing.array = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$cnt =  size of array $wing.array
+while $cnt
+dec $cnt =
+$leader = $wing.array[$cnt]
+skip if not $leader -> is of class Freighter
+remove element from array $wing.array at index $cnt
+end
+$cnt =  size of array $wing.array
+
+= [THIS] -> call script anarkis.acc.apply.relations :  active ships only?=[TRUE]
+$maincount =  size of array $wing.array
+$setup = [THIS] -> get local variable: name='anarkis.acc.setup'
+$callback = $setup[3]
+$autorename = $setup[15]
+$wing.id = 0
+
+while $maincount
+$leader = $wing.array[0]
+skip if $leader -> exists
+return null
+= [THIS] -> call script anarkis.acc.repairshields.single :  ship=$leader
+inc $wing.id =
+START $leader -> call script !ship.cmd.killenemies.std :
+$leader -> set local variable: name='anarkis.acc.wing' value=$wing.id
+if $callback == [TRUE]
+$leader -> start task 900 with script anarkis.acc.task.hullcheck and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+*if $autorename == [TRUE]
+*$leader -> start task 893 with script anarkis.acc.task.autoname and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+*end
+remove element from array $wing.array at index 0
+$cnt = 4
+$size =  size of array $wing.array
+while $cnt > 0 AND $size > 0
+dec $cnt =
+$wingmate = $wing.array[0]
+= [THIS] -> call script anarkis.acc.repairshields.single :  ship=$wingmate
+START $wingmate -> call script !ship.cmd.attacksame.std :  the target=$leader  stop if leader is docked=[FALSE]
+$wingmate -> set local variable: name='anarkis.acc.wing' value=$wing.id
+if $callback == [TRUE]
+$wingmate -> start task 900 with script anarkis.acc.task.hullcheck and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+*if $autorename == [TRUE]
+*$wingmate -> start task 893 with script anarkis.acc.task.autoname and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+*end
+remove element from array $wing.array at index 0
+$size =  size of array $wing.array
+end
+$maincount =  size of array $wing.array
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.wing.defence.pl.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.wing.defence.pl.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.acc.wing.defence.pl
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.wing.defence.pl.xml
+
+* ===========================================
+* Wing : Send a wing to protect a target
+* ===========================================
+[THIS] -> set command: ANARKIS_DEFENSIVEWING  target=$target target2=$wing.size par1=null par2=null
+= [THIS] -> call script anarkis.acc.wing.defence :  target=$target  wing size=$wing.size
+
+return null

--- a/tools/fixtures/known_good/anarkis.acc.wing.defence.x3s
+++ b/tools/fixtures/known_good/anarkis.acc.wing.defence.x3s
@@ -1,0 +1,76 @@
+#name: anarkis.acc.wing.defence
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.acc.wing.defence.xml
+
+* ===========================================
+* Wing : Send a wing to protect a target
+* ===========================================
+
+skip if $target -> exists
+return null
+
+if  is datatyp[ $wing.size ] == DATATYP_ARRAY
+$cnt =  size of array $wing.size
+dec $cnt =
+$wing.array =  clone array $wing.size : index 0 ... $cnt
+$wing.size =  size of array $wing.array
+else
+$wing.array = [THIS] -> call script anarkis.acc.get.dockedships :  ship class=Moveable Ship  no hull damaged ships=[TRUE]
+$cnt =  size of array $wing.array
+while $cnt
+dec $cnt =
+$v1 = $wing.array[$cnt]
+skip if not $v1 -> is of class Freighter
+remove element from array $wing.array at index $cnt
+end
+$cnt =  size of array $wing.array
+
+if $cnt > $wing.size
+resize array $wing.array to $wing.size
+end
+$wing.size =  size of array $wing.array
+end
+
+$leader = $wing.array[0]
+skip if $leader -> exists
+return null
+
+$setup = [THIS] -> get local variable: name='anarkis.acc.setup'
+$callback = $setup[3]
+$autorename = $setup[15]
+
+= [THIS] -> call script anarkis.acc.repairshields.single :  ship=$leader
+if $target -> is of class Moveable Ship
+START $leader -> call script anarkis.acc.cmd.protect :  protect target=$target
+*START $leader -> call script !ship.cmd.attacksame.std :  the target=$target  stop if leader is docked=[TRUE]
+else
+START $leader -> call script anarkis.acc.cmd.protect :  protect target=$target
+*START $leader -> call script !ship.cmd.protect.std :  target=$target  stop if leader docked=[TRUE]
+end
+$leader -> set local variable: name='anarkis.acc.wing' value='D'
+remove element from array $wing.array at index 0
+*if $autorename == [TRUE]
+*$leader -> start task 893 with script anarkis.acc.task.autoname and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+*end
+if $callback == [TRUE]
+$leader -> start task 900 with script anarkis.acc.task.hullcheck and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+= wait randomly from 1000 to 5000 ms
+
+$cnt =  size of array $wing.array
+while $cnt
+dec $cnt =
+$wingmate = $wing.array[$cnt]
+= [THIS] -> call script anarkis.acc.repairshields.single :  ship=$wingmate
+START $wingmate -> call script !ship.cmd.attacksame.std :  the target=$leader  stop if leader is docked=[TRUE]
+$wingmate -> set local variable: name='anarkis.acc.wing' value='D'
+*if $autorename == [TRUE]
+*$wingmate -> start task 893 with script anarkis.acc.task.autoname and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+*end
+if $callback == [TRUE]
+$wingmate -> start task 900 with script anarkis.acc.task.hullcheck and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+end
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.ads.al.init.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.al.init.x3s
@@ -1,0 +1,34 @@
+#name: anarkis.ads.al.init
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.al.init.xml
+
+* ===========================================
+* A.D.S. - Init Script, ECS Registration if available, show menu
+* ===========================================
+
+
+
+if get global variable: name='plugin.ecs.setup'
+= [THIS] -> call script anarkis.acc.ecs.register :
+end
+
+if  is datatyp[ $ecs.setup ] == DATATYP_ARRAY
+$ecs.setup[3] = [TRUE]
+else
+$ecs.setup =  array alloc: size=6
+$ecs.installed =  array alloc: size=0
+$ecs.configs =  array alloc: size=0
+$ecs.news =  array alloc: size=0
+$ecs.guilds =  array alloc: size=0
+$ecs.setup[0] = 250
+$ecs.setup[1] = $ecs.installed
+$ecs.setup[2] = $ecs.configs
+$ecs.setup[3] = [TRUE]
+$ecs.setup[4] = null
+$ecs.setup[5] = $ecs.news
+$ecs.setup[6] = $ecs.guilds
+end
+set global variable: name='plugin.ecs.setup' value=$ecs.setup
+= [THIS] -> call script plugin.sk.ecs.hotkey.install :
+return null

--- a/tools/fixtures/known_good/anarkis.ads.al.register.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.al.register.x3s
@@ -1,0 +1,48 @@
+#name: anarkis.ads.al.register
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.al.register.xml
+
+$text.id = '8510'
+
+$plugin.Vars = get global variable: name=$plugin.ID
+
+* setup new data structure and init it
+if not $plugin.Vars
+$plugin.Vars =  array alloc: size=2
+set global variable: name=$plugin.ID value=$plugin.Vars
+$plugin.Vars[0] = 0
+$plugin.Vars[1] = [TRUE]
+end
+
+* init and reinit are run every time the game loads
+if $plugin.Event == 'init' OR $plugin.Event == 'reinit'
+$desc = sprintf: pageid=$text.id textid=100, null, null, null, null, null
+al engine: set plugin $plugin.ID description to $desc
+$interval = 30 * 60
+al engine: set plugin $plugin.ID timer interval to $interval s
+skip if get global variable: name='plugin.ecs.setup'
+= [THIS] -> call script plugin.sk.ecs.al.init :
+
+else if $plugin.Event == 'isenabled'
+$desc = sprintf: pageid=$text.id textid=100, null, null, null, null, null
+al engine: set plugin $plugin.ID description to $desc
+$enabled = $plugin.Vars[1]
+return $enabled
+
+* Use this area to process special instructions when the plugin is toggled on
+else if $plugin.Event == 'start'
+$plugin.Vars[1] = [TRUE]
+= [THIS] -> call script plugin.sk.ecs.al.init :
+= [THIS] -> call script plugin.sk.ecs.manager :
+* Use this area to process special instructions when the plugin is toggled off
+else if $plugin.Event == 'stop'
+$plugin.Vars[1] = [FALSE]
+= [THIS] -> call script plugin.sk.ecs.al.stop :
+
+* The event script is called every interval
+else if $plugin.Event == 'timer'
+$enabled = $plugin.Vars[1]
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.ads.al.stop.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.al.stop.x3s
@@ -1,0 +1,12 @@
+#name: anarkis.ads.al.stop
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.al.stop.xml
+
+$ads.setup = get global variable: name='anarkis.ads.setup'
+$ads.setup[3] = [FALSE]
+set global variable: name='anarkis.ads.setup' value=$ads.setup
+
+START [THIS] -> call script plugin.sk.ecs.manager :
+
+return null

--- a/tools/fixtures/known_good/anarkis.ads.cmd.protectgrid.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.cmd.protectgrid.x3s
@@ -1,0 +1,106 @@
+#name: anarkis.ads.cmd.protectgrid
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.cmd.protectgrid.xml
+
+* ===========================================
+* CMD : Defense Grid - Interrupt Cmd : Protect Sector
+* ===========================================
+* - Should work for both AI and player owned ships
+* - Jump beacon support
+* ===========================================
+
+skip if $tg.sector -> exists
+return null
+
+$previous.sector = [SECTOR]
+[THIS] -> set local variable: name='anarkis.ads.grid.busy' value=[TRUE]
+= [THIS] -> call script anarkis.lib.shipstate.save :  ship=[THIS]
+
+$string = sprintf: fmt='(ADS) %s Jump to protect %s', [THIS], $tg.sector, null, null, null
+= [THIS] -> call script anarkis.debug.output :  msg=$string
+
+* =====
+* Energy Handling
+$energy.needed = [THIS] -> needed jump drive energy for jump to sector $tg.sector
+$v1 = [THIS] -> get amount of ware Energy Cells in cargo bay
+$energy.needed = $energy.needed - $v1
+$free.space = [THIS] -> get free amount of ware Energy Cells in cargo bay
+if $free.space < $energy.needed
+$string = sprintf: fmt='(ADS) Grid - %s can't jump to %s : Not enough cargo space for fuel', [THIS], $tg.sector, null, null, null
+= [THIS] -> call script anarkis.debug.output :  msg=$string
+[THIS] -> set local variable: name='anarkis.ads.grid.busy' value=null
+return [FALSE]
+end
+* Player has to pay, not the AI. Pay the double price. for going and wayback.
+* All expenses are here to prevent ships from behind stuck where they shouldn't be
+if [OWNER] == Player
+$pl.money = get player money
+$price = get average price of ware Energy Cells
+$price = $price * 4 * $energy.needed
+* - Check for funds
+if $price > $pl.money
+$string = sprintf: fmt='(ADS) Grid - %s can't jump to %s : Not enough money', [THIS], $tg.sector, null, null, null
+= [THIS] -> call script anarkis.debug.output :  msg=$string
+[THIS] -> set local variable: name='anarkis.ads.grid.busy' value=null
+return [FALSE]
+end
+$price = 0 - $price
+add money to player: $price
+end
+= [THIS] -> add $energy.needed units of Energy Cells
+* =====
+
+$string = sprintf: fmt='(ADS) %s jump to protect %s', [THIS], $tg.sector, null, null, null
+= [THIS] -> call script anarkis.debug.output :  msg=$string
+
+
+$attacker.owner = $attacker -> get true owner
+skip if $attacker.owner
+$attacker.owner = $attacker -> get owner race
+
+$previous.relation = [THIS] -> get relation to race $attacker.owner
+[THIS] -> set relation against $attacker.owner to Foe
+
+* =====
+* Do the jump
+if [SECTOR] != $tg.sector
+$beacon =  find ship: sector=$tg.sector class or type=Jump Beacon race=[OWNER] flags=[Find.Random] refobj=null maxdist=null maxnum=1 refpos=null
+if $beacon
+= [THIS] -> call script anarkis.lib.cmd.jumptobeacon :  jump.beacon=$beacon
+else
+$gate =  find gate: flags=[Find.Nearest], refobj=$attacker, max dist=null, refpos=null
+*$gate =  get next gate on route from $tg.sector to [SECTOR]
+= [THIS] -> call script !ship.cmd.jump.std :  target gate or sector=$gate  followers should jump too=[TRUE]
+end
+end
+* =====
+
+
+* =====
+* Battling Part - room for improvement
+if $attacker -> exists
+= [THIS] -> call script !ship.cmd.attack.std :  the victim=$attacker  do not follow in new sector=[TRUE]
+end
+$my.pos = [THIS] -> get position as array
+= [THIS] -> call script anarkis.lib.cmd.killandland.timeout :  object to land on=null  the range=100000  refpos array   x y z=$my.pos  no idle, simply stand still=null  timeout=360
+
+while [THIS] -> get local variable: name='anarkis.acc.battle'
+= [THIS] -> call script !move.idle.timeout :  timeout in sec=30  wait while docked=[FALSE]
+end
+* =====
+
+* =====
+* Restore previous settings and go back to original sector
+[THIS] -> set relation against $attacker.owner to $previous.relation
+$energy.needed = [THIS] -> needed jump drive energy for jump to sector $previous.sector
+= [THIS] -> add $energy.needed units of Energy Cells
+
+skip if [SECTOR] == $previous.sector
+= [THIS] -> call script !move.jumptosector :  sector=$previous.sector  should followers jump too=[TRUE]
+
+[THIS] -> set local variable: name='anarkis.ads.grid.busy' value=null
+= [THIS] -> call script anarkis.lib.shipstate.restore :  ship=[THIS]
+* =====
+
+return [TRUE]

--- a/tools/fixtures/known_good/anarkis.ads.comm.barracks.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.comm.barracks.x3s
@@ -1,0 +1,96 @@
+#name: anarkis.ads.comm.barracks
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.comm.barracks.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+
+$sel.role =  array alloc: size=0
+$st = sprintf: pageid=$page.id textid=1076, null, null, null, null, null
+append $st to array $sel.role
+$st = sprintf: pageid=$page.id textid=1077, null, null, null, null, null
+append $st to array $sel.role
+$st = sprintf: pageid=$page.id textid=1078, null, null, null, null, null
+append $st to array $sel.role
+$sel.role.id = 'role'
+$sel.role.select = 0
+
+while $menu.result != -1
+= wait 10 ms
+$menu =  create custom menu array
+$st = sprintf: pageid=$page.id textid=1004, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=1106, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='save'
+$st = sprintf: pageid=$page.id textid=1107, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$array = $ship -> get marines array
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$v1 = $select -> get name
+$v2 = $select -> get marine overall skill
+$v3 = $select -> get marine buy price
+$v1 = [THIS] -> call script anarkis.lib.shortstring :  string=$v1  max=20
+$v3 =  convert number $v3 to string
+$st = sprintf: pageid=$page.id textid=1080, $v1, $v2, $v3, null, null
+$sel.role.select = $select -> get local variable: name='anarkis.ads.marine'
+add value selection to menu: $menu, text=$st, value array=$sel.role, default=$sel.role.select, return id=$select
+$v1 = $select -> get marine fighting skill
+$v2 = $select -> get marine mechanical skill
+$v3 = $select -> get marine hacking skill
+$v4 = $select -> get marine engineering skill
+$st = sprintf: pageid=$page.id textid=1079, $v1, $v2, $v3, $v4, null
+add custom menu item to array $menu: text=$st returnvalue=0
+end
+
+$array = $ship -> get marines array
+$v2 = $ship -> free space for marines
+$cnt =  size of array $array
+$v2 = $v2 + $cnt
+$v1 = sprintf: pageid=$page.id textid=1109, $cnt, $v2, null, null, null
+add custom menu info line to array $menu: text=$v1
+$v1 = 0
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+skip if not $select -> get local variable: name='anarkis.ads.marine'
+inc $v1 =
+end
+$st = sprintf: pageid=$page.id textid=1108, $v1, null, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 = [THIS] -> call script anarkis.ads.crew.getcost :  ref object=$ship
+$v1 =  convert number $v1 to string
+$v1 = sprintf: pageid=$page.id textid=1105, $v1, null, null, null, null
+add custom menu info line to array $menu: text=$v1
+
+$v1 = sprintf: pageid=$page.id textid=1088, $v1, null, null, null, null
+add custom menu info line to array $menu: text=$v1
+
+$v1 =  read text: page=$page.id id=1075
+
+$v2 = sprintf: pageid=$page.id textid=455, $ship, null, null, null, null
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+if  is datatyp[ $menu.result ] == DATATYP_ARRAY
+$cnt =  size of array $menu.result
+while $cnt
+dec $cnt =
+$r.id = $menu.result[$cnt][0]
+$r.val = $menu.result[$cnt][1]
+if $r.id -> exists
+$r.id -> set local variable: name='anarkis.ads.marine' value=$r.val
+end
+end
+end
+if $menu.result -> exists
+
+$menu.result -> set local variable: name='anarkis.ads.marine' value=[TRUE]
+end
+
+
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.ads.comm.hangars.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.comm.hangars.x3s
@@ -1,0 +1,147 @@
+#name: anarkis.ads.comm.hangars
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.comm.hangars.xml
+
+$page.id = 8510
+$setup.array = [THIS] -> get local variable: name='anarkis.acc.setup'
+load text: id=$page.id
+
+
+
+while $menu.result != -1
+
+
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=1101
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=424
+add custom menu item to array $menu: text=$st returnvalue='set.home.all'
+$st =  read text: page=$page.id id=434
+add custom menu item to array $menu: text=$st returnvalue='set.name'
+$st =  read text: page=$page.id id=217
+add custom menu item to array $menu: text=$st returnvalue='setup'
+
+$st = sprintf: pageid=$page.id textid=425, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=426
+add custom menu item to array $menu: text=$st returnvalue='add.all'
+$st =  read text: page=$page.id id=427
+add custom menu item to array $menu: text=$st returnvalue='add.m3m4'
+$st =  read text: page=$page.id id=428
+add custom menu item to array $menu: text=$st returnvalue='add.m3'
+$st =  read text: page=$page.id id=429
+add custom menu item to array $menu: text=$st returnvalue='rem.all'
+
+$st = sprintf: pageid=$page.id textid=422, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$class = $curr.ship -> get object class
+$enabled = $curr.ship -> get local variable: name='anarkis.acc.ship'
+if $enabled == [TRUE]
+$v1 =  read text: page=$page.id id=431
+else
+$v1 =  read text: page=$page.id id=432
+end
+$st = sprintf: pageid=$page.id textid=430, $class, $curr.ship, $v1, null, null
+add custom menu item to array $menu: text=$st returnvalue=$curr.ship
+end
+
+$st = sprintf: pageid=$page.id textid=421, null, null, null, null, null
+add custom menu info line to array $menu: text=$st
+$v1 =  read text: page=$page.id id=420
+$v2 =  read text: page=$page.id id=260
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if $menu.result == 'add.all'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=[TRUE]
+$name = $curr.ship -> get name
+$curr.ship -> set local variable: name='anarkis.acc.oldname' value=$name
+if [OWNER] == Player
+$curr.ship -> set homebase to [THIS]
+end
+end
+
+else if $menu.result == 'rem.all'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=null
+end
+
+else if $menu.result == 'add.m3m4'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$v1 = $curr.ship -> get object class
+if $v1 == M3 OR $v1 == M4
+$name = $curr.ship -> get name
+$curr.ship -> set local variable: name='anarkis.acc.oldname' value=$name
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=[TRUE]
+$curr.ship -> set homebase to [THIS]
+end
+end
+
+else if $menu.result == 'add.m3'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$v1 = $curr.ship -> get object class
+if $v1 == M3
+$name = $curr.ship -> get name
+$curr.ship -> set local variable: name='anarkis.acc.oldname' value=$name
+$curr.ship -> set local variable: name='anarkis.acc.ship' value=[TRUE]
+$curr.ship -> set homebase to [THIS]
+end
+end
+
+else if $menu.result == 'setup'
+= [THIS] -> call script anarkis.acc.setup.ships :
+
+else if $menu.result == 'set.home.all'
+$dock.list = [THIS] -> get ship array from sector/ship/station
+$cnt =  size of array $dock.list
+while $cnt
+dec $cnt =
+$curr.ship = $dock.list[$cnt]
+$curr.ship -> set homebase to [THIS]
+end
+
+else if $menu.result == 'set.name'
+= [THIS] -> call script anarkis.acc.setup.rename :
+
+else if $menu.result -> exists
+$enabled = $menu.result -> get local variable: name='anarkis.acc.ship'
+$enabled = ! $enabled
+$menu.result -> set local variable: name='anarkis.acc.ship' value=$enabled
+if $enabled == [TRUE]
+$name = $menu.result -> get name
+$menu.result -> set local variable: name='anarkis.acc.oldname' value=$name
+$menu.result -> set homebase to [THIS]
+end
+end
+
+
+end
+
+return null

--- a/tools/fixtures/known_good/anarkis.ads.comm.manage.call.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.comm.manage.call.x3s
@@ -1,0 +1,280 @@
+#name: anarkis.ads.comm.manage.call
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.comm.manage.call.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+$cmd.id = 2010
+
+*load text: id=$page.id
+
+$m.filter = Carrier
+$m.selected = null
+$m.menumode = 'list'
+$m.showcmd = [FALSE]
+$m.showgridship = [FALSE]
+$m.viewowned = [FALSE]
+
+$is.open = get global variable: name='anarkis.ads.manager.open'
+skip if not $is.open
+return null
+set global variable: name='anarkis.ads.manager.open' value=[TRUE]
+
+
+$aim =  get player tracking aim
+if $aim -> exists
+$owner = $aim -> get owner race
+$isbig = $aim -> is of class Big Ship
+$isstation = $aim -> is of class Station
+$compat = [THIS] -> call script anarkis.acc.is.compatible :  target=$aim
+if $owner == Player
+
+if $isbig == [TRUE] OR $isstation == [TRUE] OR $compat == [TRUE]
+$m.selected = $aim
+end
+if $compat == [TRUE]
+$m.filter = Carrier
+else if $isbig == [TRUE]
+$m.menumode = 'defense.grid'
+end
+if $isstation == [TRUE]
+$m.filter = Station
+end
+
+end
+end
+
+
+$menu =  create custom menu array
+$select =  array alloc: size=0
+append $m.filter to array $select
+append $m.selected to array $select
+append $m.menumode to array $select
+append $m.showcmd to array $select
+append $m.showgridship to array $select
+append $m.viewowned to array $select
+set global variable: name='anarkis.ads.menu' value=$select
+
+START $null -> call script anarkis.ads.comm.manage.menu :  menu=$menu
+
+while $menu.result != -1
+
+if $m.selected -> exists
+$v1 = $m.selected -> get name
+$v1 = [THIS] -> call script anarkis.lib.shortstring :  string=$v1  max=25
+$v2 = $m.selected -> get sector
+$v2 = sprintf: pageid=$page.id textid=1012, $v2, $v1, null, null, null
+else
+$v2 =  read text: page=$page.id id=100
+end
+$v1 =  read text: page=$page.id id=1040
+= wait 100 ms
+$menu.result =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+if  is datatyp[ $menu.result ] == DATATYP_OBJCLASS
+$m.filter = $menu.result
+$select[0] = $menu.result
+$select[1] = null
+$select[2] = 'list'
+$m.menumode = 'list'
+$m.selected = null
+else if  is datatyp[ $menu.result ] == DATATYP_STRING
+
+* - - Setup Carrier
+if $menu.result == 'setup.object'
+$m.selected -> start task 892 with script anarkis.acc.setup and prio 0: arg1=null arg2=null arg3=null arg4=null arg5=null
+while $m.selected -> is task 892 in use
+= wait 200 ms
+end
+
+else if $menu.result == 'gen.set'
+= [THIS] -> call script anarkis.ads.setup.global :
+
+* - - Defense Grid Mode
+else if $menu.result == 'defense.grid'
+$select[0] = null
+$select[1] = null
+$select[2] = 'grid.sector'
+$m.menumode = 'grid.sector'
+$m.selected = null
+
+* - - Defense Grid Toggle
+else if $menu.result == 'toggle.grid'
+$m.selected = $select[1]
+if $m.selected -> get local variable: name='anarkis.ads.grid'
+$m.selected -> set local variable: name='anarkis.ads.grid' value=null
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+else
+$m.selected -> set local variable: name='anarkis.ads.grid' value=[TRUE]
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+end
+
+* - - Defense Grid Ship Manager
+else if $menu.result == 'grid.ship' OR $menu.result == 'grid.sector'
+$select[1] = null
+$m.showgridship = $select[4]
+$m.showgridship = ! $m.showgridship
+$select[4] = $m.showgridship
+$m.selected = null
+
+else if $menu.result == 'grid.toggle'
+if get global variable: name='anarkis.ads.grid.mode'
+set global variable: name='anarkis.ads.grid.mode' value=null
+= wait 1000 ms
+else
+set global variable: name='anarkis.ads.grid.mode' value=[TRUE]
+START $null -> call script anarkis.ads.task.maingrid :  race=Player
+end
+
+* - - Toggle ADS
+else if $menu.result == 'toggle.ads'
+if [THIS] -> call script anarkis.acc.lib.isadsactive :  target=$m.selected
+= [THIS] -> call script anarkis.ads.toggle.task :  target=$m.selected  activate=[FALSE]
+else
+= [THIS] -> call script anarkis.ads.toggle.task :  target=$m.selected  activate=[TRUE]
+end
+
+* - - Jump to Playership
+else if $menu.result == 'jumptome'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script anarkis.lib.cmd.jumpnearobject :  destination=[PLAYERSHIP]
+
+* - - Jump to Sector
+else if $menu.result == 'jumpto'
+$v1 =  read text: page=$page.id id=1026
+$v1 = $m.selected -> get user input: type=Var/Jumpdrive Gate, title=$v1
+if $v1 -> exists
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script !ship.cmd.jump.std :  target gate or sector=$v1  followers should jump too=[TRUE]
+end
+
+* - - Attack
+else if $menu.result == 'attack'
+$v1 =  read text: page=$page.id id=1027
+$v1 = $m.selected -> get user input: type=Var/Ship/Station, title=$v1
+if $v1 -> exists
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script anarkis.lib.cmd.attack :  the victim=$v1
+end
+
+* - - Dock Command
+else if $menu.result == 'dockto'
+$v1 =  read text: page=$page.id id=1026
+$v1 = $m.selected -> get user input: type=Var/Station/Carrier to dock at, title=$v1
+if $v1 -> exists
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script !ship.cmd.movestation.std :  object to land on=$v1
+end
+
+* - - Attack All
+else if $menu.result == 'attackall'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script !ship.cmd.killenemies.std :
+
+* - - Protect
+else if $menu.result == 'protect'
+$v1 = $m.selected -> get user input: type=Var/Ship/Station, title=$v1
+if $v1 -> exists
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script anarkis.acc.cmd.protect :  protect target=$v1
+end
+
+* - - Standby
+else if $menu.result == 'standby'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script !ship.cmd.stay.std :
+
+* - - Patrol
+else if $menu.result == 'patrol'
+$v1 = $m.selected -> call script !ship.cmd.patrol.multi.pl :
+$v3 = $m.selected -> get local variable: name='patrol.route'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script !ship.cmd.patrol.multi.std :  Patrol Route Array=$v3
+
+* - - Dock All
+else if $menu.result == 'dockall'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script anarkis.acc.cmd.dock.all.pl :
+
+* - - Clear Sector
+else if $menu.result == 'clearsector'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+START $m.selected -> call script anarkis.acc.wing.clearsector.pl :
+
+* - - Attack Wing
+else if $menu.result == 'wingattack'
+$v1 =  read text: page=$page.id id=1027
+$v1 = $m.selected -> get user input: type=Var/Ship/Station, title=$v1
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+= $m.selected -> call script anarkis.ads.wing.attack.pl :  target=$v1
+
+* - - Defend Wing
+else if $menu.result == 'wingdefend'
+$v1 =  read text: page=$page.id id=1027
+$v1 = $m.selected -> get user input: type=Var/Ship/Station, title=$v1
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+= $m.selected -> call script anarkis.ads.wing.defense.pl :  target=$v1
+
+* - - Buy Wares
+else if $menu.result == 'buywares'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+= $m.selected -> call script anarkis.acc.cmd.buywares.pl :
+
+* - - Sell Wares
+else if $menu.result == 'sellwares'
+$m.selected -> set local variable: name='anarkis.ads.grid.busy' value=null
+= $m.selected -> call script anarkis.acc.cmd.sellwares.pl :
+
+* - - Show ECS News
+else if $menu.result == 'alert'
+= [THIS] -> call script plugin.sk.ecs.news.display :  Plugin ID='anarkis.acc.plugin'
+
+* - - Toggle CMD Panel
+else if $menu.result == 'cmdoff'
+$select[3] = [FALSE]
+
+else if $menu.result == 'cmdon'
+$select[3] = [TRUE]
+
+* - - Toggle View Ship List
+else if $menu.result == 'viewships'
+$v1 = $select[5]
+$v1 = ! $v1
+$select[5] = $v1
+
+* - - Run un-installer
+else if $menu.result == 'uninstall'
+= [THIS] -> call script anarkis.acc.uninstall :
+$m.menumode = 'quit'
+$select[2] = 'quit'
+set global variable: name='anarkis.ads.manager.open' value=null
+
+return null
+
+* - - Show on cursor
+else if $menu.result == 'cursor'
+set player tracking aim to $m.selected ->
+$select[2] = 'quit'
+set global variable: name='anarkis.ads.manager.open' value=null
+return null
+end
+
+else if $menu.result == -1
+if $m.selected != null
+$select[1] = null
+$select[5] = [FALSE]
+$m.selected = null
+$menu.result = 0
+end
+else if $menu.result -> exists
+$select[1] = $menu.result
+$m.selected = $menu.result
+end
+
+end
+$select[2] = 'quit'
+set global variable: name='anarkis.ads.manager.open' value=null
+
+
+return null

--- a/tools/fixtures/known_good/anarkis.ads.comm.manage.menu.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.comm.manage.menu.x3s
@@ -1,0 +1,407 @@
+#name: anarkis.ads.comm.manage.menu
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.comm.manage.menu.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+
+$cmd.id = 2010
+$m.menumode = 'none'
+
+* While order /= quit
+while $m.menumode != 'quit'
+$select = get global variable: name='anarkis.ads.menu'
+
+$m.filter = $select[0]
+$m.selected = $select[1]
+$m.menumode = $select[2]
+$m.showcmd = $select[3]
+$m.viewgridship = $select[4]
+$m.viewowned = $select[5]
+
+*$debug = sprintf: fmt='%s - %s - %s - %s - %s', $m.filter, $m.selected, $m.menumode, $m.showcmd, $m.viewgridship
+*= [THIS] -> call script anarkis.debug.output :  msg=$debug
+
+resize array $menu to 0
+
+* - If something is selected
+if $m.selected -> exists
+* - - If viewship over something select
+* - - Well, let's show owned ships then
+if $m.viewowned == [TRUE]
+$list = $m.selected -> get owned ships: class/type=Ship
+$cnt =  size of array $list
+$st = sprintf: pageid=$page.id textid=1042, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$ok = [FALSE]
+while $cnt
+dec $cnt =
+$v1 = $list[$cnt]
+skip if not $v1 -> is docked
+continue
+$v2 = $v1 -> get ware type code of object
+$v3 = $v1 -> get command
+$v3 = [THIS] -> call script anarkis.lib.shortcmd :  command=$v3
+$v4 = $v1 -> get hull percent
+$v5 = $v1 -> get shield percent
+$ok = [TRUE]
+if $m.selected -> get attacker
+$st = sprintf: pageid=$page.id textid=1123, $v2, $v3, $v4, $v5, null
+else
+$st = sprintf: pageid=$page.id textid=1041, $v2, $v3, $v4, $v5, null
+end
+add custom menu item to array $menu: text=$st returnvalue=$v1
+end
+if not $ok
+$cnt =  size of array $menu
+dec $cnt =
+resize array $menu to $cnt
+end
+$ok = [FALSE]
+$cnt =  size of array $list
+$st = sprintf: pageid=$page.id textid=1043, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+while $cnt
+dec $cnt =
+$v1 = $list[$cnt]
+skip if $v1 -> is docked
+continue
+$v2 = $v1 -> get ware type code of object
+$v3 = $v1 -> get command
+$v3 = [THIS] -> call script anarkis.lib.shortcmd :  command=$v3
+$v4 = $v1 -> get hull percent
+$v5 = $v1 -> get shield percent
+$ok = [TRUE]
+$st = sprintf: pageid=$page.id textid=1041, $v2, $v3, $v4, $v5, null
+add custom menu item to array $menu: text=$st returnvalue=$v1
+end
+if not $ok
+$cnt =  size of array $menu
+dec $cnt =
+resize array $menu to $cnt
+end
+end
+* - - End Display : Owned Ships
+
+$st = sprintf: pageid=$page.id textid=1001, $m.selected, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$v1 = [PLAYERSHIP] -> get sector
+$v2 = $m.selected -> get sector
+if $v1 == $v2
+$st = sprintf: pageid=$page.id textid=1030, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='cursor'
+end
+
+* - - If the fucking selection is a ship display the comand panel
+if $m.selected -> is of class Moveable Ship
+if $m.showcmd == [FALSE]
+$st = sprintf: pageid=$page.id textid=1034, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='cmdon'
+else
+$st = sprintf: pageid=$page.id textid=1038, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='cmdoff'
+if $v1 != $v2
+$st = sprintf: pageid=$page.id textid=1023, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='jumptome'
+end
+$st = sprintf: pageid=$page.id textid=1024, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='jumpto'
+$st = sprintf: pageid=$page.id textid=1033, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='dockto'
+$st = sprintf: pageid=$page.id textid=1025, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='attack'
+$st = sprintf: pageid=$page.id textid=1036, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='protect'
+$st = sprintf: pageid=$page.id textid=1029, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='attackall'
+$st = sprintf: pageid=$page.id textid=1028, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='patrol'
+$st = sprintf: pageid=$page.id textid=1037, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='standby'
+$isadscompat = [THIS] -> call script anarkis.acc.is.compatible :  target=$m.selected
+$isadsactive = [THIS] -> call script anarkis.acc.lib.isadsactive :  target=$m.selected
+if $isadscompat == [TRUE] AND $isadsactive == [FALSE]
+$st = sprintf: pageid=$cmd.id textid=834, null, null, null, null, null
+$st = sprintf: pageid=$page.id textid=1039, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='wingattack'
+$st = sprintf: pageid=$cmd.id textid=833, null, null, null, null, null
+$st = sprintf: pageid=$page.id textid=1039, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='wingdefend'
+$st = sprintf: pageid=$cmd.id textid=835, null, null, null, null, null
+$st = sprintf: pageid=$page.id textid=1039, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='clearsector'
+$st = sprintf: pageid=$cmd.id textid=836, null, null, null, null, null
+$st = sprintf: pageid=$page.id textid=1039, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='dockall'
+$st = sprintf: pageid=$cmd.id textid=832, null, null, null, null, null
+$st = sprintf: pageid=$page.id textid=1039, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='buywares'
+$st = sprintf: pageid=$cmd.id textid=831, null, null, null, null, null
+$st = sprintf: pageid=$page.id textid=1039, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='sellwares'
+end
+end
+end
+* - - End
+
+* - - ACC Commands for Stations
+if $m.selected -> is of class Station
+$isadscompat = [THIS] -> call script anarkis.acc.is.compatible :  target=$m.selected
+$isadsactive = [THIS] -> call script anarkis.acc.lib.isadsactive :  target=$m.selected
+if $isadscompat == [TRUE] AND $isadsactive == [FALSE]
+$st = sprintf: pageid=$cmd.id textid=834, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='wingattack'
+
+$st = sprintf: pageid=$cmd.id textid=833, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='wingdefend'
+
+$st = sprintf: pageid=$cmd.id textid=835, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='clearsector'
+
+$st = sprintf: pageid=$cmd.id textid=836, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='dockall'
+$st = sprintf: pageid=$cmd.id textid=832, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='buywares'
+$st = sprintf: pageid=$cmd.id textid=831, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='sellwares'
+
+end
+end
+
+if [THIS] -> call script anarkis.acc.lib.isadsactive :  target=$m.selected
+$v1 = sprintf: pageid=$page.id textid=201, null, null, null, null, null
+else
+$v1 = sprintf: pageid=$page.id textid=202, null, null, null, null, null
+end
+* - - End
+
+* - - If the selected object has docking bays, show menu
+if $m.selected -> get dock bay size
+$st = sprintf: pageid=$page.id textid=1035, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='viewships'
+end
+* - - End
+
+* - - If the selected object is ADS compatible show setup and automode
+if [THIS] -> call script anarkis.acc.is.compatible :  target=$m.selected
+$st = sprintf: pageid=$page.id textid=1018, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='toggle.ads'
+$v2 = $m.selected -> get object class
+$st = sprintf: pageid=$page.id textid=1019, $v2, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='setup.object'
+end
+* - - End
+
+* - - Show the Grid Mode toggle for big ships
+if $m.selected -> is of class Big Ship
+if $m.selected -> get local variable: name='anarkis.ads.grid'
+$st =  read text: page=$page.id id=820
+else
+$st =  read text: page=$page.id id=821
+end
+$st = sprintf: pageid=$page.id textid=1059, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='toggle.grid'
+end
+* - - End
+end
+* - Ship Menu Done
+
+* - Show the main menu
+if $m.selected == null AND $m.menumode != 'grid.sector'
+if $m.filter == null
+$v1 =  read text: page=$page.id id=1044
+else
+$v1 = $m.filter
+end
+$st = sprintf: pageid=$page.id textid=1001, $v1, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=1003
+add custom menu item to array $menu: text=$st returnvalue=Carrier
+$st =  read text: page=$page.id id=1002
+add custom menu item to array $menu: text=$st returnvalue=Station
+$st =  read text: page=$page.id id=1044
+add custom menu item to array $menu: text=$st returnvalue='defense.grid'
+end
+* - End
+
+* - Defense Grid : Main Menu
+if $m.menumode == 'grid.sector'
+$st =  read text: page=$page.id id=1049
+add custom menu heading to array $menu: title=$st
+
+if $m.viewgridship == [TRUE]
+$st =  read text: page=$page.id id=820
+else
+$st =  read text: page=$page.id id=204
+end
+$st = sprintf: pageid=$page.id textid=1047, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='grid.ship'
+end
+
+* - Defense Grid : Ship List
+if $m.viewgridship == [TRUE]
+$st =  read text: page=$page.id id=1118
+add custom menu heading to array $menu: title=$st
+$v1 =  get ship array: of race Player class/type=Big Ship
+$v2 =  size of array $v1
+while $v2
+dec $v2 =
+$v3 = $v1[$v2]
+if $v3 -> get local variable: name='anarkis.ads.grid'
+$st = [THIS] -> call script anarkis.ads.lib.shiptostring :  target=$v3
+add custom menu item to array $menu: text=$st returnvalue=$v3
+end
+end
+$st =  read text: page=$page.id id=1119
+add custom menu heading to array $menu: title=$st
+$v1 =  get ship array: of race Player class/type=Big Ship
+$v2 =  size of array $v1
+while $v2
+dec $v2 =
+$v3 = $v1[$v2]
+if not $v3 -> get local variable: name='anarkis.ads.grid'
+$st = [THIS] -> call script anarkis.ads.lib.shiptostring :  target=$v3
+add custom menu item to array $menu: text=$st returnvalue=$v3
+end
+end
+
+end
+
+* - Defense Grid : Sector List
+if $m.menumode == 'grid.sector'
+$st =  read text: page=$page.id id=1050
+add custom menu heading to array $menu: title=$st
+$v1 = [THIS] -> call script anarkis.ads.lib.get.plsectors :
+$v2 =  size of array $v1
+while $v2
+dec $v2 =
+$v3 = $v1[$v2]
+$v4 = $v3 -> get player owned station array from sector
+$v4 =  size of array $v4
+$v5 = [THIS] -> call script anarkis.ads.lib.get.sectorthreat :  sector=$v3  race=Player
+$x = $v3 -> get universe x index
+$y = $v3 -> get universe y index
+$st = sprintf: pageid=$page.id textid=1051, $x, $y, $v3, $v4, $v5
+add custom menu item to array $menu: text=$st returnvalue=0
+end
+end
+
+* - Handle Carrier and Station Lists
+if $m.menumode == 'list'
+$st = sprintf: pageid=$page.id textid=1017, $m.filter, null, null, null, null
+add custom menu heading to array $menu: title=$st
+if $m.filter == Carrier
+$list = [THIS] -> call script anarkis.acc.get.acc.carriers :  active only?=[FALSE]
+else
+$list =  get station array: of race Player class/type=Dock
+end
+$cnt =  size of array $list
+while $cnt
+dec $cnt =
+$select = $list[$cnt]
+$st = [THIS] -> call script anarkis.ads.lib.shiptostring :  target=$select
+add custom menu item to array $menu: text=$st returnvalue=$select
+end
+
+end
+
+* - If nothing selected
+if $m.selected == null
+$st =  read text: page=$page.id id=1004
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=1006, $m.filter, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='alert'
+
+$st =  read text: page=$page.id id=1089
+add custom menu item to array $menu: text=$st returnvalue='gen.set'
+
+
+if get global variable: name='anarkis.ads.grid.mode'
+$st =  read text: page=$page.id id=201
+else
+$st =  read text: page=$page.id id=202
+end
+
+
+$st = sprintf: pageid=$page.id textid=1058, $st, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='grid.toggle'
+
+if $m.filter != null
+$st = sprintf: pageid=$page.id textid=1008, $m.filter, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='applyall'
+end
+$st = sprintf: pageid=$page.id textid=1007, $m.filter, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='uninstall'
+
+end
+
+* - Info Lines
+if $m.selected != null
+$v1 = $m.selected -> get hull percent
+$v2 = $m.selected -> get shield percent
+$st = sprintf: pageid=$page.id textid=1013, $v1, $v2, null, null, null
+add custom menu info line to array $menu: text=$st
+if $m.selected -> is of class Moveable Ship
+$v1 = $m.selected -> get command
+$v1 = [THIS] -> call script anarkis.lib.shortcmd :  command=$v1
+$v2 = $m.selected -> get command target
+skip if $v2 -> exists
+$v2 = $m.selected -> get destination
+if $v2 -> exists
+$v2 = $v2 -> get name
+else
+$v2 = ' '
+end
+*$v2 = [THIS] -> call script anarkis.lib.shortstring :  string=$v2  max=18
+$st = sprintf: pageid=$page.id textid=1014, $v1, $v2, null, null, null
+add custom menu info line to array $menu: text=$st
+end
+
+$v1 = $m.selected -> get sector
+$v1 = [THIS] -> call script anarkis.acc.evalute.danger :  sector=$v1  checker=$m.selected
+
+if $m.selected -> get attacker
+$v2 =  read text: page=$page.id id=203
+else
+$v2 =  read text: page=$page.id id=204
+end
+
+if $m.selected -> get local variable: name='anarkis.acc.battle'
+$v3 =  read text: page=$page.id id=203
+else
+$v3 =  read text: page=$page.id id=204
+end
+
+$st = sprintf: pageid=$page.id textid=1015, $v1, $v2, $v3, null, null
+add custom menu info line to array $menu: text=$st
+$v1 = $m.selected -> get owned ships: class/type=Ship
+$v1 =  size of array $v1
+$v2 = $m.selected -> get number of landed ships
+$v3 = [THIS] -> call script anarkis.acc.lib.get.adsonly.from :  from=$m.selected
+$v3 =  size of array $v3
+$st = sprintf: pageid=$page.id textid=1016, $v1, $v2, $v3, null, null
+add custom menu info line to array $menu: text=$st
+
+else
+$st =  read text: page=$page.id id=1010
+add custom menu info line to array $menu: text=$st
+$st =  read text: page=$page.id id=1011
+add custom menu info line to array $menu: text=$st
+end
+
+if $m.selected
+$v1 = $m.selected -> get name
+$v1 = [THIS] -> call script anarkis.lib.shortstring :  string=$v1  max=25
+$v2 = $m.selected -> get sector
+$v2 = sprintf: pageid=$page.id textid=1012, $v2, $v1, null, null, null
+else
+$v2 =  read text: page=$page.id id=100
+end
+$v1 =  read text: page=$page.id id=1000
+
+= wait 100 ms
+end
+
+
+return null

--- a/tools/fixtures/known_good/anarkis.ads.comm.wingmenu.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.comm.wingmenu.x3s
@@ -1,0 +1,152 @@
+#name: anarkis.ads.comm.wingmenu
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.comm.wingmenu.xml
+
+$gl.setup = get global variable: name='anarkis.ads.setup'
+$page.id = $gl.setup[0]
+
+load text: id=$page.id
+
+[THIS] -> set local variable: name='anarkis.menu.result' value=null
+
+$sel.role =  array alloc: size=0
+$sel.active =  read text: page=$page.id id=1069
+$sel.active = sprintf: pageid=$page.id textid=1066, $sel.active, null, null, null, null
+append $sel.active to array $sel.role
+$sel.active =  read text: page=$page.id id=1068
+$sel.active = sprintf: pageid=$page.id textid=1071, $sel.active, null, null, null, null
+append $sel.active to array $sel.role
+
+$sel.mode =  array alloc: size=0
+$sel.active = sprintf: pageid=$page.id textid=1073, null, null, null, null, null
+append $sel.active to array $sel.mode
+$sel.active = sprintf: pageid=$page.id textid=1072, null, null, null, null, null
+append $sel.active to array $sel.mode
+$sel.mode.id = 'mode'
+$sel.mode.select = 0
+
+$v1 = [THIS] -> call script anarkis.lib.get.dockedowned :  ship class=Moveable Ship  local to check=null
+$cnt =  size of array $v1
+$sel.cnt =  array alloc: size=0
+$x = 0
+while $x < $cnt
+inc $x =
+append $x to array $sel.cnt
+end
+$sel.count.id = 'count'
+if  find $defaultcount in array: $sel.cnt
+$sel.count.select =  get index of $defaultcount in array $sel.cnt offset=-1 + 1
+else
+$sel.count.select = $cnt - 1
+end
+
+$ship.count = $defaultcount
+$ship.list =  array alloc: size=0
+
+while $menu.result != -1
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=1061
+add custom menu heading to array $menu: title=$st
+$st =  read text: page=$page.id id=1062
+add custom menu item to array $menu: text=$st returnvalue='launch'
+$st = sprintf: pageid=$page.id textid=1063, $target, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue='change.tg'
+
+$st =  read text: page=$page.id id=803
+add value selection to menu: $menu, text=$st, value array=$sel.mode, default=$sel.mode.select, return id=$sel.mode.id
+$st =  read text: page=$page.id id=1064
+add value selection to menu: $menu, text=$st, value array=$sel.cnt, default=$sel.count.select, return id=$sel.count.id
+
+$st = sprintf: pageid=$page.id textid=1065, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+
+$array = [THIS] -> call script anarkis.lib.get.dockedowned :  ship class=Moveable Ship  local to check=null
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$sel.class = $select -> get object class
+$sel.hull = $select -> get hull percent
+if $sel.hull == 100
+$sel.hull = sprintf: pageid=$page.id textid=1070, $sel.hull, null, null, null, null
+$sel.hull = sprintf: pageid=$page.id textid=1066, $sel.hull, null, null, null, null
+else if $sel.hull > 87
+$sel.hull = sprintf: pageid=$page.id textid=1070, $sel.hull, null, null, null, null
+$sel.hull = sprintf: pageid=$page.id textid=1067, $sel.hull, null, null, null, null
+else
+$sel.hull = sprintf: pageid=$page.id textid=1070, $sel.hull, null, null, null, null
+$sel.hull = sprintf: pageid=$page.id textid=1068, $sel.hull, null, null, null, null
+end
+$v1 =  size of array $ship.list
+if  find $select in array: $ship.list
+$sel.role.select = 0
+else
+$sel.role.select = 1
+end
+
+$sel.name = $select -> get name
+$sel.name = [THIS] -> call script anarkis.lib.shortstring :  string=$sel.name  max=30
+$st = sprintf: pageid=$page.id textid=1060, $sel.class, $sel.hull, $sel.name, $sel.active, null
+add value selection to menu: $menu, text=$st, value array=$sel.role, default=$sel.role.select, return id=$select
+end
+
+
+$v1 =  read text: page=$page.id id=420
+$v2 =  read text: page=$page.id id=260
+
+$menu.result =  open custom menu: title=$title description=$v2 option array=$menu
+
+* ===================
+* Handle answer
+* ===================
+
+if  is datatyp[ $menu.result ] == DATATYP_ARRAY
+$cnt =  size of array $menu.result
+* ==
+while $cnt
+dec $cnt =
+$r.id = $menu.result[$cnt][0]
+$r.val = $menu.result[$cnt][1]
+if $r.id == $sel.mode.id
+$sel.mode.select = $r.val
+else if $r.id == $sel.count.id
+$sel.count.select = $r.val
+else if $r.id -> is of class Moveable Ship
+if $r.val == 0
+skip if  find $r.id in array: $ship.list
+append $r.id to array $ship.list
+else
+if  find $r.id in array: $ship.list
+$v1 =  get index of $r.id in array $ship.list offset=-1 + 1
+remove element from array $ship.list at index $v1
+end
+end
+end
+end
+
+* ==
+$r.id = $menu.result[0]
+if $r.id == 'change.tg'
+$v1 =  read text: page=$page.id id=1027
+$v1 = [THIS] -> get user input: type=Var/Ship/Station, title=$v1
+if $v1 -> exists
+$target = $v1
+end
+else if $r.id == 'launch'
+if $sel.mode.select == 0
+$ship.list =  array alloc: size=0
+end
+$ship.count = $sel.cnt[$sel.count.select]
+$result =  create new array, arguments=$target, $ship.count, $ship.list, null, null
+[THIS] -> set local variable: name='anarkis.menu.result' value=$result
+return [TRUE]
+
+end
+end
+end
+
+
+
+return null

--- a/tools/fixtures/known_good/anarkis.ads.crew.getcost.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.crew.getcost.x3s
@@ -1,0 +1,19 @@
+#name: anarkis.ads.crew.getcost
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.crew.getcost.xml
+
+$array = $ref.object -> get marines array
+$cnt =  size of array $array
+$price = 0
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$status = $select -> get local variable: name='anarkis.ads.marine'
+if $status == 1
+$price = $price + 16000
+else if $status == 2
+$price = $price + 24000
+end
+end
+return $price

--- a/tools/fixtures/known_good/anarkis.ads.crew.sleep.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.crew.sleep.x3s
@@ -1,0 +1,14 @@
+#name: anarkis.ads.crew.sleep
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.crew.sleep.xml
+
+$array = $ref.object -> get marines array
+$cnt =  size of array $array
+$price = 0
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$select -> set local variable: name='anarkis.ads.marine' value=0
+end
+return null

--- a/tools/fixtures/known_good/anarkis.ads.crew.train.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.crew.train.x3s
@@ -1,0 +1,53 @@
+#name: anarkis.ads.crew.train
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.crew.train.xml
+
+$array = $ref.object -> get marines array
+$cnt =  size of array $array
+while $cnt
+dec $cnt =
+$select = $array[$cnt]
+$type = $select -> get local variable: name='anarkis.ads.marine'
+* - s
+if $type == 1
+
+$add =  = random value from 0 to 8 - 1
+$mech = $select -> get marine mechanical skill
+$add = $mech + $add + 4
+if $add > 100
+$add = 100
+end
+$select -> set marine skill: mechanical=$add
+
+$add =  = random value from 0 to 8 - 1
+$mech = $select -> get marine hacking skill
+$add = $mech + $add + 4
+if $add > 100
+$add = 100
+end
+$select -> set marine skill: hacking=$add
+
+$add =  = random value from 0 to 8 - 1
+$mech = $select -> get marine engineering skill
+$add = $mech + $add + 4
+if $add > 100
+$add = 100
+end
+$select -> set marine skill: engineering=$add
+
+else if $type == 2
+$add =  = random value from 0 to 7 - 1
+$mech = $select -> get marine fighting skill
+$add = $mech + $add + 4
+if $add > 100
+$add = 100
+$select -> set local variable: name='anarkis.ads.marine' value=0
+end
+$mech -> set marine skill: fighting=$add
+
+end
+* - s
+
+end
+return null

--- a/tools/fixtures/known_good/anarkis.ads.lib.enemy.strongest.x3s
+++ b/tools/fixtures/known_good/anarkis.ads.lib.enemy.strongest.x3s
@@ -1,0 +1,32 @@
+#name: anarkis.ads.lib.enemy.strongest
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.ads.lib.enemy.strongest.xml
+
+$refobject =  find station: sector=$sector class or type=Station race=$race flags=[Find.Random] refobj=null maxdist=null maxnum=1 refpos=null
+skip if $refobject -> exists
+$refobject =  find ship: sector=$sector class or type=Ship race=$race flags=[Find.Random] refobj=null maxdist=null maxnum=1 refpos=null
+skip if $refobject -> exists
+return null
+
+
+$flags = [Find.Enemy] | [Find.Multiple]
+$max.threat = 0
+$result.ship = null
+$ship.list =  find ship: sector=$sector class or type=Moveable Ship race=null flags=$flags refobj=$refobject maxdist=null maxnum=50 refpos=null
+$ship.count =  size of array $ship.list
+while $ship.count
+dec $ship.count =
+$ship = $ship.list[$ship.count]
+skip if $ship -> is $refobject a enemy
+continue
+skip if not $ship -> is civilian ship
+continue
+$threat = [THIS] -> call script anarkis.ads.lib.get.shipthreat :  ship/class=$ship
+if $threat > $max.threat
+$max.threat = $threat
+$result.ship = $ship
+end
+end
+
+return $result.ship

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -650,6 +650,20 @@
             "examples": [
                 "$p.face = = random value from 0 to 4 - 1"
             ]
+        },
+        {
+            "name": "array.alloc",
+            "regex": "^\\$[A-Za-z0-9_.]+\\s*=\\s*array alloc: size=(\\$[A-Za-z0-9_.]+|\\d+)$",
+            "examples": [
+                "$sel.role = array alloc: size=0"
+            ]
+        },
+        {
+            "name": "menu.create",
+            "regex": "^\\$[A-Za-z0-9_.]+\\s*=\\s*create custom menu array$",
+            "examples": [
+                "$menu = create custom menu array"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Plan
- Import 20 more ADS scripts into known-good fixtures.
- Record any new statement shapes in the lint allowlist and language docs.
- Ensure lint and test tooling covers the expanded fixtures.

## Changes
- Added 20 ADS `.x3s` scripts to `tools/fixtures/known_good/` and noted the update in `README.md`.
- Extended `tools/x3s_rules.json` with `array.alloc` and `menu.create` patterns.
- Documented the new patterns in `docs/x3s-language.md`.

## Test Results
- `python tools/x3s_lint.py`
- `python tools/x3s_lint.py tools/fixtures/known_good`
- `python tools/test_x3s.py`

## Pattern List
- `array.alloc`
- `menu.create`

## Safety Checks
- Linter verifies control-flow matching, wait-in-while, and required `load text` in setup scripts.


------
https://chatgpt.com/codex/tasks/task_e_68c6a1202090832698122ec6d689c449