### PR TITLE
feat: track 20 more ADS fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 SLX is a lightweight station-to-station logistics mod for X3TC: Terran Conflict. Moves wares between enrolled player stations (same- or cross-sector) — no NPC trade or scanning — via per-ware roles (Producer, Consumer, Store) with Min/Max/Chunk thresholds and a priority-based transfer loop.
 
 ## ADS Sample Files
-The linter is validated against these 180 known-good ADS scripts (20 newly added from ADS):
+The linter is validated against these 200 known-good ADS scripts (20 newly added from ADS):
 
 - !init.anarkis.modified.x3s
 - al.plugin.sk.ecs.x3s
@@ -184,3 +184,23 @@ The linter is validated against these 180 known-good ADS scripts (20 newly added
 - anarkis.lib.encyclopedia.chapter.x3s
 - anarkis.lib.encyclopedia.x3s
 - anarkis.lib.get.bycargovalue.fro.x3s
+- anarkis.lib.get.bycargovalue.x3s
+- anarkis.lib.get.dockedowned.x3s
+- anarkis.lib.get.fighter.array.x3s
+- anarkis.lib.get.military.array.x3s
+- anarkis.lib.get.militarybase.x3s
+- anarkis.lib.get.plsector.array.x3s
+- anarkis.lib.get.plsector.pership.x3s
+- anarkis.lib.get.plsector.x3s
+- anarkis.lib.get.race.array.short.x3s
+- anarkis.lib.get.race.array.x3s
+- anarkis.lib.get.racesectors.x3s
+- anarkis.lib.get.random.pos.from.x3s
+- anarkis.lib.get.random.pos.x3s
+- anarkis.lib.get.rnd.race.x3s
+- anarkis.lib.get.sector.plus.x3s
+- anarkis.lib.get.ship.cargovalue.x3s
+- anarkis.lib.get.shipcount.x3s
+- anarkis.lib.get.shiplist.from.sy.x3s
+- anarkis.lib.get.ships.fast.x3s
+- anarkis.lib.get.ships.from.x3s

--- a/tools/fixtures/known_good/anarkis.lib.get.bycargovalue.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.bycargovalue.x3s
@@ -1,0 +1,28 @@
+#name: anarkis.lib.get.bycargovalue
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.bycargovalue.xml
+
+$class =  array alloc: size=2
+$class[0] = TS
+$class[1] = TP
+$rel = [THIS] -> get relation to race Player
+if $rel == Foe
+$include = [FALSE]
+else
+$include = [TRUE]
+end
+*$array = [THIS] -> call script anarkis.lib.get.ships.from :  array of class=$class  force race=null  jump.range=$jump.range  ignore khaak/xenon?=[FALSE]  ignore pirate/yaki?=[FALSE]  ignore civilians?=[FALSE]  ignore player?=$include  from=$ship
+$array = [THIS] -> call script anarkis.lib.get.ships.var :  array of class=$class  force race=null  jump.range=$jump.range  ignore khaak/xenon?=[TRUE]  ignore pirate/yaki?=[FALSE]  ignore civilians?=[FALSE]  ignore player?=$include  local.var=null  from=$ship
+$cnt =  size of array $array
+$result =  array alloc: size=0
+while $cnt
+dec $cnt =
+$ship = $array[$cnt]
+$value = [THIS] -> call script anarkis.lib.get.ship.cargovalue :  ship=$ship
+if $value < $mincargo
+remove element from array $array at index $cnt
+end
+end
+
+return $array

--- a/tools/fixtures/known_good/anarkis.lib.get.dockedowned.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.dockedowned.x3s
@@ -1,0 +1,30 @@
+#name: anarkis.lib.get.dockedowned
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.dockedowned.xml
+
+$ship.array = [THIS] -> get ship array from sector/ship/station
+$ship.cnt =  size of array $ship.array
+while $ship.cnt
+$remove = [FALSE]
+dec $ship.cnt =
+$test.ship = $ship.array[$ship.cnt]
+$homebase = $test.ship -> get homebase
+skip if $test.ship -> is of class $ship.class
+$remove = [TRUE]
+$skipship = $test.ship -> get local variable: name='anarkis.skipme'
+if ( $skipship == [TRUE] ) OR ( [THIS] != $homebase )
+$remove = [TRUE]
+end
+if $localvar
+$var.result = $test.ship -> get local variable: name=$localvar
+if not $var.result == [TRUE]
+$remove = [TRUE]
+end
+end
+if $remove == [TRUE]
+remove element from array $ship.array at index $ship.cnt
+end
+end
+
+return $ship.array

--- a/tools/fixtures/known_good/anarkis.lib.get.fighter.array.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.fighter.array.x3s
@@ -1,0 +1,7 @@
+#name: anarkis.lib.get.fighter.array
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.fighter.array.xml
+
+$selected.array = $dock -> get owned ships: class/type=Fighter
+return $selected.array

--- a/tools/fixtures/known_good/anarkis.lib.get.military.array.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.military.array.x3s
@@ -1,0 +1,70 @@
+#name: anarkis.lib.get.military.array
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.military.array.xml
+
+* ===========================================
+* Find an array of military ships in the vecinity
+* ===========================================
+
+$null = null
+
+$class.array =  array alloc: size=0
+append M3 to array $class.array
+append M6 to array $class.array
+append M7 to array $class.array
+append M8 to array $class.array
+append M2 to array $class.array
+append M1 to array $class.array
+$class.cnt =  size of array $class.array
+
+$military.array =  array alloc: size=0
+
+
+if $jump.range > 0
+$sector.list = [THIS] -> find all sectors within $jump.range jumps: Only known sectors=[FALSE]
+else
+$sector.list =  array alloc: size=0
+append [SECTOR] to array $sector.list
+end
+
+$cnt =  size of array $sector.list
+* For all sectors
+while $cnt
+dec $cnt =
+$sector = $sector.list[$cnt]
+$ship.array = $sector -> get ship array from sector/ship/station
+$cnt.ship =  size of array $ship.array
+* - For each ship in sector
+while $cnt.ship
+= wait 20 ms
+dec $cnt.ship =
+$test.ship = $ship.array[$cnt.ship]
+* - - Check Race
+$owner = $test.ship -> get owner race
+if $owner == Pirates OR $owner == Yaki OR $owner == Goner
+continue
+end
+if $ignore.player == [TRUE] AND $owner == Player
+continue
+end
+* - - Check Laser strength
+$laser = $test.ship -> get current laser strength
+if $laser == 0
+continue
+end
+* - - Check class
+$ship.class = $test.ship -> get object class
+$x = $class.cnt
+while $x
+dec $x =
+$test.class = $class.array[$x]
+if $ship.class == $test.class
+append $test.ship to array $military.array
+break
+end
+end
+end
+end
+
+return $military.array

--- a/tools/fixtures/known_good/anarkis.lib.get.militarybase.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.militarybase.x3s
@@ -1,0 +1,47 @@
+#name: anarkis.lib.get.militarybase
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.militarybase.xml
+
+$military.types =  array alloc: size=0
+append Military Outpost to array $military.types
+append OTAS HQ to array $military.types
+append Terracorp HQ to array $military.types
+append Jonferco Headquarters to array $military.types
+append Plutarch Mining Corporation HQ to array $military.types
+append Atreus Headquarters to array $military.types
+append Military Outpost to array $military.types
+append Military Outpost to array $military.types
+append Strong Arms HQ to array $military.types
+append Military Outpost to array $military.types
+append Military Outpost to array $military.types
+append NMMC Headquarters to array $military.types
+append Duke's Haven to array $military.types
+append Orbital Defence Station to array $military.types
+append Orbital Defence Station to array $military.types
+append Military Base to array $military.types
+append Orbital Defence Station to array $military.types
+append Orbital Patrol Base to array $military.types
+append Headquarters to array $military.types
+append Military Base to array $military.types
+append Orbital Defence Station to array $military.types
+$military.cnt =  size of array $military.types
+
+
+$result =  array alloc: size=0
+
+$sector.stations =  find station: sector=$sector class or type=Dock race=$race flags=[Find.Multiple] refobj=null maxdist=null maxnum=100 refpos=null
+$cnt =  size of array $sector.stations
+while $cnt
+dec $cnt =
+$select = $sector.stations[$cnt]
+$type = $select -> get ware type code of object
+skip if not  find $type in array: $military.types
+append $select to array $result
+end
+
+$cnt =  size of array $result
+skip if $cnt
+return null
+
+return $result

--- a/tools/fixtures/known_good/anarkis.lib.get.plsector.array.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.plsector.array.x3s
@@ -1,0 +1,39 @@
+#name: anarkis.lib.get.plsector.array
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.plsector.array.xml
+
+* ===========================================
+* Retrieve an array of sectors 'owned' by the player
+* ===========================================
+* This script may take a while to run given the amount of player owned stations
+
+$station.array =  get station array: of race Player class/type=Station
+$station.count =  size of array $station.array
+$sector.array =  array alloc: size=0
+
+while $station.count
+dec $station.count =
+$station = $station.array[$station.count]
+$station.sector = $station -> get sector
+$jump.distance = get jumps from sector [SECTOR] to sector $station.sector
+$sector.already =  find $station.sector in array: $sector.array
+skip if $jump.distance > $max.jump OR $sector.already == [TRUE]
+append $station.sector to array $sector.array
+= wait 100 ms
+end
+
+$sector.count =  size of array $sector.array
+
+while $sector.count
+dec $sector.count =
+$sector = $sector.array[$sector.count]
+$station.array =  find station: sector=$sector class or type=Station race=Player flags=[Find.Multiple] refobj=null maxdist=null maxnum=100 refpos=null
+$station.count =  size of array $station.array
+if $station.count < $min.station
+remove element from array $sector.array at index $sector.count
+end
+= wait 100 ms
+end
+
+return $sector.array

--- a/tools/fixtures/known_good/anarkis.lib.get.plsector.pership.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.plsector.pership.x3s
@@ -1,0 +1,44 @@
+#name: anarkis.lib.get.plsector.pership
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.plsector.pership.xml
+
+* ===========================================
+* Retrieve a sector with a bunch of ships owned by the player
+* ===========================================
+* This script may take a while to execute given the amount of player owned ships
+* TC Fix : Speed improvement
+* TODO : Speed hack through 2 row array
+
+$ship.array =  get ship array: of race Player class/type=Moveable Ship
+$ship.count =  size of array $ship.array
+$sector.array =  array alloc: size=0
+
+while $ship.count
+dec $ship.count =
+$ship = $ship.array[$ship.count]
+$ship.sector = $ship -> get sector
+$jump.distance = get jumps from sector [SECTOR] to sector $ship.sector
+$sector.already =  find $ship.sector in array: $sector.array
+skip if $jump.distance > $max.jump OR $sector.already == [TRUE]
+append $ship.sector to array $sector.array
+= wait 10 ms
+end
+
+$s.amount = 0
+$s.sector = null
+$sector.count =  size of array $sector.array
+while $sector.count
+dec $sector.count =
+$sector = $sector.array[$sector.count]
+$ship.array =  find ship: sector=$sector class or type=Moveable Ship race=Player flags=[Find.Multiple] refobj=null maxdist=null maxnum=100 refpos=null
+$ship.count =  size of array $ship.array
+$rnd =  = random value from 0 to 2 - 1
+if ( $s.amount < $ship.count ) OR ( $s.amount == $ship.count AND $rnd == 1 )
+$s.amount = $ship.count
+$s.sector = $sector
+end
+= wait 10 ms
+end
+
+return $s.sector

--- a/tools/fixtures/known_good/anarkis.lib.get.plsector.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.plsector.x3s
@@ -1,0 +1,51 @@
+#name: anarkis.lib.get.plsector
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.plsector.xml
+
+* ===========================================
+* Retrieve a sector with the most player stations given a distance to object
+* ===========================================
+* This script may take a while to run given the amount of player owned stations
+* TC Fix : Speed improvement
+* TODO : Speed hack through 2 row array
+
+$station.array =  get station array: of race Player class/type=Station
+$station.count =  size of array $station.array
+$sector.array =  array alloc: size=0
+
+while $station.count
+dec $station.count =
+$station = $station.array[$station.count]
+$station.sector = $station -> get sector
+$jump.distance = get jumps from sector [SECTOR] to sector $station.sector
+$sector.already =  find $station.sector in array: $sector.array
+skip if $jump.distance > $max.jump OR $sector.already == [TRUE]
+append $station.sector to array $sector.array
+= wait 100 ms
+end
+
+$s.amount = 0
+$s.sector = null
+$sector.count =  size of array $sector.array
+
+* If no station, fall back to ship
+if $sector.count == 0
+$s.sector = [THIS] -> call script anarkis.lib.get.plsector.pership :  max jump distance=$max.jump
+return $s.sector
+end
+
+while $sector.count
+dec $sector.count =
+$sector = $sector.array[$sector.count]
+$station.array =  find station: sector=$sector class or type=Station race=Player flags=[Find.Multiple] refobj=null maxdist=null maxnum=100 refpos=null
+$station.count =  size of array $station.array
+$rnd =  = random value from 0 to 2 - 1
+if ( $s.amount < $station.count ) OR ( $s.amount == $station.count AND $rnd == 1 )
+$s.amount = $station.count
+$s.sector = $sector
+end
+= wait 100 ms
+end
+
+return $s.sector

--- a/tools/fixtures/known_good/anarkis.lib.get.race.array.short.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.race.array.short.x3s
@@ -1,0 +1,23 @@
+#name: anarkis.lib.get.race.array.short
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.race.array.short.xml
+
+$res =  array alloc: size=0
+append Argon to array $res
+append Boron to array $res
+append Split to array $res
+append Paranid to array $res
+append Teladi to array $res
+append Xenon to array $res
+append Kha'ak to array $res
+append Pirates to array $res
+append Goner to array $res
+append Player to array $res
+append Unknown to array $res
+append Race 1 to array $res
+append Race 2 to array $res
+append ATF to array $res
+append Terran to array $res
+append Yaki to array $res
+return $res

--- a/tools/fixtures/known_good/anarkis.lib.get.race.array.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.race.array.x3s
@@ -1,0 +1,23 @@
+#name: anarkis.lib.get.race.array
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.race.array.xml
+
+$res =  array alloc: size=0
+append Argon to array $res
+append Boron to array $res
+append Split to array $res
+append Paranid to array $res
+append Teladi to array $res
+append Xenon to array $res
+append Kha'ak to array $res
+append Pirates to array $res
+append Goner to array $res
+append Player to array $res
+append Unknown to array $res
+append Race 1 to array $res
+append Race 2 to array $res
+append ATF to array $res
+append Terran to array $res
+append Yaki to array $res
+return $res

--- a/tools/fixtures/known_good/anarkis.lib.get.racesectors.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.racesectors.x3s
@@ -1,0 +1,22 @@
+#name: anarkis.lib.get.racesectors
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.racesectors.xml
+
+$res =  array alloc: size=0
+
+$m.x = get max sectors in x direction
+while $m.x
+dec $m.x =
+$m.y = get max sectors in y direction
+while $m.y
+dec $m.y =
+$sector = get sector from universe index: x=$m.x, y=$m.y
+if $sector -> exists
+$v1 = $sector -> get owner race
+skip if not $race == $v1
+append $sector to array $res
+end
+end
+end
+return $res

--- a/tools/fixtures/known_good/anarkis.lib.get.random.pos.from.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.random.pos.from.x3s
@@ -1,0 +1,54 @@
+#name: anarkis.lib.get.random.pos.from
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.random.pos.from.xml
+
+$retry.count = 100
+$st.array = $sector -> get all stationary objects: include asteroids=[TRUE]
+
+$o.x = $object -> get x position
+$o.y = $object -> get y position
+$o.z = $object -> get z position
+
+$error = [TRUE]
+while $retry.count
+dec $retry.count =
+$p.x =  = random value from $min.dist to $max.dist - 1
+$rnd =  = random value from 0 to 2 - 1
+if $rnd == 1
+$p.x = $o.x - $p.x
+else
+$p.x = $o.x + $p.x
+end
+$p.y =  = random value from $min.dist to $max.dist - 1
+$rnd =  = random value from 0 to 2 - 1
+if $rnd == 1
+$p.y = $o.y - $p.y
+else
+$p.y = $o.y + $p.y
+end
+$p.z =  = random value from $min.dist to $max.dist - 1
+$rnd =  = random value from 0 to 2 - 1
+if $rnd == 1
+$p.z = $o.z - $p.z
+else
+$p.z = $o.z + $p.z
+end
+$error = [FALSE]
+$cur.pos =  create new array, arguments=$p.x, $p.y, $p.z, null, null
+$station.count =  size of array $st.array
+while $station.count
+dec $station.count =
+$select = $st.array[$station.count]
+$size = $select -> get size of object
+$dist = $select -> get distance to: x=$p.x y=$p.y z=$p.z
+if $dist < $size
+$error = [TRUE]
+break
+end
+end
+if $error == [FALSE]
+break
+end
+end
+return $cur.pos

--- a/tools/fixtures/known_good/anarkis.lib.get.random.pos.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.random.pos.x3s
@@ -1,0 +1,41 @@
+#name: anarkis.lib.get.random.pos
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.random.pos.xml
+
+$retry.count = 100
+$st.array = $sector -> get all stationary objects: include asteroids=[TRUE]
+
+$error = [TRUE]
+while $retry.count
+dec $retry.count =
+$p.x =  = random value from $min.dist to $max.dist - 1
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+$p.x = 0 - $p.x
+$p.y =  = random value from $min.dist to $max.dist - 1
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+$p.y = 0 - $p.y
+$p.z =  = random value from $min.dist to $max.dist - 1
+$rnd =  = random value from 0 to 2 - 1
+skip if $rnd == 1
+$p.z = 0 - $p.z
+$error = [FALSE]
+$cur.pos =  create new array, arguments=$p.x, $p.y, $p.z, null, null
+$station.count =  size of array $st.array
+while $station.count
+dec $station.count =
+$select = $st.array[$station.count]
+$size = $select -> get size of object
+$dist = $select -> get distance to: x=$p.x y=$p.y z=$p.z
+if $dist < $size
+$error = [TRUE]
+break
+end
+end
+if $error == [FALSE]
+break
+end
+end
+return $cur.pos

--- a/tools/fixtures/known_good/anarkis.lib.get.rnd.race.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.rnd.race.x3s
@@ -1,0 +1,41 @@
+#name: anarkis.lib.get.rnd.race
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.rnd.race.xml
+
+* ===========================================
+* Get a random race according to parameters
+* ===========================================
+
+$array =  array alloc: size=0
+
+append Argon to array $array
+append Boron to array $array
+append Split to array $array
+append Paranid to array $array
+append Teladi to array $array
+append Terran to array $array
+
+if $include.aliens
+append Xenon to array $array
+append Kha'ak to array $array
+end
+
+skip if not $include.unknown
+append Unknown to array $array
+
+if $include.renegades
+append Pirates to array $array
+append Yaki to array $array
+end
+
+skip if not $add.race1
+append $add.race1 to array $array
+skip if not $add.race2
+append $add.race2 to array $array
+
+$cnt =  size of array $array
+$nb =  = random value from 0 to $cnt - 1
+$race = $array[$nb]
+
+return $race

--- a/tools/fixtures/known_good/anarkis.lib.get.sector.plus.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.sector.plus.x3s
@@ -1,0 +1,52 @@
+#name: anarkis.lib.get.sector.plus
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.sector.plus.xml
+
+* ===========================================
+* Get a sector according to the params
+* ===========================================
+
+$retry = 25
+$flags = [Find.Random]
+$random.race = null
+$sector = null
+$sector.list = $ref.object -> find all sectors within $max.jump jumps: Only known sectors=[FALSE]
+$sector.cnt =  size of array $sector.list
+
+while $sector.cnt
+dec $sector.cnt =
+$sector = $sector.list[$sector.cnt]
+$sector.owner = $sector -> get owner race
+if $race != null AND $sector.owner != $race
+remove element from array $sector.list at index $sector.cnt
+continue
+end
+if $no.unknown == [TRUE] AND $sector.owner == Unknown
+remove element from array $sector.list at index $sector.cnt
+continue
+end
+if $ignore.alien == [TRUE] AND ( $sector.owner == Xenon OR $sector.owner == Kha'ak )
+remove element from array $sector.list at index $sector.cnt
+continue
+end
+if $ignore.pirate == [TRUE] AND ( $sector.owner == Pirates OR $sector.owner == Yaki )
+remove element from array $sector.list at index $sector.cnt
+continue
+end
+$is.core = $sector -> is core sector
+if $remove.border == [TRUE] AND $is.core == [FALSE]
+remove element from array $sector.list at index $sector.cnt
+continue
+end
+if $remove.core == [TRUE] AND $is.core == [TRUE]
+remove element from array $sector.list at index $sector.cnt
+continue
+end
+end
+
+$sector.cnt =  size of array $sector.list
+$sector.cnt =  = random value from 0 to $sector.cnt - 1
+$sector = $sector.list[$sector.cnt]
+
+return $sector

--- a/tools/fixtures/known_good/anarkis.lib.get.ship.cargovalue.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.ship.cargovalue.x3s
@@ -1,0 +1,23 @@
+#name: anarkis.lib.get.ship.cargovalue
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.ship.cargovalue.xml
+
+* 1.02 - Added player support
+$owner = $ship -> get owner race
+if $owner != Player
+$ware.list =  get warearray for $ship
+else
+$ware.list = $ship -> get tradeable ware array from ship
+end
+
+$ware.cnt =  size of array $ware.list
+$total = 0
+while $ware.cnt
+dec $ware.cnt =
+$ware = $ware.list[$ware.cnt]
+$amount = $ship -> get amount of ware $ware in cargo bay
+$price = get average price of ware $ware
+$total = $total + ( $amount * $price )
+end
+return $total

--- a/tools/fixtures/known_good/anarkis.lib.get.shipcount.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.shipcount.x3s
@@ -1,0 +1,39 @@
+#name: anarkis.lib.get.shipcount
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.shipcount.xml
+
+* ===========================================
+* Get minimal ship count against a target
+* ===========================================
+
+$res = 3
+if $class == M2
+$res = 35
+else if $class == M1
+$res = 30
+else if $class == M7
+$res = 25
+else if $class == TL
+$res = 15
+else if $class == M6
+$res = 14
+else if $class == M8
+$res = 6
+else if $class == M3
+$res = 4
+else if $class == M4
+$res = 3
+else if $class == M5
+$res = 2
+else if $class == TM
+$res = 4
+else if $class == TS OR $class == TP
+$res = 3
+else if $class == Lasertower
+$res = 8
+else if $class == Dock
+$res = 20
+end
+
+return $res

--- a/tools/fixtures/known_good/anarkis.lib.get.shiplist.from.sy.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.shiplist.from.sy.x3s
@@ -1,0 +1,25 @@
+#name: anarkis.lib.get.shiplist.from.sy
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.shiplist.from.sy.xml
+
+* Fix 1 : Performance increased, one less loop
+
+$trade.array = $sy -> get tradeable ware array from station
+$cnt =  size of array $trade.array
+while $cnt
+dec $cnt =
+$test.ware = $trade.array[$cnt]
+* - Remove Stations
+$transport.class = get transport class of ware $test.ware
+if $transport.class == Station Containers ST
+remove element from array $trade.array at index $cnt
+continue
+end
+* - Quick and Dirty method to check ship class
+$ship =  create ship: type=$test.ware owner=Friendly Race addto=$sy x=0 y=0 z=0
+skip if $ship -> is of class $ship.class
+remove element from array $trade.array at index $cnt
+$ship -> destruct: show no explosion=[TRUE]
+end
+return $trade.array

--- a/tools/fixtures/known_good/anarkis.lib.get.ships.fast.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.ships.fast.x3s
@@ -1,0 +1,90 @@
+#name: anarkis.lib.get.ships.fast
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.ships.fast.xml
+
+* ===========================================
+* Find all ships according to the parameters
+* ===========================================
+
+$null = null
+$class.cnt =  size of array $class.array
+if $class.array == null
+$class.cnt = 0
+else if $class.cnt == 0
+$class.array = null
+end
+
+$military.array =  array alloc: size=0
+
+if $jump.range > 0
+$sector.list = $from -> find all sectors within $jump.range jumps: Only known sectors=[FALSE]
+else
+$sector.list =  array alloc: size=0
+append [SECTOR] to array $sector.list
+end
+$cnt =  size of array $sector.list
+
+* For all sectors
+$sl.cnt = 0
+while $cnt
+dec $cnt =
+$sector = $sector.list[$cnt]
+$ship.array = $sector -> get ship array from sector/ship/station
+$cnt.ship =  size of array $ship.array
+* - For each ship in sector
+while $cnt.ship
+inc $sl.cnt =
+if $sl.cnt == 1000
+$sl.cnt = 0
+= wait 25 ms
+end
+dec $cnt.ship =
+$test.ship = $ship.array[$cnt.ship]
+* - - Check Race
+$owner = $test.ship -> get true owner
+if $force.race != null AND $owner != $force.race
+continue
+else if $force.race != null AND $owner == $force.race
+goto label skipracecheck
+end
+* - - Ignore Player
+if $ignore.player == [TRUE] AND $owner == Player
+continue
+end
+* - - Ignore Khaaks and Xenons ?
+if $ignore.aliens == [TRUE] AND ( $owner == Kha'ak OR $owner == Xenon )
+continue
+end
+* - - Ignore Pirates ?
+if $ignore.pirates == [TRUE] AND ( $owner == Pirates OR $owner == Yaki )
+continue
+end
+skipracecheck:
+* - - Ignore invincible
+skip if not $test.ship -> is invincible
+continue
+* - - Ignore civilians
+if $ignore.civilians
+skip if not $test.ship -> is civilian ship
+continue
+skip if $test.ship -> get current laser strength
+continue
+end
+* - - Check Local
+if $checkvar
+skip if $test.ship -> get local variable: name=$checkvar
+continue
+end
+
+* - - Check class
+$ship.class = $test.ship -> get object class
+$found =  find $ship.class in array: $class.array
+if $found == [TRUE] OR $class.array == null
+append $test.ship to array $military.array
+end
+
+end
+end
+
+return $military.array

--- a/tools/fixtures/known_good/anarkis.lib.get.ships.from.x3s
+++ b/tools/fixtures/known_good/anarkis.lib.get.ships.from.x3s
@@ -1,0 +1,11 @@
+#name: anarkis.lib.get.ships.from
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/anarkis.lib.get.ships.from.xml
+
+* ===========================================
+* Find all ships according to the parameters
+* ===========================================
+$military.array = [THIS] -> call script anarkis.lib.get.ships.var :  array of class=$class.array  force race=$force.race  jump.range=$jump.range  ignore khaak/xenon?=$ignore.aliens  ignore pirate/yaki?=$ignore.pirates  ignore civilians?=$ignore.civilians  ignore player?=$ignore.player  local.var=$null  from=$from
+
+return $military.array


### PR DESCRIPTION
## Plan
- Copy 20 additional ADS .x3s files into fixtures
- Reference them in README so test suite exercises these scripts

## Changes
- Added 20 ADS scripts to `tools/fixtures/known_good`
- Updated README to list 200 ADS scripts total

## Test Results
- `python tools/x3s_lint.py`
- `python tools/test_x3s.py`

## Pattern List
- No new statement patterns were required; existing allowlist covered the additional files.

## Safety Checks
- Lint confirms structural rules, wait-in-while, and setup `load text` on all known-good scripts.


------
https://chatgpt.com/codex/tasks/task_e_68c6a2a276888326b3fba5466cab7941