### PR TITLE
Learn from known-good .x3s and update our linter (no XML build)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 SLX is a lightweight station-to-station logistics mod for X3TC: Terran Conflict. Moves wares between enrolled player stations (same- or cross-sector) — no NPC trade or scanning — via per-ware roles (Producer, Consumer, Store) with Min/Max/Chunk thresholds and a priority-based transfer loop.
 
 ## ADS Sample Files
-The linter is validated against these 240 known-good ADS scripts (20 newly added from ADS):
+The linter is validated against these 240 known-good ADS scripts (now including 20 plugin.sk.ecs.* files):
 
 - !init.anarkis.modified.x3s
 - al.plugin.sk.ecs.x3s

--- a/tools/fixtures/known_good/plugin.sk.ecs.al.init.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.al.init.x3s
@@ -1,0 +1,29 @@
+#name: plugin.sk.ecs.al.init
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.al.init.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+if  is datatyp[ $ecs.setup ] == DATATYP_ARRAY
+$ecs.setup[3] = [TRUE]
+else
+$ecs.setup =  array alloc: size=6
+$ecs.installed =  array alloc: size=0
+$ecs.configs =  array alloc: size=0
+$ecs.news =  array alloc: size=0
+$ecs.guilds =  array alloc: size=0
+$ecs.setup[0] = 250
+$ecs.setup[1] = $ecs.installed
+$ecs.setup[2] = $ecs.configs
+$ecs.setup[3] = [TRUE]
+$ecs.setup[4] = null
+$ecs.setup[5] = $ecs.news
+$ecs.setup[6] = $ecs.guilds
+end
+set global variable: name='plugin.ecs.setup' value=$ecs.setup
+= [THIS] -> call script plugin.sk.ecs.hotkey.install :
+return null

--- a/tools/fixtures/known_good/plugin.sk.ecs.al.register.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.al.register.x3s
@@ -1,0 +1,48 @@
+#name: plugin.sk.ecs.al.register
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.al.register.xml
+
+$text.id = 8511
+
+$plugin.Vars = get global variable: name=$plugin.ID
+
+* setup new data structure and init it
+if not $plugin.Vars
+$plugin.Vars =  array alloc: size=2
+set global variable: name=$plugin.ID value=$plugin.Vars
+$plugin.Vars[0] = 0
+$plugin.Vars[1] = [TRUE]
+end
+
+* init and reinit are run every time the game loads
+if $plugin.Event == 'init' OR $plugin.Event == 'reinit'
+$desc = sprintf: pageid=$text.id textid=100, null, null, null, null, null
+al engine: set plugin $plugin.ID description to $desc
+$interval = 30 * 60
+al engine: set plugin $plugin.ID timer interval to $interval s
+skip if get global variable: name='plugin.ecs.setup'
+= [THIS] -> call script plugin.sk.ecs.al.init :
+
+else if $plugin.Event == 'isenabled'
+$desc = sprintf: pageid=$text.id textid=100, null, null, null, null, null
+al engine: set plugin $plugin.ID description to $desc
+$enabled = $plugin.Vars[1]
+return $enabled
+
+* Use this area to process special instructions when the plugin is toggled on
+else if $plugin.Event == 'start'
+$plugin.Vars[1] = [TRUE]
+= [THIS] -> call script plugin.sk.ecs.al.init :
+= [THIS] -> call script plugin.sk.ecs.manager :
+* Use this area to process special instructions when the plugin is toggled off
+else if $plugin.Event == 'stop'
+$plugin.Vars[1] = [FALSE]
+= [THIS] -> call script plugin.sk.ecs.al.stop :
+
+* The event script is called every interval
+else if $plugin.Event == 'timer'
+$enabled = $plugin.Vars[1]
+end
+
+return null

--- a/tools/fixtures/known_good/plugin.sk.ecs.al.stop.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.al.stop.x3s
@@ -1,0 +1,15 @@
+#name: plugin.sk.ecs.al.stop
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.al.stop.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+$ecs.setup[3] = [FALSE]
+set global variable: name='plugin.ecs.setup' value=$ecs.setup
+START [THIS] -> call script plugin.sk.ecs.manager :
+
+return null

--- a/tools/fixtures/known_good/plugin.sk.ecs.call.script.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.call.script.x3s
@@ -1,0 +1,53 @@
+#name: plugin.sk.ecs.call.script
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.call.script.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* This script is started each time the ECS hotkey is pressed.
+* It gets the player's current targeti and check every ECS plugin to see if the
+* object is handled by such plugin. If found, it will run the plugin's comm.script
+* ===========================================
+
+$target =  get player tracking aim
+skip if $target -> exists
+return null
+$setup = get global variable: name='plugin.ecs.setup'
+skip if  is datatyp[ $setup ] == DATATYP_ARRAY
+return null
+
+$setup.installed = $setup[1]
+$setup.configs = $setup[2]
+
+$plugin.count =  size of array $setup.installed
+while $plugin.count
+dec $plugin.count =
+$plugin.name = $setup.installed[$plugin.count]
+if get global variable: name=$plugin.name
+$index =  get index of $plugin.name in array $setup.installed offset=-1 + 1
+$plugin.config = $setup.configs[$index]
+$plugin.config.global = $plugin.config[0]
+$plugin.config.script = $plugin.config[1]
+$plugin.config.local = $plugin.config[2]
+$plugin.config.race = $plugin.config[3]
+$plugin.config.class = $plugin.config[4]
+$target.local = $target -> get local variable: name=$plugin.config.local
+if $plugin.config.local != null AND $target.local == null
+continue
+end
+$target.race = $target -> get owner race
+if $plugin.config.race != null AND $target.race != $plugin.config.race
+continue
+end
+if $plugin.config.class != null
+skip if $target -> is of class $plugin.config.class
+continue
+end
+= [THIS] -> call named script: script=$plugin.config.script, $target, null, null, null, null
+break
+end
+end
+
+return [TRUE]

--- a/tools/fixtures/known_good/plugin.sk.ecs.dialog.menu.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.dialog.menu.x3s
@@ -1,0 +1,35 @@
+#name: plugin.sk.ecs.dialog.menu
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dialog.menu.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* You can make your own menu using the new X3TC custom menu commands
+* And use this script to display it through ECS
+* ===========================================
+* Script Settings:
+* $ship : object sending the message (ship/station/roid/...)
+* $sound : Sound ID to be player with 'send audio message..' command (can be null)
+* $dialog.title : window's title
+* $dialog.menu : custom menu array
+* ===========================================
+* Script Returns:
+* -1 : Player closed the window pressing ESC
+* other : menu result
+* ===========================================
+
+$page.id = 8511
+
+$pilot.name = $ship -> get pilot name
+skip if $pilot.name
+$pilot.name = $ship
+
+skip if not $sound
+$ship -> send audio message $sound to player
+
+$from = sprintf: pageid=$page.id textid=217, $ship, null, null, null, null
+$menu.result =  open custom menu: title=$dialog.title description=$from option array=$dialog.menu
+
+return $menu.result

--- a/tools/fixtures/known_good/plugin.sk.ecs.dialog.ok.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.dialog.ok.x3s
@@ -1,0 +1,47 @@
+#name: plugin.sk.ecs.dialog.ok
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dialog.ok.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* Call this script when you want to show a simple message windows with a single
+* ok button
+* ===========================================
+* Script Settings:
+* $ship : object sending the message (ship/station/roid/...)
+* $sound : Sound ID to be player with 'send audio message..' command (can be null)
+* $dialog.title : window's title
+* $dialog.content : window's main text
+* $dialog.ok : button ok caption
+* ===========================================
+* Script Returns: -1
+* ===========================================
+
+$page.id = 8511
+
+if $ship -> is of class Station
+$pilot.name = $ship -> get name
+else
+$pilot.name = $ship -> get pilot name
+skip if $pilot.name
+$pilot.name = $ship
+end
+
+skip if not $sound
+$ship -> send audio message $sound to player
+
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=224
+add custom menu heading to array $menu: title=$st
+add custom menu item to array $menu: text=$dialog.ok returnvalue=-1
+
+$st = sprintf: pageid=$page.id textid=225, $dialog.content, $pilot.name, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$from = sprintf: pageid=$page.id textid=217, $ship, null, null, null, null
+$menu.result =  open custom menu: title=$dialog.title description=$from option array=$menu
+
+return $menu.result

--- a/tools/fixtures/known_good/plugin.sk.ecs.dialog.yesno.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.dialog.yesno.x3s
@@ -1,0 +1,53 @@
+#name: plugin.sk.ecs.dialog.yesno
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dialog.yesno.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* Call this script when you want to show a dialog window with 2 possible
+* answers.
+* ===========================================
+* Script Settings:
+* $ship : object sending the message (ship/station/roid/...)
+* $sound : Sound ID to be player with 'send audio message..' command (can be null)
+* $dialog.title : window's title
+* $dialog.content : window's main text
+* $dialog.yes : option 1 caption
+* $dialog.no : option 2 caption
+* ===========================================
+* Script Returns:
+* -1 : Player closed the window pressing ESC
+* 1 : Player choosed the first answer
+* 2 : Player choosed the second answer
+* ===========================================
+
+$page.id = 8511
+
+if $ship -> is of class Station
+$pilot.name = $ship -> get name
+else
+$pilot.name = $ship -> get pilot name
+skip if $pilot.name
+$pilot.name = $ship
+end
+
+skip if not $sound
+$ship -> send audio message $sound to player
+
+$menu =  create custom menu array
+
+$st =  read text: page=$page.id id=224
+add custom menu heading to array $menu: title=$st
+add custom menu item to array $menu: text=$dialog.yes returnvalue=1
+add custom menu item to array $menu: text=$dialog.no returnvalue=2
+
+$st = sprintf: pageid=$page.id textid=225, $dialog.content, $pilot.name, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$from = sprintf: pageid=$page.id textid=217, $ship, null, null, null, null
+$menu.result =  open custom menu: title=$dialog.title description=$from option array=$menu
+
+
+return $menu.result

--- a/tools/fixtures/known_good/plugin.sk.ecs.dummy.commscript.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.dummy.commscript.x3s
@@ -1,0 +1,22 @@
+#name: plugin.sk.ecs.dummy.commscript
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dummy.commscript.xml
+
+* Here, each time the player 'spot' / ecs-comm a ship, it willl add a report
+* to the ECS Newsfeed. Notice that a true plugin should aim for a specific target
+* with local variable on the targeted object, or a specific class, etc.
+
+$pl.sector = [PLAYERSHIP] -> get sector
+$sector = $target -> get sector
+
+
+$title = sprintf: fmt='%s located here : %s', $target, $sector, null, null, null
+$content = sprintf: fmt='%s has been spotted in sector %s', $target, $sector, null, null, null
+= [THIS] -> call script plugin.sk.ecs.news.add :  Plugin ID='plugin.ecs.dummy'  News Title=$title  News Content=$content  from=[PLAYERSHIP]
+
+* And then, show the newsfeed (with the 10 last scanned roids):
+= [THIS] -> call script plugin.sk.ecs.news.display :  Plugin ID='plugin.ecs.dummy'
+
+
+return null

--- a/tools/fixtures/known_good/plugin.sk.ecs.dummy.register.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.dummy.register.x3s
@@ -1,0 +1,25 @@
+#name: plugin.sk.ecs.dummy.register
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dummy.register.xml
+
+* We create an array with this example script's ECS setup
+* Read the documentation included in plugin.sk.ecs.register for details
+$setup =  array alloc: size=7
+* Default value: script to call when hotkey is pressed, local var to check on
+* selected object, race and class check of selected object.
+$setup[0] = 'plugin.ecs.dummy'
+$setup[1] = 'plugin.ecs.dummy.commscript'
+$setup[2] = null
+$setup[3] = null
+$setup[4] = Ship
+* ECS Newsfeed setup (can be null if not used)
+* Index 5 is max amount of news to store, 6 is the newsfeed window's title.
+$setup[5] = 10
+$setup[6] = 'ECS Spy Ship'
+
+* We call register to add the script to the ECS plugin list
+skip if [THIS] -> call script plugin.sk.ecs.register :  Setup Array=$setup
+send incoming message 'Error registering dummy script' to player: display it=[TRUE]
+
+return null

--- a/tools/fixtures/known_good/plugin.sk.ecs.dummy.remove.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.dummy.remove.x3s
@@ -1,0 +1,10 @@
+#name: plugin.sk.ecs.dummy.remove
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dummy.remove.xml
+
+
+skip if [THIS] -> call script plugin.sk.ecs.unregister :  Plugin ID='plugin.ecs.dummy'
+send incoming message 'Error removing dummy from ECS' to player: display it=[TRUE]
+
+return null

--- a/tools/fixtures/known_good/plugin.sk.ecs.dummy.setup.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.dummy.setup.x3s
@@ -1,0 +1,26 @@
+#name: plugin.sk.ecs.dummy.setup
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dummy.setup.xml
+
+* ===========================================
+* ECS 2.5 Demo Script - Spy Ship
+* ===========================================
+* This example script allows the player to keep track of the 10 last
+* ships he has spotted, with current location info
+* ===========================================
+* This script should be renamed/copied as setup.ecs.dummy to be
+* run when game starts.
+* ===========================================
+
+* We set a global to easily check if the script is installed
+set global variable: name='plugin.ecs.dummy' value=[TRUE]
+
+* Then we call the script used to register to ECS
+= [THIS] -> call script plugin.sk.ecs.dummy.register :
+
+* ... here comes whatever you need to add in your setup script ...
+
+* ...
+
+return null

--- a/tools/fixtures/known_good/plugin.sk.ecs.dummy.uninstall.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.dummy.uninstall.x3s
@@ -1,0 +1,20 @@
+#name: plugin.sk.ecs.dummy.uninstall
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.dummy.uninstall.xml
+
+* ===========================================
+* Usually, ECS plugins should be released as AL plugins and this script should be
+* called in the AL 'stop' event. Anyway, it's used here to unregister to  ECS.
+* ===========================================
+
+* We disable the scipt's global variable
+set global variable: name='plugin.ecs.dummy' value=null
+
+* Function used to remove all messages in the ECS Newsfeed, not mendatory here.
+= [THIS] -> call script plugin.sk.ecs.news.clear :  Plugin ID='plugin.ecs.dummy'
+* I cleany unregister to ECS here. AL plugin can also only alter the plugin's
+* global variable here.
+skip if [THIS] -> call script plugin.sk.ecs.unregister :  Plugin ID='plugin.ecs.dummy'
+send incoming message 'Unable to unregister dummy script : Script not registered to ECS' to player: display it=[TRUE]
+return null

--- a/tools/fixtures/known_good/plugin.sk.ecs.hotkey.install.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.hotkey.install.x3s
@@ -1,0 +1,16 @@
+#name: plugin.sk.ecs.hotkey.install
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.hotkey.install.xml
+
+$setup = get global variable: name='plugin.ecs.setup'
+skip if  is datatyp[ $setup ] == DATATYP_ARRAY
+return null
+$hotkey.id = $setup[4]
+skip if not $hotkey.id
+return null
+$msg = sprintf: pageid=8511 textid=103, null, null, null, null, null
+$hotkey.id =  register hotkey $msg to call script plugin.sk.ecs.call.script
+$setup[4] = $hotkey.id
+set global variable: name='anarkis.ecs.setup' value=$setup
+return [TRUE]

--- a/tools/fixtures/known_good/plugin.sk.ecs.hotkey.remove.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.hotkey.remove.x3s
@@ -1,0 +1,15 @@
+#name: plugin.sk.ecs.hotkey.remove
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.hotkey.remove.xml
+
+$setup = get global variable: name='plugin.ecs.setup'
+skip if  is datatyp[ $setup ] == DATATYP_ARRAY
+return null
+$hotkey.id = $setup[4]
+skip if $hotkey.id
+return null
+unregister hotkey $hotkey.id
+$setup[4] = null
+set global variable: name='anarkis.ecs.setup' value=$setup
+return [TRUE]

--- a/tools/fixtures/known_good/plugin.sk.ecs.manager.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.manager.x3s
@@ -1,0 +1,112 @@
+#name: plugin.sk.ecs.manager
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.manager.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+
+* Retrieve ECS configuration
+$page.id = 8511
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+$ecs.installed = $ecs.setup[1]
+$ecs.configs = $ecs.setup[2]
+$status = $ecs.setup[3]
+$ecs.news = $ecs.setup[5]
+
+$res = 0
+$selected = 0
+while $res != -1
+$menu =  create custom menu array
+$st = sprintf: pageid=$page.id textid=211, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$st = sprintf: pageid=$page.id textid=213, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=-1
+if not $status
+$st = sprintf: pageid=$page.id textid=212, null, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=3
+end
+
+$st = sprintf: pageid=$page.id textid=202, null, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$cnt =  size of array $ecs.configs
+while $cnt
+dec $cnt =
+$cfg = $ecs.configs[$cnt]
+$v1 = $cfg[0]
+$v2 = get global variable: name=$v1
+if $v2
+$v2 =  read text: page=$page.id id=303
+else
+$v2 =  read text: page=$page.id id=302
+end
+$st = sprintf: pageid=$page.id textid=203, $v1, $v2, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=$v1
+end
+
+if  find $selected in array: $ecs.installed
+
+$st = sprintf: pageid=$page.id textid=204, $res, null, null, null, null
+add custom menu heading to array $menu: title=$st
+$v2 =  read text: page=$page.id id=206
+add custom menu item to array $menu: text=$v2 returnvalue=2
+
+$st =  read text: page=$page.id id=205
+add custom menu heading to array $menu: title=$st
+
+$index =  get index of $res in array $ecs.installed offset=-1 + 1
+$mycfg = $ecs.configs[$index]
+$v1 = $mycfg[1]
+$st = sprintf: pageid=$page.id textid=207, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=0
+$v1 = $mycfg[2]
+$st = sprintf: pageid=$page.id textid=208, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=0
+$v1 = $mycfg[3]
+$st = sprintf: pageid=$page.id textid=209, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=0
+$v1 = $mycfg[4]
+$st = sprintf: pageid=$page.id textid=210, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=0
+$v1 = $mycfg[5]
+$st = sprintf: pageid=$page.id textid=226, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=0
+$v1 = $mycfg[6]
+$st = sprintf: pageid=$page.id textid=227, $v1, null, null, null, null
+add custom menu item to array $menu: text=$st returnvalue=0
+
+end
+
+if $status
+$v2 =  read text: page=$page.id id=300
+else
+$v2 =  read text: page=$page.id id=301
+end
+$st = sprintf: pageid=$page.id textid=201, $v2, null, null, null, null
+add custom menu info line to array $menu: text=$st
+
+$v1 =  read text: page=$page.id id=200
+$v2 =  read text: page=$page.id id=104
+$res =  open custom menu: title=$v1 description=$v2 option array=$menu
+
+if $res == 2
+= [THIS] -> call script plugin.sk.ecs.unregister :  Plugin ID=$selected
+$selected = null
+else if $res == 3
+= [THIS] -> call script plugin.sk.ecs.hotkey.remove :
+$ecs.configs =  array alloc: size=0
+$ecs.installed =  array alloc: size=0
+$ecs.setup =  array alloc: size=0
+$ecs.news =  array alloc: size=0
+$selected = null
+set global variable: name='plugin.ecs.setup' value=null
+$st =  read text: page=$page.id id=214
+send incoming message $st to player: display it=[TRUE]
+return [TRUE]
+else if  is datatyp[ $res ] == DATATYP_STRING
+$selected = $res
+end
+
+end
+return [TRUE]

--- a/tools/fixtures/known_good/plugin.sk.ecs.news.add.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.news.add.x3s
@@ -1,0 +1,51 @@
+#name: plugin.sk.ecs.news.add
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.news.add.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* Use this function to add a news/message to the list.
+* ===========================================
+* Parameter :
+* - plugin.id : The global variable you used to register (string)
+* - news.title : News Title
+* - news.content : Main text of the news
+* - news.from : Who is sending this message (optional)
+* ===========================================
+
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+$ecs.installed = $ecs.setup[1]
+$ecs.configs = $ecs.setup[2]
+$ecs.news = $ecs.setup[5]
+
+skip if  find $plugin.id in array: $ecs.installed
+return null
+$index =  get index of $plugin.id in array $ecs.installed offset=-1 + 1
+
+$my.config = $ecs.configs[$index]
+$max.news.count = $my.config[5]
+$news.list = $ecs.news[$index]
+
+
+$my.news =  array alloc: size=4
+$my.news[0] = $news.title
+$my.news[1] = $news.content
+$my.news[2] = $news.from
+$pl.time = playing time
+$my.news[3] = $pl.time
+if $news.list
+insert $my.news into array $news.list at index 0
+else
+$news.list =  array alloc: size=1
+$news.list[0] = $my.news
+end
+
+$news.count =  size of array $news.list
+if $news.count > $max.news.count
+resize array $news.list to $max.news.count
+end
+
+
+return [TRUE]

--- a/tools/fixtures/known_good/plugin.sk.ecs.news.display.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.news.display.x3s
@@ -1,0 +1,86 @@
+#name: plugin.sk.ecs.news.display
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.news.display.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* Use this script to show the News List GUI. It will show a menu allowing the
+* player to browse the latest messages posted to news list.
+* ===========================================
+* Parameter :
+* - plugin.id : The global variable you used to register (string)
+* ===========================================
+
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+load text: id=8511
+$ecs.installed = $ecs.setup[1]
+$ecs.configs = $ecs.setup[2]
+$ecs.news = $ecs.setup[5]
+
+skip if  find $plugin.id in array: $ecs.installed
+return null
+$index =  get index of $plugin.id in array $ecs.installed offset=-1 + 1
+
+$my.config = $ecs.configs[$index]
+$max.news.count = $my.config[5]
+$bbs.title = $my.config[6]
+
+$news.list = $ecs.news[$index]
+$news.count =  size of array $news.list
+$menu.result = 0
+$selected = -1
+while $menu.result != -1
+$menu =  create custom menu array
+$string = sprintf: pageid=8511 textid=221, null, null, null, null, null
+add custom menu heading to array $menu: title=$string
+if $news.count
+$x = 0
+while $x < $news.count
+$c.news = $news.list[$x]
+$c.news.title = $c.news[0]
+$ago = $c.news[3]
+$pl.time = playing time
+$ago = $pl.time - $ago
+$ago =  format time: $ago
+$string = sprintf: pageid=8511 textid=216, $ago, $c.news.title, null, null, null
+$res = $x + 10
+add custom menu item to array $menu: text=$string returnvalue=$res
+inc $x =
+end
+else
+$string = sprintf: pageid=8511 textid=222, null, null, null, null, null
+add custom menu item to array $menu: text=$string returnvalue=-1
+end
+
+if $selected >= 0
+$c.news = $news.list[$selected]
+$c.title = $c.news[0]
+$c.content = $c.news[1]
+$c.from = $c.news[2]
+$ago = $c.news[3]
+$pl.time = playing time
+$ago = $pl.time - $ago
+$ago =  format time: $ago
+$string = sprintf: pageid=8511 textid=220, $c.title, null, null, null, null
+add custom menu info line to array $menu: text=$string
+$string = sprintf: pageid=8511 textid=218, $c.content, $ago, null, null, null
+add custom menu info line to array $menu: text=$string
+if $c.from -> exists
+$string = sprintf: pageid=8511 textid=217, $c.from, null, null, null, null
+else
+$string = null
+end
+else
+$string = sprintf: pageid=8511 textid=223, null, null, null, null, null
+add custom menu info line to array $menu: text=$string
+end
+$menu.result =  open custom menu: title=$bbs.title description=$string option array=$menu
+if $menu.result != -1
+$menu.result = $menu.result - 10
+$selected = $menu.result
+end
+end
+
+return [TRUE]

--- a/tools/fixtures/known_good/plugin.sk.ecs.news.getrandom.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.news.getrandom.x3s
@@ -1,0 +1,41 @@
+#name: plugin.sk.ecs.news.getrandom
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.news.getrandom.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* Use this function to get a random message from the list
+* ===========================================
+* Parameter :
+* - plugin.id : The global variable you used to register (string)
+* ===========================================
+* Output : Array
+* - 0 : Title
+* - 1 : Main text of the news
+* - 2 : Who is sending this message (optional)
+* - 3 : Date of publication
+* ===========================================
+
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+$ecs.installed = $ecs.setup[1]
+$ecs.configs = $ecs.setup[2]
+$ecs.news = $ecs.setup[5]
+
+skip if  find $plugin.id in array: $ecs.installed
+return null
+$index =  get index of $plugin.id in array $ecs.installed offset=-1 + 1
+
+$my.config = $ecs.configs[$index]
+$max.news.count = $my.config[5]
+$news.list = $ecs.news[$index]
+
+$mycount =  size of array $news.list
+skip if not $mycount == 0
+return null
+
+$mycount =  = random value from 0 to $mycount - 1
+$result = $news.list[$mycount]
+
+return $result

--- a/tools/fixtures/known_good/plugin.sk.ecs.register.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.register.x3s
@@ -1,0 +1,69 @@
+#name: plugin.sk.ecs.register
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.register.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* Use this function to register your plugin or script to ECS, allowing you
+* to use the ECS hotkey
+* ===========================================
+* Parameter : SETUP -> Array
+* - 00 : Global variable to check to see if your plugin is enabled (string)
+* - 01 : Script to call when the ECS key is pressed (string)
+* - 02 : Restrict ECS to objects with this local variable set to TRUE (string)
+* - 03 : Restrict ECS to this RACE (var/race)
+* - 04 : Restrict ECS to this Object Class (var/class)
+* - 05 : News Channel (null=off, else max amount of news to store)
+* - 06 : News System Name (string, can be null if not used)
+* Indexes 02, 03, 04, 05 can be null
+* As an example Pirate Guild use the following SETUP array :
+* - 00 : anarkis.pirate.plugin (will check this global)
+* - 01 : anarkis.pirate.comm (if found, it will call this script only...)
+* - 02 : anarkis.pirate (... if this local var is found)
+* - 03 : Pirates (and this is pirate owned object)
+* - 04 : null (we dont care about object class)
+* - 05 : 12 (we want to store 12 most recent news)
+* - 06 : "Pirate Guild BBS"
+* ===========================================
+* Output :
+* - null : Script registration failed
+* - TRUE : Your script has be registered to ECS
+* ===========================================
+* If a same script is re registered, previous config will be overwritten.
+* ===========================================
+
+* Check the parameter, quit if error
+skip if  is datatyp[ $setup ] == DATATYP_ARRAY
+return null
+$setup.width =  size of array $setup
+if $setup.width != 7
+resize array $setup to 7
+end
+$setup.width =  size of array $setup
+* ---
+
+$global = $setup[0]
+
+* Retrieve ECS configuration
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+$ecs.installed = $ecs.setup[1]
+$ecs.configs = $ecs.setup[2]
+$ecs.news = $ecs.setup[5]
+if  find $global in array: $ecs.installed
+* - Update if setup already found in list
+$index =  get index of $global in array $ecs.installed offset=-1 + 1
+$config.to.update = $ecs.configs[$index]
+copy array $setup index 0 ... 6 into array $config.to.update at index 0
+* - ---
+else
+* - We add the new plugin (todo: conflict check)
+append $global to array $ecs.installed
+append $setup to array $ecs.configs
+$my.news =  array alloc: size=0
+append $my.news to array $ecs.news
+* - ---
+end
+* ---
+return [TRUE]

--- a/tools/fixtures/known_good/plugin.sk.ecs.unregister.x3s
+++ b/tools/fixtures/known_good/plugin.sk.ecs.unregister.x3s
@@ -1,0 +1,32 @@
+#name: plugin.sk.ecs.unregister
+#lang: 44
+#origin_mod: ADS
+#source: mods/ADS/scripts/plugin.sk.ecs.unregister.xml
+
+* ===========================================
+* Extended Communication System 2.5
+* ===========================================
+* Use this function to remove your plugin or script from ECS
+* ===========================================
+* Parameter :
+* - plugin.id : The global variable you used to register (string)
+* ===========================================
+* Output :
+* - null : Script isn't registered
+* - TRUE : Script removed succesfully
+* ===========================================
+
+$ecs.setup = get global variable: name='plugin.ecs.setup'
+$ecs.installed = $ecs.setup[1]
+$ecs.configs = $ecs.setup[2]
+$ecs.news = $ecs.setup[5]
+
+skip if  find $plugin.id in array: $ecs.installed
+return null
+
+$index =  get index of $plugin.id in array $ecs.installed offset=-1 + 1
+remove element from array $ecs.installed at index $index
+remove element from array $ecs.configs at index $index
+remove element from array $ecs.news at index $index
+
+return [TRUE]


### PR DESCRIPTION
## Plan
- Cross-reference ADS fixtures and bring in remaining plugin.sk.ecs scripts
- Ensure README lists the full set of ADS scripts
- Run linter and tests to confirm coverage

## Changes
- Copied remaining 20 `plugin.sk.ecs.*` scripts from ADS into `tools/fixtures/known_good`
- Updated README note to mention inclusion of ECS scripts

## Test Results
- `python tools/test_x3s.py`

## Pattern List
- No new line-shape patterns were required; existing rules already covered these scripts

## Safety Checks
- Verified while-loop wait enforcement via `tools/fixtures/should_fail/missing_wait.x3s`


------
https://chatgpt.com/codex/tasks/task_e_68c6a92921348326bfb531ba6352a3a4