### PR TITLE
Add SLX init and station configuration menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.2-internal
+- Added init script to register plugin config and launch manager.
+- Implemented station configuration menu for per-ware settings.
+
 ## 0.1.1-internal
 - Added manager tick script to balance wares between stations.
 - Introduced basic status reason strings and formatter.

--- a/docs/slx/README.md
+++ b/docs/slx/README.md
@@ -12,9 +12,10 @@ It ignores NPC trading and focuses purely on balancing your own production netwo
 - Enroll a station via Plugin Config > SLX > Station Logistics.
 - Each ware can be set as **Producer**, **Consumer**, or **Store** with Min/Max/Chunk limits.
 - A manager task runs roughly every 10 seconds and transfers wares in priority order:
-  1. Producer -> Store when above Max%.
-  2. Store -> Consumer when Consumer below Min%.
-  3. Producer -> Consumer when Producer above Min% and Consumer below Max%.
-  4. Store balancing last.
+    1. Producer -> Store when above Max%.
+    2. Store -> Consumer when Consumer below Min%.
+    3. Producer -> Consumer when Producer above Min% and Consumer below Max%.
+    4. Store balancing last.
 - Transfers occur instantly without ships and respect each station's limits.
+- The station menu displays the last transfer reason for each ware.
 

--- a/src/scripts/plugin.slx.init.x3s
+++ b/src/scripts/plugin.slx.init.x3s
@@ -3,5 +3,18 @@
 * DESCRIPTION: Initialize SLX and start core tasks
 * AUTHOR:      Brandon              DATE: 8 September 2025
 * ******************************************************************************
+$PageId = 89055
+load text: id=$PageId
+
+$section = read text: page=$PageId id=101
+$txt = read text: page=$PageId id=102
+
+add custom menu item to plugin config: heading=$section text=$txt script='plugin.slx.station.menu'
+
+$running = get global variable: name='g.slx.manager.running'
+if not $running
+  START [THIS] -> call script plugin.slx.manager.tick :
+  set global variable: name='g.slx.manager.running' value=[TRUE]
+end
 
 return null

--- a/src/scripts/plugin.slx.station.menu.x3s
+++ b/src/scripts/plugin.slx.station.menu.x3s
@@ -3,5 +3,68 @@
 * DESCRIPTION: Station configuration menu for SLX
 * AUTHOR:      Brandon              DATE: 8 September 2025
 * ******************************************************************************
+$station = argument 1
+$PageId = 89055
+
+if not $station
+  $prompt = read text: page=$PageId id=209
+  $station = null  ->  get user input: type=Var/Ship/Station owned by Player, title=$prompt
+end
+if not $station
+  return null
+end
+
+while [TRUE]
+  $title = read text: page=$PageId id=101
+  $menu = = create custom menu array: heading=$title
+  $wares = $station -> get tradeable ware array from station
+  $wcount = size of array $wares
+  while $wcount
+    dec $wcount =
+    $ware = $wares[$wcount]
+    $cfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$station, ware=$ware
+    $last = $station -> get local variable: name='slx.ware.last_reason'
+    $code = $last[$ware]
+    $reason = call script 'lib.slx.ui' : function='FormatReason', code=$code
+    $row = = sprintf: pageid=$PageId textid=214, $ware, $cfg['role'], $cfg['min_pct'], $cfg['max_pct'], $cfg['chunk_pct'], $reason
+    add custom menu item to array $menu: text=$row returnvalue=$ware
+    = wait 1 ms
+  end
+  add section to custom menu: $menu
+  $exit = read text: page=$PageId id=208
+  add custom menu item to array $menu: text=$exit returnvalue=null
+  $sel = open custom menu: title=$title description=null option array=$menu
+  if not $sel
+    break
+  end
+  $cfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$station, ware=$sel
+  $txtRole = read text: page=$PageId id=210
+  $role = null  ->  get user input: type=Var/String, title=$txtRole
+  if not $role
+    $role = $cfg['role']
+  end
+  $txtMin = read text: page=$PageId id=211
+  $min = null  ->  get user input: type=Var/Number, title=$txtMin
+  if not $min
+    $min = $cfg['min_pct']
+  end
+  $txtMax = read text: page=$PageId id=212
+  $max = null  ->  get user input: type=Var/Number, title=$txtMax
+  if not $max
+    $max = $cfg['max_pct']
+  end
+  $txtChunk = read text: page=$PageId id=213
+  $chunk = null  ->  get user input: type=Var/Number, title=$txtChunk
+  if not $chunk
+    $chunk = $cfg['chunk_pct']
+  end
+  $new = array alloc: size=0
+  $new['role'] = $role
+  $new['min_pct'] = $min
+  $new['max_pct'] = $max
+  $new['chunk_pct'] = $chunk
+  call script 'lib.slx.query' : function='SetStationWareConfig', station=$station, ware=$sel, map=$new
+  = wait 1 ms
+end
 
 return null

--- a/t/89055-L044.xml
+++ b/t/89055-L044.xml
@@ -10,5 +10,12 @@
     <t id="205">Exported to consumer</t>
     <t id="206">Imported from store</t>
     <t id="207">Imported from producer</t>
+    <t id="208">Exit</t>
+    <t id="209">Select Station</t>
+    <t id="210">Role (producer|consumer|store|auto)</t>
+    <t id="211">Min %</t>
+    <t id="212">Max %</t>
+    <t id="213">Chunk %</t>
+    <t id="214">%s | %s %s %s %s %s</t>
   </page>
 </language>


### PR DESCRIPTION
## Summary
- Register SLX with the plugin config and ensure the logistics manager task runs
- Provide an in-game station menu to edit per-ware roles and limits
- Document station menu and add text resources

## Testing
- `python tools/test_x3s.py`

------
https://chatgpt.com/codex/tasks/task_e_68c71892558083269087c06c48050429