### PR TITLE
feat: add station enrollment toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.3-internal
+- Added station enrollment toggle with default ware settings.
+- Fixed menu row formatting for per-ware display.
+
 ## 0.1.2-internal
 - Added init script to register plugin config and launch manager.
 - Implemented station configuration menu for per-ware settings.

--- a/src/scripts/plugin.slx.station.menu.x3s
+++ b/src/scripts/plugin.slx.station.menu.x3s
@@ -16,7 +16,15 @@ end
 
 while [TRUE]
   $title = read text: page=$PageId id=101
-  $menu = = create custom menu array: heading=$title
+  $menu = create custom menu array: heading=$title
+  $enrolled = $station -> get local variable: name='slx.enrolled'
+  if $enrolled
+    $toggle = read text: page=$PageId id=216
+  else
+    $toggle = read text: page=$PageId id=215
+  end
+  add custom menu item to array $menu: text=$toggle returnvalue='toggle'
+  add section to custom menu: $menu
   $wares = $station -> get tradeable ware array from station
   $wcount = size of array $wares
   while $wcount
@@ -26,7 +34,7 @@ while [TRUE]
     $last = $station -> get local variable: name='slx.ware.last_reason'
     $code = $last[$ware]
     $reason = call script 'lib.slx.ui' : function='FormatReason', code=$code
-    $row = = sprintf: pageid=$PageId textid=214, $ware, $cfg['role'], $cfg['min_pct'], $cfg['max_pct'], $cfg['chunk_pct'], $reason
+    $row = sprintf: pageid=$PageId textid=214, $ware, $cfg['role'], $cfg['min_pct'], $cfg['max_pct'], $cfg['chunk_pct'], $reason
     add custom menu item to array $menu: text=$row returnvalue=$ware
     = wait 1 ms
   end
@@ -36,6 +44,27 @@ while [TRUE]
   $sel = open custom menu: title=$title description=null option array=$menu
   if not $sel
     break
+  end
+  if $sel == 'toggle'
+    if $enrolled
+      $station -> set local variable: name='slx.enrolled' value=null
+    else
+      $station -> set local variable: name='slx.enrolled' value=[TRUE]
+      $def = array alloc: size=0
+      $def['role'] = 'auto'
+      $def['min_pct'] = 10
+      $def['max_pct'] = 90
+      $def['chunk_pct'] = 20
+      $all = $station -> get tradeable ware array from station
+      $idx = size of array $all
+      while $idx
+        dec $idx
+        $w = $all[$idx]
+        call script 'lib.slx.query' : function='SetStationWareConfig', station=$station, ware=$w, map=$def
+        = wait 1 ms
+      end
+    end
+    continue
   end
   $cfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$station, ware=$sel
   $txtRole = read text: page=$PageId id=210

--- a/t/89055-L044.xml
+++ b/t/89055-L044.xml
@@ -17,5 +17,7 @@
     <t id="212">Max %</t>
     <t id="213">Chunk %</t>
     <t id="214">%s | %s %s %s %s %s</t>
+    <t id="215">Enroll Station</t>
+    <t id="216">Unenroll Station</t>
   </page>
 </language>


### PR DESCRIPTION
## Summary
- add enroll/unenroll option to station menu with default ware config
- fix menu row formatting and expose new text strings

## Testing
- `python tools/test_x3s.py`


------
https://chatgpt.com/codex/tasks/task_e_68c71b273030832699d059f846640399