### PR TITLE
Loop manager tick at 10s intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.4-internal
+- Manager tick now runs continuously every ~10 seconds.
+
 ## 0.1.3-internal
 - Added station enrollment toggle with default ware settings.
 - Fixed menu row formatting for per-ware display.

--- a/src/scripts/plugin.slx.manager.tick.x3s
+++ b/src/scripts/plugin.slx.manager.tick.x3s
@@ -4,31 +4,34 @@
 * AUTHOR:      Brandon              DATE: 8 September 2025
 * ******************************************************************************
 
-$stations = call script 'lib.slx.query' : function='ListEnrolledStations'
-$scount = size of array $stations
-while $scount
-  dec $scount
-  $st = $stations[$scount]
-  $wares = $st -> get tradeable ware array from station
-  $wcount = size of array $wares
-  while $wcount
-    dec $wcount
-    $ware = $wares[$wcount]
-    $cfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$st, ware=$ware
-    $role = $cfg['role']
-    if not $role
-      continue
-    end
-    $pct = call script 'lib.slx.query' : function='GetStationWarePct', station=$st, ware=$ware
-    if $role == 'producer'
-      gosub ProducerLoop
-    end
-    if $role == 'consumer'
-      gosub ConsumerLoop
+while [TRUE]
+  $stations = call script 'lib.slx.query' : function='ListEnrolledStations'
+  $scount = size of array $stations
+  while $scount
+    dec $scount
+    $st = $stations[$scount]
+    $wares = $st -> get tradeable ware array from station
+    $wcount = size of array $wares
+    while $wcount
+      dec $wcount
+      $ware = $wares[$wcount]
+      $cfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$st, ware=$ware
+      $role = $cfg['role']
+      if not $role
+        continue
+      end
+      $pct = call script 'lib.slx.query' : function='GetStationWarePct', station=$st, ware=$ware
+      if $role == 'producer'
+        gosub ProducerLoop
+      end
+      if $role == 'consumer'
+        gosub ConsumerLoop
+      end
+      = wait 1 ms
     end
     = wait 1 ms
   end
-  = wait 1 ms
+  = wait 10000 ms
 end
 
 return null


### PR DESCRIPTION
## Summary
- Run manager tick in a continuous loop with a 10s wait to keep logistics active
- Document change in the changelog

## Testing
- `python tools/test_x3s.py`

------
https://chatgpt.com/codex/tasks/task_e_68c71e6d80e48326a3746548c59b224c