### PR TITLE
Remove unused Wares call from setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.5-internal
+- Removed unused call to nonexistent `plugin.slx.Wares` from setup script.
+
 ## 0.1.4-internal
 - Manager tick now runs continuously every ~10 seconds.
 

--- a/src/scripts/setup.plugin.slx.x3s
+++ b/src/scripts/setup.plugin.slx.x3s
@@ -56,8 +56,6 @@ $st = array alloc: size=0
 set global variable: name='slx.stations' value=$st
 end
 
-= [THIS]-> call script 'plugin.slx.Wares' : argument1=null
-
 * Register AL plugin for SLX
 al engine: register script='al.plugin.slx'
 al engine: set plugin 'al.plugin.slx' description to 'SLX Station Logistics'


### PR DESCRIPTION
## Summary
- drop stray call to missing `plugin.slx.Wares` from setup script
- document removal in changelog

## Testing
- `python tools/test_x3s.py`


------
https://chatgpt.com/codex/tasks/task_e_68c72d85e7a483268b9ef6376bfd2ca1