### PR TITLE
Add reason codes for store balancing and filled-to-max events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.5-internal
+- Added reason codes for store balancing and filled-to-max events with supporting text.
+- Transfer logic now sets these codes when moves exhaust headroom or balance stores.
+
 ## 0.1.4-internal
 - Manager tick now runs continuously every ~10 seconds.
 

--- a/docs/ids.md
+++ b/docs/ids.md
@@ -3,4 +3,6 @@
 | Type | ID | Notes |
 |------|----|-------|
 | Text Page | 89055 | Core SLX strings |
+| Text ID | 203 | Filled to Max reason |
+| Text ID | 217 | Store balanced reason |
 

--- a/src/scripts/lib.slx.ui.x3s
+++ b/src/scripts/lib.slx.ui.x3s
@@ -36,6 +36,10 @@ if $fn == 'FormatReason'
     $txt = read text: page=$page id=207
     return $txt
   end
+  if $code == 'S_BAL'
+    $txt = read text: page=$page id=217
+    return $txt
+  end
   $txt = ''
   return $txt
 end

--- a/src/scripts/plugin.slx.manager.tick.x3s
+++ b/src/scripts/plugin.slx.manager.tick.x3s
@@ -77,8 +77,18 @@ ProducerLoop:
         $ok = call script 'lib.slx.transfer' : function='CanMove', src=$st, dst=$dst, ware=$ware, amount=$amt
         if $ok
           call script 'lib.slx.transfer' : function='ApplyMove', src=$st, dst=$dst, ware=$ware, amount=$amt
-          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text='P2S'
-          call script 'lib.slx.query' : function='SetLastReason', station=$dst, ware=$ware, text='P2S_RECV'
+          if $amt == $available
+            $srcCode = 'S_BAL'
+          else
+            $srcCode = 'P2S'
+          end
+          if $amt == $room
+            $dstCode = 'FILLED_MAX'
+          else
+            $dstCode = 'P2S_RECV'
+          end
+          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$srcCode
+          call script 'lib.slx.query' : function='SetLastReason', station=$dst, ware=$ware, text=$dstCode
         else
           call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text='NO_STORE'
         end
@@ -128,8 +138,18 @@ ProducerLoop:
         $ok = call script 'lib.slx.transfer' : function='CanMove', src=$st, dst=$dst, ware=$ware, amount=$amt
         if $ok
           call script 'lib.slx.transfer' : function='ApplyMove', src=$st, dst=$dst, ware=$ware, amount=$amt
-          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text='P2C'
-          call script 'lib.slx.query' : function='SetLastReason', station=$dst, ware=$ware, text='P2C'
+          if $amt == $available
+            $srcCode = 'S_BAL'
+          else
+            $srcCode = 'P2C'
+          end
+          if $amt == $room
+            $dstCode = 'FILLED_MAX'
+          else
+            $dstCode = 'P2C'
+          end
+          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$srcCode
+          call script 'lib.slx.query' : function='SetLastReason', station=$dst, ware=$ware, text=$dstCode
         else
           call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text='AT_MIN'
         end
@@ -185,8 +205,18 @@ ConsumerLoop:
         $ok = call script 'lib.slx.transfer' : function='CanMove', src=$src, dst=$st, ware=$ware, amount=$amt
         if $ok
           call script 'lib.slx.transfer' : function='ApplyMove', src=$src, dst=$st, ware=$ware, amount=$amt
-          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text='S2C'
-          call script 'lib.slx.query' : function='SetLastReason', station=$src, ware=$ware, text='S2C'
+          if $amt == $room
+            $dstCode = 'FILLED_MAX'
+          else
+            $dstCode = 'S2C'
+          end
+          if $amt == $available
+            $srcCode = 'S_BAL'
+          else
+            $srcCode = 'S2C'
+          end
+          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$dstCode
+          call script 'lib.slx.query' : function='SetLastReason', station=$src, ware=$ware, text=$srcCode
         else
           call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text='NO_STORE'
         end

--- a/t/89055-L044.xml
+++ b/t/89055-L044.xml
@@ -19,5 +19,6 @@
     <t id="214">%s | %s %s %s %s %s</t>
     <t id="215">Enroll Station</t>
     <t id="216">Unenroll Station</t>
+    <t id="217">Store balanced</t>
   </page>
 </language>


### PR DESCRIPTION
## Summary
- add UI formatter support for `FILLED_MAX` and new `S_BAL` reason codes
- adjust manager tick transfers to set codes when balancing or filling to max
- document new text IDs

## Testing
- `python tools/test_x3s.py`

------
https://chatgpt.com/codex/tasks/task_e_68c72d86d6c08326bd402c9e6933aec0