### PR TITLE
lint: flag positional arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.8-internal
+- Linter now rejects positional argument syntax and scripts use named parameters.
+
 ## 0.1.7-internal
 - Added overview section to SLX README for clarity.
 

--- a/src/scripts/lib.slx.query.x3s
+++ b/src/scripts/lib.slx.query.x3s
@@ -3,9 +3,8 @@
 * DESCRIPTION: Query helpers for SLX
 * AUTHOR:      Brandon              DATE: 8 September 2025
 * ******************************************************************************
-$fn = argument 1
 
-if $fn == 'ListEnrolledStations'
+if $function == 'ListEnrolledStations'
   $result = array alloc: size=0
   $all = get station array: of race=Player
   $count = size of array $all
@@ -20,9 +19,7 @@ if $fn == 'ListEnrolledStations'
   return $result
 end
 
-if $fn == 'GetStationWarePct'
-  $station = argument 2
-  $ware = argument 3
+if $function == 'GetStationWarePct'
   $amt = $station -> get amount of ware $ware in cargo bay
   $cap = $station -> get max amount of ware $ware that can be stored in cargo bay
   if $cap <= 0
@@ -32,15 +29,12 @@ if $fn == 'GetStationWarePct'
   return $pct
 end
 
-if $fn == 'GetSector'
-  $station = argument 2
+if $function == 'GetSector'
   $sec = $station -> get sector
   return $sec
 end
 
-if $fn == 'GetStationWareConfig'
-  $station = argument 2
-  $ware = argument 3
+if $function == 'GetStationWareConfig'
   $roleArr = $station -> get local variable: name='slx.ware.role'
   $minArr = $station -> get local variable: name='slx.ware.min_pct'
   $maxArr = $station -> get local variable: name='slx.ware.max_pct'
@@ -53,44 +47,38 @@ if $fn == 'GetStationWareConfig'
   return $cfg
 end
 
-if $fn == 'SetStationWareConfig'
-  $station = argument 2
-  $ware = argument 3
-  $cfg = argument 4
+if $function == 'SetStationWareConfig'
   $roleArr = $station -> get local variable: name='slx.ware.role'
   if not $roleArr
     $roleArr = array alloc: size=0
   end
-  $roleArr[$ware] = $cfg['role']
+  $roleArr[$ware] = $map['role']
   $station -> set local variable: name='slx.ware.role' value=$roleArr
 
   $minArr = $station -> get local variable: name='slx.ware.min_pct'
   if not $minArr
     $minArr = array alloc: size=0
   end
-  $minArr[$ware] = $cfg['min_pct']
+  $minArr[$ware] = $map['min_pct']
   $station -> set local variable: name='slx.ware.min_pct' value=$minArr
 
   $maxArr = $station -> get local variable: name='slx.ware.max_pct'
   if not $maxArr
     $maxArr = array alloc: size=0
   end
-  $maxArr[$ware] = $cfg['max_pct']
+  $maxArr[$ware] = $map['max_pct']
   $station -> set local variable: name='slx.ware.max_pct' value=$maxArr
 
   $chunkArr = $station -> get local variable: name='slx.ware.chunk_pct'
   if not $chunkArr
     $chunkArr = array alloc: size=0
   end
-  $chunkArr[$ware] = $cfg['chunk_pct']
+  $chunkArr[$ware] = $map['chunk_pct']
   $station -> set local variable: name='slx.ware.chunk_pct' value=$chunkArr
   return null
 end
 
-if $fn == 'SetLastReason'
-  $station = argument 2
-  $ware = argument 3
-  $text = argument 4
+if $function == 'SetLastReason'
   $arr = $station -> get local variable: name='slx.ware.last_reason'
   if not $arr
     $arr = array alloc: size=0

--- a/src/scripts/lib.slx.transfer.x3s
+++ b/src/scripts/lib.slx.transfer.x3s
@@ -3,21 +3,16 @@
 * DESCRIPTION: Ware transfer helpers for SLX
 * AUTHOR:      Brandon              DATE: 8 September 2025
 * ******************************************************************************
-$fn = argument 1
 
-if $fn == 'CanMove'
-  $src = argument 2
-  $dst = argument 3
-  $ware = argument 4
-  $amt = argument 5
+if $function == 'CanMove'
   $srcAmt = $src -> get amount of ware $ware in cargo bay
   $srcCap = $src -> get max amount of ware $ware that can be stored in cargo bay
   $dstAmt = $dst -> get amount of ware $ware in cargo bay
   $dstCap = $dst -> get max amount of ware $ware that can be stored in cargo bay
   $srcCfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$src, ware=$ware
   $dstCfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$dst, ware=$ware
-  $srcNew = ($srcAmt - $amt) * 100 / $srcCap
-  $dstNew = ($dstAmt + $amt) * 100 / $dstCap
+  $srcNew = ($srcAmt - $amount) * 100 / $srcCap
+  $dstNew = ($dstAmt + $amount) * 100 / $dstCap
   if $srcNew < $srcCfg['min_pct']
     return [FALSE]
   end
@@ -27,13 +22,9 @@ if $fn == 'CanMove'
   return [TRUE]
 end
 
-if $fn == 'ApplyMove'
-  $src = argument 2
-  $dst = argument 3
-  $ware = argument 4
-  $amt = argument 5
-  = $src -> add -$amt units of $ware
-  = $dst -> add $amt units of $ware
+if $function == 'ApplyMove'
+  = $src -> add -$amount units of $ware
+  = $dst -> add $amount units of $ware
   return null
 end
 

--- a/src/scripts/lib.slx.ui.x3s
+++ b/src/scripts/lib.slx.ui.x3s
@@ -3,10 +3,8 @@
 * DESCRIPTION: UI helpers for SLX
 * AUTHOR:      Brandon              DATE: 8 September 2025
 * ******************************************************************************
-$fn = argument 1
 
-if $fn == 'FormatReason'
-  $code = argument 2
+if $function == 'FormatReason'
   $page = 89055
   * auto roles use same text as base codes
   if $code == 'A_AT_MIN'

--- a/src/scripts/lib.slx.util.x3s
+++ b/src/scripts/lib.slx.util.x3s
@@ -3,11 +3,8 @@
 * DESCRIPTION: Utility helpers for SLX
 * AUTHOR:      Brandon              DATE: 8 September 2025
 * ******************************************************************************
-$fn = argument 1
 
-if $fn == 'Min'
-  $a = argument 2
-  $b = argument 3
+if $function == 'Min'
   if $a < $b
     return $a
   else
@@ -15,9 +12,7 @@ if $fn == 'Min'
   end
 end
 
-if $fn == 'Max'
-  $a = argument 2
-  $b = argument 3
+if $function == 'Max'
   if $a > $b
     return $a
   else
@@ -25,9 +20,7 @@ if $fn == 'Max'
   end
 end
 
-if $fn == 'SafeDiv'
-  $num = argument 2
-  $den = argument 3
+if $function == 'SafeDiv'
   if $den <= 0
     return 0
   else
@@ -36,9 +29,7 @@ if $fn == 'SafeDiv'
   end
 end
 
-if $fn == 'Percent'
-  $part = argument 2
-  $whole = argument 3
+if $function == 'Percent'
   if $whole <= 0
     return 0
   end

--- a/src/scripts/plugin.slx.station.menu.x3s
+++ b/src/scripts/plugin.slx.station.menu.x3s
@@ -3,7 +3,6 @@
 * DESCRIPTION: Station configuration menu for SLX
 * AUTHOR:      Brandon              DATE: 8 September 2025
 * ******************************************************************************
-$station = argument 1
 $PageId = 89055
 
 if not $station

--- a/tools/fixtures/should_fail/bad_argument.x3s
+++ b/tools/fixtures/should_fail/bad_argument.x3s
@@ -1,0 +1,3 @@
+* Demonstrates invalid positional argument syntax
+$fn = argument 1
+return null

--- a/tools/x3s_lint.py
+++ b/tools/x3s_lint.py
@@ -159,6 +159,10 @@ def lint_file(path: Path, patterns: list[Rule] | None = None) -> list[str]:
           b.has_progress = True
           break
 
+    # disallow positional argument references like "argument 1"
+    if re.search(r"\bargument\s+\d+\b", low):
+      errors.append(f"{path.name}:{ln}: use named arguments instead of 'argument n'")
+
     # line-shape validation (warn on unknown shapes)
     recognizable = any(pat.regex.match(line.strip()) for pat in patterns)
     if not recognizable and not (re.match(r'^if\b', low) or re.match(r'^else\s+if\b', low) or low == "else" or low == "end" or re.match(r'^while\b', low)):


### PR DESCRIPTION
## Summary
- reject `$fn = argument 1` syntax in x3s linter
- migrate SLX scripts to named parameters
- add fixture demonstrating invalid positional argument usage

## Testing
- `python tools/test_x3s.py`


------
https://chatgpt.com/codex/tasks/task_e_68c739aa5f308326bf3402da5a3d9867