### PR TITLE
docs: add macro command reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.1.8-internal
+- Added macro commands documentation.
 - Linter now rejects positional argument syntax and scripts use named parameters.
 - Fixed remaining positional-style references in ware config query.
 - Enforced numeric array indexing for ware configs and linter rejects string keys.

--- a/docs/macro-commands.md
+++ b/docs/macro-commands.md
@@ -1,0 +1,11 @@
+# Macro Commands
+
+This reference lists macro commands available in X3TC scripting.
+
+- `add custom menu heading to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
+- `add custom menu info line to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
+- `add custom menu item to array <Var/Array>: page=<Var/Number1> id=<Var/Number2> returnvalue=<Value>`
+- `dim <Var/Array> = <Value> [, <Value> ] [, <Value> ] ... [, <Value> ]`
+- `for <Var> = <Var/Number1> to <Var/Number2> step <Number>`
+- `for each <Var> in array <Var/Array>`
+- `for each <Var1> in array <Var/Array> using counter <Var2>`


### PR DESCRIPTION
## Plan
- Document macro commands for menus and loops
- Note addition in changelog

## Testing
- `python tools/test_x3s.py`

## Checklist
- [x] Added macro command documentation
- [x] Updated changelog


------
https://chatgpt.com/codex/tasks/task_e_68c74cd8358083269500f05c4619a0cf