### PR TITLE
docs: add array commands reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Linter now rejects positional argument syntax and scripts use named parameters.
 - Fixed remaining positional-style references in ware config query.
 - Enforced numeric array indexing for ware configs and linter rejects string keys.
+- Documented array commands.
 
 ## 0.1.7-internal
 - Added overview section to SLX README for clarity.

--- a/docs/array-commands.md
+++ b/docs/array-commands.md
@@ -1,0 +1,25 @@
+# Array Commands
+
+This reference lists array commands available in X3TC scripting.
+
+- `<RetVar/IF> = <Var/Array>[<Var/Number>]`
+- `<RetVar/IF> = <Var/Array>[<Var/Number1>][<Var/Number2>]`
+- `<Var/Array>[<Var/Number1>][<Var/Number2>] = <Value>`
+- `<Var/Array>[<Var/Number>] = <Value>`
+- `<Var/Array1>[<Var/Number1>] = <Var/Array2>[<Var/Number2>]`
+- `append <Value> to array <Var/Array>`
+- `<RetVar> array alloc: size=<Var/Number>`
+- `<RetVar/IF> arrays <Value1> and <Value2> are equal`
+- `<RetVar> clone array <Var/Array> : index <Var/Number1> ... <Var/Number2>`
+- `copy array <Var/Array1> index <Var/Number1> ... <Var/Number2> into array <Var/Array2> at index <Var/Number3>`
+- `<RetVar> create new array, arguments=<Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
+- `<RetVar/IF> find <Value> in array: <Value>`
+- `<RetVar> get index of <Value> in array <Var/Array> offset=<Var/Number>`
+- `<RetVar/IF> <RefObj> get object name array`
+- `insert <Value> into array <Var/Array> at index <Var/Number>`
+- `remove element from array <Var/Array> at index <Var/Number>`
+- `resize array <Var/Array> to <Var/Number>`
+- `<RetVar/IF> reverse array <Value>`
+- `<RetVar/IF> size of array <Var/Array>`
+- `<RetVar> sort array <Value>`
+- `<RetVar> sort array: data=<Value> sort values=<Value>`


### PR DESCRIPTION
## Summary
- document array commands for X3TC scripting
- note array docs in changelog

## Testing
- `python tools/test_x3s.py`


------
https://chatgpt.com/codex/tasks/task_e_68c74cc4d7dc83269ba51f877aff0df7