### PR TITLE
docs: add marine command reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.9-internal
+- Added marine commands documentation.
+
 ## 0.1.8-internal
 - Linter now rejects positional argument syntax and scripts use named parameters.
 - Fixed remaining positional-style references in ware config query.

--- a/docs/Marine Commands.md
+++ b/docs/Marine Commands.md
@@ -1,0 +1,30 @@
+# Marine Commands
+
+This reference covers marine-related commands available in X3TC scripting. Each entry shows the basic syntax.
+
+- `<RetVar/IF> <RefObj> add marine <value> to attack group on ship`
+- `<RefObj> create marine from passenger: fighting=<Var/Number0> hacking=<Var/Number1> mechanical=<Var/Number2> engineering=<Var/Number3>`
+- `<RetVar/IF> <RefObj> free space for marines`
+- `<RetVar/IF> <RefObj> get hacking security level`
+- `<RetVar/IF> <RefObj> get incoming marines`
+- `<RetVar/IF> <RefObj> get marine buy price`
+- `<RetVar/IF> <RefObj> get marine engineering skill`
+- `<RetVar/IF> <RefObj> get marine fighting skill`
+- `<RetVar/IF> <RefObj> get marine hacking skill`
+- `<RetVar/IF> <RefObj> get marine mechanical skill`
+- `<RetVar/IF> <RefObj> get marine overall skill`
+- `<RetVar/IF> <RefObj> get marines array`
+- `<RetVar/IF> <RefObj> get maximum number of marines`
+- `<RetVar/IF> <RefObj> get number of decks on ship`
+- `<RetVar/IF> <RefObj> get number of marines attacking`
+- `<RetVar/IF> <RefObj> get number of marines can board`
+- `<RetVar/IF> <RefObj> get ship boarding defence level`
+- `<RetVar/IF> is marine: passenger/astronaut=<Var/Passenger>`
+- `<RetVar/IF> <RefObj> move marine to board: <value>, timeout=<value>`
+- `<RetVar/IF> <RefObj> send marines to board ship: <Var/Ship> marines=<value>`
+- `<RefObj> set marine skill: engineering=<Var/Number>`
+- `<RefObj> set marine skill: fighting=<Var/Number>`
+- `<RefObj> set marine skill: hacking=<Var/Number>`
+- `<RefObj> set marine skill: mechanical=<Var/Number>`
+- `<RefObj> stop incoming marines`
+- `<RefObj> train passenger to marine`


### PR DESCRIPTION
## Summary
- add documentation for marine-related script commands

## Testing
- `python tools/test_x3s.py`


------
https://chatgpt.com/codex/tasks/task_e_68c74cee1b9c8326aac091424fecc655