### PR TITLE
docs: add math commands reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.9-internal
+- Added math commands reference.
+
 ## 0.1.8-internal
 - Linter now rejects positional argument syntax and scripts use named parameters.
 - Fixed remaining positional-style references in ware config query.

--- a/docs/math-commands.md
+++ b/docs/math-commands.md
@@ -1,0 +1,12 @@
+# Math Commands
+
+This reference lists math operations and random number commands in X3TC scripting. Each entry shows the basic syntax.
+
+- `dec <Var>`
+- `<RetVar> fixed cos <Var/Number>`
+- `<RetVar> fixed sin <Var/Number>`
+- `<RetVar> get maximum, <Var/Number0>, <Var/Number1>, <Var/Number2>, <Var/Number3>, <Var/Number4>`
+- `inc <Var>`
+- `<RetVar> random value between <Var/Number1> and <Var/Number2>`
+- `<RetVar/IF> random value from zero to <Var/Number>`
+- `<RetVar> square root of <Var/Number>`


### PR DESCRIPTION
## Summary
- add math operations and random number command reference
- record addition in changelog

## Testing
- `python tools/test_x3s.py`


------
https://chatgpt.com/codex/tasks/task_e_68c74cfe53408326a218405e4b232353