### PR TITLE
docs: add merchant commands reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.9-internal
+- Document merchant commands.
+
 ## 0.1.8-internal
 - Linter now rejects positional argument syntax and scripts use named parameters.
 - Fixed remaining positional-style references in ware config query.

--- a/docs/Merchant Commands.md
+++ b/docs/Merchant Commands.md
@@ -1,0 +1,19 @@
+# Merchant Commands
+
+This reference covers merchant-related commands available in X3TC scripting. Each entry shows the basic syntax.
+
+- `<RefObj> add merchant name=<Var/String> wanted wares=<Var/Array> owned wares=<Var/Array> cash=<Var/Number> rank=<Var/Number>`
+- `<RetVar> get data for merchant <Var/String> : item number=<Var/Number>`
+- `<RetVar> <RefObj> get merchants`
+- `merchant <Var/String> got ware <Var/Ware> : quantity=<Var/Number>`
+- `merchant <Var/String> sold ware <Var/Ware> : quantity=<Var/Number>`
+- `remove merchant <Var/String>`
+- `reset merchant <Var/String> expiry`
+- `<RefObj> trademaster: add trader=<Value> to dock as merchant`
+- `<RetVar> trademaster: is <Value> a trader`
+- `<RetVar> trademaster: is trader=<Value> a merchant`
+- `trademaster: remove trader=<Value> from dock`
+- `<RetVar> trademaster order: find and register order for <Var/Ware>`
+- `trademaster order: trader=<Value> delivery aborted`
+- `trademaster order: trader=<Value> delivery of amount=<Var/Ware> successful`
+


### PR DESCRIPTION
## Summary
- document merchant and Trademaster commands
- record merchant command doc in changelog

## Testing
- `python tools/test_x3s.py`

------
https://chatgpt.com/codex/tasks/task_e_68c74d10eee88326bed9ea61e903f580