### PR TITLE
docs: add NPC command reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.9-internal
+- Document NPC commands for reference.
+
 ## 0.1.8-internal
 - Linter now rejects positional argument syntax and scripts use named parameters.
 - Fixed remaining positional-style references in ware config query.

--- a/docs/non-player-character-commands.md
+++ b/docs/non-player-character-commands.md
@@ -1,0 +1,14 @@
+# Non-Player Character Commands
+
+This reference lists commands for interacting with non-player characters in X3TC scripting.
+
+- `<RetVar> <RefObj> get NPC fleet`
+- `<RetVar> <RefObj> get NPC personal ship`
+- `<RetVar> get random NPC`
+- `<RetVar> <RefObj> NPC is aggressive`
+- `<RefObj> NPC send voice message: id=<Var/Number>`
+- `<RefObj> NPC wants to bail`
+- `<RefObj> release NPC`
+- `<RefObj> release NPC personal ship`
+- `<RefObj> spawn NPC fleet: rank=<Var/Number>`
+- `<RefObj> spawn NPC personal ship: rank=<Var/Number>`


### PR DESCRIPTION
## Summary
- document commands for interacting with NPCs
- note addition in changelog

## Testing
- `python tools/test_x3s.py`


------
https://chatgpt.com/codex/tasks/task_e_68c74d27258083269e0f026b4e28e7eb