### PR TITLE
docs: add object action command reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.9-internal
+- Added object action command reference.
+
 ## 0.1.8-internal
 - Linter now rejects positional argument syntax and scripts use named parameters.
 - Fixed remaining positional-style references in ware config query.

--- a/docs/object-action-commands.md
+++ b/docs/object-action-commands.md
@@ -1,0 +1,13 @@
+# Object Action Commands
+
+This reference lists object-related action commands available in X3TC scripting. Each entry shows the basic syntax.
+
+- `<RefObj> add lasers per value=<Var/Number> flags=<Var/Number>`
+- `<RefObj> add shields per value=<Var/Number>`
+- `<RefObj> destroy object: killer=<value>, show no explosion=<Var/Number>`
+- `<RefObj> destruct: show no explosion=<Var/Number>`
+- `<RefObj> force position: x=<Var/Number> y=<Var/Number> z=<Var/Number>`
+- `<RefObj> put into environment <RefObj>`
+- `<RefObj> send signal <Object Signal> : arg1=<value>, arg2=<value>, arg3=<value>, arg4=<value>`
+- `<RefObj> set command: <Object Command> target=<value> target2=<value> par1=<value> par2=<value>`
+


### PR DESCRIPTION
## Summary
- document object action scripting commands
- note the new reference in the changelog

## Testing
- `python tools/test_x3s.py`


------
https://chatgpt.com/codex/tasks/task_e_68c74d3dc22c83268ecdae1f58951a2e