### PR TITLE
fix: specify station class in query helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.9-internal
+- Clarified required station array syntax and fixed query helper to include class and wrapped race.
+- Added lint rule for station array queries and consolidated language guide.
+- Documented script object races in a dedicated reference file.
+- Enforced `dec <var>` syntax, added option-based lint rules, and removed redundant ship array rule.
+- Restricted station array rule to known races and station classes and added station class reference.
+
 ## 0.1.8-internal
 - Linter now rejects positional argument syntax and scripts use named parameters.
 - Fixed remaining positional-style references in ware config query.

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -2,10 +2,14 @@
 
 ## Rules
 - Arrays can only be indexed by numbers or numeric variables. String keys like $arr['foo'] are invalid.
+- Script object constants (such as races or station classes) must be wrapped in square brackets, e.g., `get station array: of race [Player] class/type=[Station]`.
+- See `x3s-races.md` for valid races and `x3s-stations.md` for station classes.
 
-## New Statements Recognized
+## Statements
+Placeholders like `<var>` denote a variable.
+
 - **write.log**: `write to log file $DebugID append=[FALSE] value=$txt`
-- **dec**: `dec $s`
+- **dec**: `dec <var>`
 - **remove.array.elem**: `remove element from array $config.Array at index $s`
 - **skip.if**: `skip if $section`
 - **al.description.var**: `al engine: set plugin $al.PluginID description to $plugin.description`
@@ -31,8 +35,6 @@
 - **display.subtitle**: `display subtitle text: text=$txt duration=2000 ms`
 - **menu.open**: `open custom menu: title=$txt description=null option array=$menu`
 - **skip.if.eq**: `skip if $open.menu == 1`
-
-### New Statements Recognized
 - **break**: `break`
 - **continue**: `continue`
 - **do.if**: `do if $Config[$Config.Debug.Enabled]`
@@ -50,20 +52,14 @@
 - **set.script.command**: `set script command: [GLEN_OK_TRADE]`
 - **send.message**: `send incoming message $Msg to player: display it=0`
 - **play.sample**: `play sample 972`
-
-### New Statements Recognized
 - **menu.open.info**: `open custom info menu: title=$txt description=null option array=$menu maxoptions=2`
 - **al.timer.vars**: `al engine: set plugin $plugin.ID timer interval to $interval s`
 - **speak.text**: `= speak text: page=13 id=1276 priority=0`
 - **speak.array**: `= speak array: $d prio=0`
-
-### New Statements Recognized
 - **send.message.literal**: `send incoming message 'ECS Not Detected - Comms with ships and stations will be disabled !' to player: display it=[TRUE]`
 - **return.bool**: `return [TRUE]`
 - **start.speak.text**: `START speak text: page=13 id=131 priority=0`
 - **unregister.hotkey**: `unregister hotkey $hotkey.id`
-
-### New Statements Recognized
 - **gosub.label**: `gosub dodock`
 - **send.message.var.bool**: `send incoming message $msg to player: display it=[TRUE]`
 - **set.command.upgrade.software**: `set script command upgrade: command=ANARKIS_DOCKALL  upgrade=Carrier Command Software`
@@ -75,53 +71,28 @@
 - **insert.array**: `insert $my.news into array $news.list at index 0`
 - **copy.array.literal**: `copy array $setup index 0 ... 6 into array $config.to.update at index 0`
 - **start.command.args**: `START $new.leader -> command $cmd.name : arg1=$arg1, arg2=$arg2, arg3=$arg3, arg4=null`
-
-### New Statements Recognized
 - **append.class**: `append M2 to array $class.list`
 - **menu.value.selection**: `add value selection to menu: $menu, text=$st, value array=$sel.threat, default=$sel.threat.selection, return id=$sel.threat.id`
-
-### New Statements Recognized
 - **play.sample.named**: `play sample [IncomingTransmission.SOS]`
 - **menu.item.textnum**: `add custom menu item to array $menu: text='1' returnvalue=1`
-
-### New Statements Recognized
 - **remove.array.elem.num**: `remove element from array $wing.array at index 0`
 - **set.player.tracking.aim**: `set player tracking aim to $m.selected ->`
 - **menu.item.enum**: `add custom menu item to array $menu: text=$st returnvalue=Carrier`
-
-### New Statements Recognized
 - **append.player**: `append Player to array $ignore`
 - **append.null**: `append null to array $setup`
-
-## Fixtures
-
-Known-good mod fixtures live under `tools/fixtures/known_good/<mod_name>`. Each mod
-provides `src/scripts/*.x3s` as the canonical source along with any `t/` text pages
-or optional `director/` XML. These fixtures are generated from `tools/fixtures/mods/<mod_name>`
-via `python tools/convert_mods.py` and are used by the test suite.
-
-### New Statements Recognized
 - **write.log.num**: `write to log file #8513  append=1  value=$m`
 - **append.string**: `append 'anarkis.lib.cmd.attackland' to array $cmd`
-
-### New Statements Recognized
 - **append.race**: `append Argon to array $res`
 - **append.station**: `append Military Outpost to array $military.types`
 - **set.discovered.status**: `set discovered status: type=$race status=$show`
 - **set.notoriety**: `set notoriety of $base.race -> $target.race to $new.noto points`
-
-### New Statements Recognized
 - **find.station**: `$refobject = find station: sector=$sector class or type=Station race=$race flags=[Find.Random] refobj=null maxdist=null maxnum=1 refpos=null`
 - **find.ship**: `$ship.list = find ship: sector=$sector class or type=Moveable Ship race=null flags=$flags refobj=$refobject maxdist=null maxnum=50 refpos=null`
 - **size.of.array**: `$ship.count = size of array $ship.list`
 - **create.station**: `$select = create station: type=$station.type owner=$race addto=$sector x=$x y=$y z=$z`
 - **random.value**: `$p.face = = random value from 0 to 4 - 1`
-
-### New Statements Recognized
 - **array.alloc**: `$sel.role = array alloc: size=0`
 - **menu.create**: `$menu = create custom menu array`
-
-### New Statements Recognized
 - **skip.if.find.array**: `skip if  find $plugin.id in array: $ecs.installed`
 - **skip.if.datatyp**: `skip if  is datatyp[ $setup ] == DATATYP_ARRAY`
 - **skip.if.not.var**: `skip if not $sound`
@@ -132,7 +103,12 @@ via `python tools/convert_mods.py` and are used by the test suite.
 - **skip.if.is.class**: `skip if $target -> is of class $plugin.config.class`
 - **skip.if.not.eq.num**: `skip if not $mycount == 0`
 - **array.get.index**: `$index =  get index of $plugin.id in array $ecs.installed offset=-1 + 1`
-
-### New Statements Recognized
-- **get.ship.array.by.race**: `$arr =  get ship array: of race $r class/type=Moveable Ship`
+- **get.station.array.by.race**: `$arr = get station array: of race [Player] class/type=[Station]` — returns an array of stations filtered by race and class. The race token and station class must be bracketed. `class/type` accepts `[Station]`, `[Dock]`, `[Complex Hub]`, `[Shipyard]`, or `null`.
 - **destruct.no.explosion**: `$s -> destruct: show no explosion=[TRUE]`
+
+## Fixtures
+Known-good mod fixtures live under `tools/fixtures/known_good/<mod_name>`. Each mod
+provides `src/scripts/*.x3s` as the canonical source along with any `t/` text pages
+or optional `director/` XML. These fixtures are generated from `tools/fixtures/mods/<mod_name>`
+via `python tools/convert_mods.py` and are used by the test suite.
+

--- a/docs/x3s-races.md
+++ b/docs/x3s-races.md
@@ -1,0 +1,23 @@
+# Script Object Races
+
+These race constants must be enclosed in square brackets when used in script expressions (e.g., `get station array: of race [Argon] class/type=[Shipyard]`).
+
+- Argon
+- ATF
+- Boron
+- Enemy Race
+- Goner
+- Kha'ak
+- Neutral Race
+- Paranid
+- Pirates
+- Player
+- Race 1
+- Race 2
+- Split
+- Teladi
+- Terran
+- Unknown
+- Xenon
+- Yaki
+

--- a/docs/x3s-stations.md
+++ b/docs/x3s-stations.md
@@ -1,0 +1,8 @@
+# Script Object Station Classes
+
+These station class constants must be enclosed in square brackets when used in script expressions (e.g., `get station array: of race [Argon] class/type=[Shipyard]`).
+
+- Station
+- Dock
+- Complex Hub
+- Shipyard

--- a/src/scripts/lib.slx.query.x3s
+++ b/src/scripts/lib.slx.query.x3s
@@ -11,10 +11,10 @@ $CHUNK_PCT = 3
 
 if $function == 'ListEnrolledStations'
   $result = array alloc: size=0
-  $all = get station array: of race=Player
+  $all = get station array: of race [Player] class/type=[Station]
   $count = size of array $all
   while $count
-    dec $count =
+    dec $count
     $st = $all[$count]
     $enrolled = $st -> get local variable: name='slx.enrolled'
     if $enrolled

--- a/src/scripts/plugin.slx.station.menu.x3s
+++ b/src/scripts/plugin.slx.station.menu.x3s
@@ -32,7 +32,7 @@ while [TRUE]
   $wares = $station -> get tradeable ware array from station
   $wcount = size of array $wares
   while $wcount
-    dec $wcount =
+    dec $wcount
     $ware = $wares[$wcount]
     $cfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$station, ware=$ware
     $last = $station -> get local variable: name='slx.ware.last_reason'

--- a/tools/x3s_lint.py
+++ b/tools/x3s_lint.py
@@ -31,9 +31,17 @@ def load_patterns() -> list[Rule]:
   pats: list[Rule] = []
   for entry in data.get("patterns", []):
     rx = entry.get("regex")
+    if not rx and (pattern := entry.get("pattern")):
+      rx = re.escape(pattern)
+      for token, sub in entry.get("options", {}).items():
+        if isinstance(sub, list):
+          sub_rx = "(?:" + "|".join(sub) + ")"
+        else:
+          sub_rx = f"(?:{sub})"
+        rx = rx.replace(re.escape(token), sub_rx)
     name = entry.get("name", "")
     if rx:
-      pats.append(Rule(name, re.compile(rx, re.I)))
+      pats.append(Rule(name, re.compile(rf"^{rx}$", re.I)))
   return pats
 
 HEADER_RX = re.compile(r'^\s*#(\w+)\s*:\s*(.+)$')

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -79,9 +79,12 @@
         },
         {
             "name": "dec",
-            "regex": "^dec \\$[A-Za-z0-9_.]+(?:\\s*=\\s*)?$",
+            "pattern": "dec <var>",
+            "options": {
+                "<var>": "\\$[A-Za-z0-9_.]+"
+            },
             "examples": [
-                "dec $s ="
+                "dec $s"
             ]
         },
         {
@@ -736,10 +739,24 @@
             ]
         },
         {
-            "name": "get.ship.array.by.race",
-            "regex": "^\\$[A-Za-z0-9_.]+\\s*=\\s*get ship array: of race \\$[A-Za-z0-9_.]+ class/type=Moveable Ship$",
+            "name": "get.station.array.by.race",
+            "pattern": "<ret> = get station array: of race <race> class/type=<type>",
+            "options": {
+                "<ret>": "\\$[A-Za-z0-9_.]+",
+                "<race>": [
+                    "\\$[A-Za-z0-9_.]+",
+                    "\\[(?:Argon|ATF|Boron|Enemy\\sRace|Goner|Kha'ak|Neutral\\sRace|Paranid|Pirates|Player|Race\\s1|Race\\s2|Split|Teladi|Terran|Unknown|Xenon|Yaki)\\]"
+                ],
+                "<type>": [
+                    "\\[Station\\]",
+                    "\\[Dock\\]",
+                    "\\[Complex\\sHub\\]",
+                    "\\[Shipyard\\]",
+                    "null"
+                ]
+            },
             "examples": [
-                "$arr =  get ship array: of race $r class/type=Moveable Ship"
+                "$arr = get station array: of race [Player] class/type=[Station]"
             ]
         },
         {


### PR DESCRIPTION
## Summary
- fix query helper to request station arrays with explicit class and bracketed race
- document station array syntax and bracket requirement; consolidate language guide
- add lint rule recognizing station array queries
- record script object race constants in dedicated reference file
- enforce `dec` statement without trailing `=` and refactor linter to support option-based patterns
- restrict station array lint rule to known races and station classes; document station class constants

## Testing
- `python tools/test_x3s.py`


------
https://chatgpt.com/codex/tasks/task_e_68c747a08d6883268aed4293966cefe2