### PR TITLE
docs: add passenger command reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.9-internal
+- Added passenger command reference.
+
 ## 0.1.8-internal
 - Linter now rejects positional argument syntax and scripts use named parameters.
 - Fixed remaining positional-style references in ware config query.

--- a/docs/passenger-commands.md
+++ b/docs/passenger-commands.md
@@ -1,0 +1,15 @@
+# Passenger Commands
+
+This reference lists passenger management commands available in X3TC scripting.
+
+- `<RetVar/IF> <RefObj> add passenger to ship <Var/Ship>`
+- `<RetVar/IF> <RefObj> create passenger in ship: name=<Var/String> race=<Var/Race> voice=<Var/Number> face=<Var/Number>`
+- `<RetVar/IF> <RefObj> destroy passenger`
+- `<RetVar/IF> <RefObj> eject passenger`
+- `<RetVar/IF> <RefObj> enslave passenger`
+- `<RetVar/IF> <RefObj> get passenger array`
+- `<RetVar/IF> <RefObj> get passenger transport destination`
+- `<RetVar/IF> <RefObj> get passenger transport payment`
+- `<RetVar/IF> <RefObj> is passenger to be transported`
+- `<RetVar/IF> <RefObj> move passenger to ship <Var/Ship> : set passenger as pilot=<Var/Boolean>`
+- `<RefObj> set passenger transport, destination=<Var/Station>, payment=<Var/Number>`


### PR DESCRIPTION
## Summary
- document passenger management commands in new reference
- note passenger commands doc in changelog

## Testing
- `python tools/test_x3s.py`


------
https://chatgpt.com/codex/tasks/task_e_68c74d90a0c08326933c0c6dc80e7da9