### PR TITLE
docs: add pilot command reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.9-internal
+- Added pilot command reference.
+
 ## 0.1.8-internal
 - Linter now rejects positional argument syntax and scripts use named parameters.
 - Fixed remaining positional-style references in ware config query.

--- a/docs/pilot-commands.md
+++ b/docs/pilot-commands.md
@@ -1,0 +1,18 @@
+# Pilot Commands
+
+This reference lists pilot-related commands available in X3TC scripting.
+
+- `<RetVar/IF> <RefObj> add pilot of ship <Var/Ship> as passenger: disable ship=<Var/Boolean>`
+- `<RetVar/IF> <RefObj> get pilot aggression`
+- `<RetVar/IF> <RefObj> get pilot fightskill`
+- `<RetVar/IF> <RefObj> get pilot morale`
+- `<RetVar/IF> <RefObj> get pilot name`
+- `<RetVar/IF> <RefObj> get pilot tradeskill`
+- `<RetVar/IF> get random name: race=<Var/Race>`
+- `<RetVar/IF> <RefObj> move pilot to ship <Var/Ship>: disable=<Var/Boolean>`
+- `<RetVar/IF> <RefObj> pilot eject from ship`
+- `<RefObj> set pilot aggression: <Var/Number>`
+- `<RefObj> set pilot fightskill to <Var/Number>`
+- `<RefObj> set pilot morale: <Var/Number>`
+- `<RefObj> set pilot name to <Var/String>`
+- `<RefObj> set pilot tradeskill to <Var/Number>`


### PR DESCRIPTION
## Summary
- document pilot-related commands
- record pilot command doc in changelog

## Testing
- `python tools/test_x3s.py`


------
https://chatgpt.com/codex/tasks/task_e_68c74dc37c288326974013e338f55152