### PR TITLE
docs: add script property command reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.9-internal
+- Added script property command reference.
+
 ## 0.1.8-internal
 - Linter now rejects positional argument syntax and scripts use named parameters.
 - Fixed remaining positional-style references in ware config query.

--- a/docs/script-property-commands.md
+++ b/docs/script-property-commands.md
@@ -1,0 +1,27 @@
+# Script Property Commands
+
+This reference lists script property commands available in X3TC scripting.
+
+- `add blueprints to player HQ: type=<Var/Ship Type>`
+- `add money to player: <Var/Number>`
+- `<RetVar/IF> get fight rank`
+- `<RetVar/IF> get fight rank percentage`
+- `<RetVar/IF> get fight rank title: text=<Var/Boolean>`
+- `<RetVar/IF> get mission rank: name=<Var/String>`
+- `<RetVar/IF> get player money`
+- `<RetVar/IF> get player name`
+- `<RetVar/IF> get player ship`
+- `<RetVar/IF> get player tracking aim`
+- `<RetVar/IF> get trade rank`
+- `<RetVar/IF> get trade rank percentage`
+- `<RetVar/IF> get trade rank title: text=<Var/Boolean>`
+- `<RetVar/IF> last load time`
+- `<RetVar/IF> move player to ship <Var/Ship>: Teleport=<Var/Number>`
+- `<RetVar/IF> player has police licence for race <Var/Race>`
+- `<RetVar/IF> player HQ has blueprints for: type=<Var/Ship Type>`
+- `player loses police licence for race <Var/Race>`
+- `<RetVar/IF> playing time`
+- `remove blueprints from player HQ: type=<Var/Ship Type>`
+- `set mission rank: name=<Var/String> rank=<Var/Number>`
+- `set player tracking aim to <RefObj>`
+


### PR DESCRIPTION
## Summary
- document script property commands
- note documentation in changelog

## Testing
- `python tools/test_x3s.py`


------
https://chatgpt.com/codex/tasks/task_e_68c74deefa3483269b46107c8fc5b8c3