### PR TITLE
docs: add ship trading commands reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Documented script object races in a dedicated reference file.
 - Enforced `dec <var>` syntax, added option-based lint rules, and removed redundant ship array rule.
 - Restricted station array rule to known races and station classes and added station class reference.
+- Added ship trading command reference.
 
 ## 0.1.8-internal
 - Added macro commands documentation.

--- a/docs/Ship Trading Commands.md
+++ b/docs/Ship Trading Commands.md
@@ -1,0 +1,36 @@
+# Ship Trading Commands
+
+This reference covers ship trading commands available in X3TC scripting. Each entry shows the basic syntax.
+
+- `<RetVar/IF> <RefObj> add <Var/Number> units of <Var/Ware>`
+- `<RetVar/IF> <RefObj> buy <Var/Number> units of <Var/Ware>`
+- `<RetVar/IF> <RefObj> buy <Var/Number1> units of <Var/Ware> to a max. price of <Var/Number2> cr`
+- `<RetVar/IF> <RefObj> can buy ware <Var/Ware> at station <Var/Station>`
+- `<RetVar/IF> <RefObj> can buy ware <Var/Ware> from race <Var/Race>`
+- `<RetVar/IF> <RefObj> can transport ware <Var/Ware>`
+- `<RetVar/IF> <RefObj> get amount of ware <Var/Ware> in cargo bay`
+- `<RetVar/IF> <RefObj> get cargo bay size`
+- `<RetVar/IF> <RefObj> get defined amount of ware <Var/Ware> as ship hardware`
+- `<RetVar/IF> <RefObj> get free amount of ware <Var/Ware> in cargo bay`
+- `<RetVar/IF> <RefObj> get free volume of cargo bay`
+- `<RetVar/IF> <RefObj> get free volume of ware <Var/Ware> in cargo bay`
+- `<RetVar/IF> <RefObj> get max. ware transport class`
+- `<RetVar/IF> <RefObj> get max amount of ware <Var/Ware> that can be stored in cargo bay`
+- `<RetVar/IF> <RefObj> get ship hardware as array`
+- `<RetVar/IF> <RefObj> get total volume in cargo bay`
+- `<RetVar/IF> <RefObj> get tradeable ware array from ship`
+- `<RetVar/IF> <RefObj> get true amount of ware <Var/Ware> in cargo bay`
+- `<RetVar/IF> <RefObj> get true volume of ware <Var/Ware> in cargo bay`
+- `<RetVar/IF> <RefObj> get upgrade price: cargo-speed-rot <Var/Ware> units:<Var/Number>`
+- `<RetVar/IF> <RefObj> get volume of ware <Var/Ware> in cargo bay`
+- `<RetVar/IF> <RefObj> get wanted ware`
+- `<RetVar/IF> <RefObj> get wanted ware count`
+- `<RetVar/IF> <RefObj> get warearray for <Value>`
+- `<RetVar/IF> <RefObj> get storage percentage: ware=<Var/Ware>`
+- `<RetVar/IF> <RefObj> install <Var/Number> units of <Var/Ware>`
+- `<RetVar/IF> <RefObj> load <Var/Number> units of <Var/Ware>`
+- `<RetVar/IF> <RefObj> sell ware <Var/Ware>`
+- `<RetVar/IF> <RefObj> set defined amount of ware <Var/Ware> as ship hardware`
+- `<RetVar/IF> <RefObj> set wanted ware count to <Var/Number>`
+- `<RetVar/IF> <RefObj> set wanted ware to <Var/Ware>`
+- `<RetVar/IF> <RefObj> unload <Var/Number> units of <Var/Ware>`


### PR DESCRIPTION
## Summary
- document ship trading commands for quick script reference
- note addition in changelog

## Testing
- `python tools/test_x3s.py`

------
https://chatgpt.com/codex/tasks/task_e_68c796e073148326af3b911c8327587c