### PR TITLE
Add string command reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Document merchant commands.
 - Added math commands reference.
 - Added marine commands documentation.
+- Added string commands reference.
 - Clarified required station array syntax and fixed query helper to include class and wrapped race.
 - Added lint rule for station array queries and consolidated language guide.
 - Documented script object races in a dedicated reference file.

--- a/docs/string-commands.md
+++ b/docs/string-commands.md
@@ -1,0 +1,21 @@
+# String Commands
+
+This reference lists string commands available in X3TC scripting.
+
+- `<RetVar> convert number <Var/Number> to string`
+- `<RetVar> find position of pattern <Var/String1> in <Var/String2>`
+- `<RetVar> format seconds=<Var/String> to Zura time string`
+- `<RetVar> format time: <Var/Number>`
+- `<RetVar/IF> get length of string <Var/String>`
+- `<RetVar/IF> get string font length: <Var/String>`
+- `<RetVar> get substring of <Var/String> offset=<Var/Number1> length=<Var/Number2>`
+- `<RetVar/IF> get text id: ware=<Var/Ware>`
+- `load text: id=<Var/Number>`
+- `<RetVar/IF> match regular expression: <Var/String1> to string <Var/String2>`
+- `<RetVar> read text: page=<Var/Number1> id=<Var/Number2>`
+- `<RetVar/IF> read text: page id=<Var/Number1>, from <Var/Number2> to <Var/Number3> to array, include empty=<Var/Number4>`
+- `<RetVar/IF> read text: page id=<Var/Number>, id=<Var/Number> exists`
+- `<RetVar> sprintf: fmt=<Var/String>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
+- `<RetVar> sprintf: pageid=<Var/Number> textid=<Var/Number>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
+- `<RetVar> string <Var/String> to integer`
+- `<RetVar> substitute in string <Var/String1>: pattern <Var/String2> with <Var/String3>`


### PR DESCRIPTION
## Summary
- document available string commands for X3TC scripting
- record addition in changelog

## Testing
- `python tools/test_x3s.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7973a0b988326bf8766056c7b5627