### PR TITLE
docs: add system property command reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added passenger command reference.
 - Added pilot command reference.
 - Added script property command reference.
+- Added system property command reference.
 - Added player command reference documentation.
 - Added object property commands documentation.
 - Added object action command reference.

--- a/docs/System Property Commands.md
+++ b/docs/System Property Commands.md
@@ -1,0 +1,10 @@
+# System Property Commands
+
+This reference lists system property commands available in X3TC scripting.
+
+- `capture screen`
+- `set monitor mode and viewpoint: monitor=<Var/Number> cockpit=<Var/Number> mode=<Var/Number> alpha=<Var/Number> beta=<Var/Number> gamma=<Var/Number> range=<Var/Number>`
+- `<RetVar/IF> system date is month=<Var/Number1>, day=<Var/Number2>`
+- `write to log file <Var/Number> append=<Var/Number> printf: fmt=<Var/String>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
+- `write to log file <Var/Number> append=<Var/Number> printf: pageid=<Var/Number2> textid=<Var/Number3>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
+- `write to log file <Var/Number> append=<Var/Number> value=<Value>`


### PR DESCRIPTION
## Summary
- document system property commands such as `capture screen` and monitor management
- log the new reference in the changelog

## Testing
- `python tools/test_x3s.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7974e5ce8832680d5f7d481eace38