### PR TITLE
docs: add weapon property command reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.1.9-internal
+- Added weapon property command reference.
 - Added passenger command reference.
 - Added pilot command reference.
 - Added script property command reference.

--- a/docs/Weapon Property Commands.md
+++ b/docs/Weapon Property Commands.md
@@ -1,0 +1,17 @@
+# Weapon Property Commands
+
+This reference lists weapon property commands available in X3TC scripting.
+
+- `<RetVar/IF> get ammunition of laser <Var/Ware>`
+- `<RetVar> get bullet speed of laser <Var/Ware>`
+- `<RetVar> <RefObj> get compatible laser array: turret=<Var/Number>`
+- `<RetVar> get default launch time difference for missile type: <Var/Ware>`
+- `<RetVar> get hull damage of laser <Var/Ware>`
+- `<RetVar> get missile max damage of <Var/Ware>`
+- `<RetVar> get missile range of <Var/Ware>`
+- `<RetVar/IF> get OOS hull damage of laser <Var/Ware>`
+- `<RetVar/IF> get OOS shield damage of laser <Var/Ware>`
+- `<RetVar> get power generator of ship/station type <Var/Ware>`
+- `<RetVar> get range of laser <Var/Ware>`
+- `<RetVar> get range of missile type <Var/Ware>`
+- `<RetVar> get shield damage of laser <Var/Ware>`


### PR DESCRIPTION
## Summary
- document weapon property commands in dedicated doc
- note addition in changelog

## Testing
- `python tools/test_x3s.py`
- `python tools/x3s_lint.py`


------
https://chatgpt.com/codex/tasks/task_e_68c797c145e083269ea5379ca157341c