### PR TITLE
Remove stray '=' from wait commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Expanded linter rules and constant handling to reduce warnings on known-good scripts.
 - Fixed inc/dec rule patterns to avoid stray '=' tokens.
 - Disallowed leading '=' before wait commands.
+- Removed stray '=' before wait commands in manager tick and station menu scripts.
 - Added ware property command reference.
 - Added weapon property command reference.
 - Added universe data command reference.

--- a/src/scripts/plugin.slx.manager.tick.x3s
+++ b/src/scripts/plugin.slx.manager.tick.x3s
@@ -46,11 +46,11 @@ while [TRUE]
       if $role == 'store'
         gosub StoreLoop
       end
-      = wait 1 ms
+      wait 1 ms
     end
-    = wait 1 ms
+    wait 1 ms
   end
-  = wait 10000 ms
+  wait 10000 ms
 end
 
 return null
@@ -77,7 +77,7 @@ ProducerLoop:
           $dst = $other
         end
       end
-      = wait 1 ms
+      wait 1 ms
     end
     if $dst
       $srcAmt = $st -> get amount of ware $ware in cargo bay
@@ -164,7 +164,7 @@ ProducerLoop:
           $dst = $other
         end
       end
-      = wait 1 ms
+      wait 1 ms
     end
     if $dst
       $srcAmt = $st -> get amount of ware $ware in cargo bay
@@ -261,7 +261,7 @@ ConsumerLoop:
           $src = $other
         end
       end
-      = wait 1 ms
+      wait 1 ms
     end
     if $src
       $srcAmt = $src -> get amount of ware $ware in cargo bay
@@ -345,7 +345,7 @@ StoreLoop:
         $dst = $other
         break
       end
-      = wait 1 ms
+      wait 1 ms
     end
     if $dst
       $srcAmt = $st -> get amount of ware $ware in cargo bay
@@ -405,7 +405,7 @@ StoreLoop:
         $src = $other
         break
       end
-      = wait 1 ms
+      wait 1 ms
     end
     if $src
       $srcAmt = $src -> get amount of ware $ware in cargo bay

--- a/src/scripts/plugin.slx.station.menu.x3s
+++ b/src/scripts/plugin.slx.station.menu.x3s
@@ -40,7 +40,7 @@ while [TRUE]
     $reason = call script 'lib.slx.ui' : function='FormatReason', code=$code
     $row = sprintf: pageid=$PageId textid=214, $ware, $cfg[$ROLE], $cfg[$MIN_PCT], $cfg[$MAX_PCT], $cfg[$CHUNK_PCT], $reason
     add custom menu item to array $menu: text=$row returnvalue=$ware
-    = wait 1 ms
+    wait 1 ms
   end
   add section to custom menu: $menu
   $exit = read text: page=$PageId id=208
@@ -65,7 +65,7 @@ while [TRUE]
         dec $idx
         $w = $all[$idx]
         call script 'lib.slx.query' : function='SetStationWareConfig', station=$station, ware=$w, cfg=$def
-        = wait 1 ms
+        wait 1 ms
       end
     end
     continue
@@ -97,7 +97,7 @@ while [TRUE]
   $new[$MAX_PCT] = $max
   $new[$CHUNK_PCT] = $chunk
   call script 'lib.slx.query' : function='SetStationWareConfig', station=$station, ware=$sel, cfg=$new
-  = wait 1 ms
+  wait 1 ms
 end
 
 return null


### PR DESCRIPTION
## Summary
- fix linter issues by removing leading '=' from wait lines in manager tick and station menu scripts
- document the fix in the changelog

## Testing
- `python tools/x3s_lint.py`
- `python tools/test_x3s.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7a5c5b9ec83269aae452dbd1b328b