### PR TITLE
lint: prohibit negative add amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.1.9-internal
+- Linter now rejects negative amounts in `add` commands; assign the value to a variable first.
 - Expanded linter rules and constant handling to reduce warnings on known-good scripts.
 - Fixed inc/dec rule patterns to avoid stray '=' tokens.
 - Disallowed leading '=' before wait commands.

--- a/src/scripts/lib.slx.transfer.x3s
+++ b/src/scripts/lib.slx.transfer.x3s
@@ -27,7 +27,8 @@ if $function == 'CanMove'
 end
 
 if $function == 'ApplyMove'
-  = $src -> add -$amount units of $ware
+  $reduce = -$amount
+  = $src -> add $reduce units of $ware
   = $dst -> add $amount units of $ware
   return null
 end

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Update.Ware.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Update.Ware.x3s
@@ -148,7 +148,8 @@ $station  ->  set local variable: name=$pointer value=$array
 $physical.check = $station  ->  get amount of ware $ware in cargo bay
 if not $physical.check > 0
  = $station  ->  add 1 units of $ware
- = $station  ->  add -1 units of $ware
+ $reduce = -1
+ = $station  ->  add $reduce units of $ware
 end
 endsub
 * -----------------------------------------------------------------------------------

--- a/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Wares.Summary.x3s
+++ b/tools/fixtures/known_good/FDN/src/scripts/plugin.LI.FDN.Wares.Summary.x3s
@@ -268,7 +268,8 @@ $station  ->  set local variable: name=$pointer value=$settings.array
 $physical.check = $station  ->  get amount of ware $ware in cargo bay
 if not $physical.check > 0
  = $station  ->  add 1 units of $ware
- = $station  ->  add -1 units of $ware
+ $reduce = -1
+ = $station  ->  add $reduce units of $ware
 end
 endsub
 * -----------------------------------------------------------------------------------

--- a/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.lib.x3s
+++ b/tools/fixtures/known_good/OKTraders1_7_1/src/scripts/glen.trade.ok.lib.x3s
@@ -865,11 +865,12 @@
 			$rc = 1
 			append $Ware to array $Infinite.Wares
 			else
-			= $Station-> add -1 units of $Ware
-			append $Ware to array $Finite.Wares
-			end
-			end
-			end
+                        $reduce = -1
+                        = $Station-> add $reduce units of $Ware
+                        append $Ware to array $Finite.Wares
+                        end
+                        end
+                        end
 			$Ship.Proxy-> destruct: show no explosion=[TRUE]
 
 			break

--- a/tools/tests/test_lint_negative_add.py
+++ b/tools/tests/test_lint_negative_add.py
@@ -1,0 +1,21 @@
+import tempfile
+from pathlib import Path
+import sys
+import unittest
+
+# Ensure we can import x3s_lint from the tools directory
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import x3s_lint
+
+
+class NegativeAddTests(unittest.TestCase):
+    def test_negative_add_requires_variable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "bad.x3s"
+            p.write_text("= $src -> add -$amount units of $ware\n", encoding="utf-8")
+            msgs = x3s_lint.lint_file(p)
+            self.assertTrue(any("negative amounts in 'add'" in m for m in msgs), msgs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/x3s_lint.py
+++ b/tools/x3s_lint.py
@@ -188,6 +188,10 @@ def lint_file(path: Path, patterns: list[Rule] | None = None) -> list[str]:
     if re.search(r"\[\s*'[A-Za-z0-9_.]+'\s*\]", line):
       errors.append(f"{path.name}:{ln}: array indices must be numeric")
 
+    # disallow negative amounts directly in add commands
+    if re.search(r"->\s*add\s*-", line):
+      errors.append(f"{path.name}:{ln}: negative amounts in 'add' require temp variable")
+
     # line-shape validation (warn on unknown shapes)
     recognizable = any(pat.regex.match(line.strip()) for pat in patterns)
     if not recognizable and not (re.match(r'^if\b', low) or re.match(r'^else\s+if\b', low) or low == "else" or low == "end" or re.match(r'^while\b', low)):


### PR DESCRIPTION
## Summary
- flag negative amounts passed to `add` in X3S linter
- rewrite scripts and fixtures to assign negative values before calling `add`
- cover new check with unit test and changelog entry

## Testing
- `python tools/test_x3s.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7ab7cdf788326a67f79b0b80bce8c