### PR TITLE
Enforce object reference for call script calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.1.9-internal
+- Enforced explicit object reference for all `call script` invocations and updated linter to flag omissions.
 - Cached array indices before conditional checks to avoid invalid direct indexing in transfer and manager scripts.
 - Linter now flags array indexing inside conditional statements, enforcing variable caching before comparisons.
 - Linter now rejects negative amounts in `add` commands; assign the value to a variable first.

--- a/src/scripts/lib.slx.transfer.x3s
+++ b/src/scripts/lib.slx.transfer.x3s
@@ -13,8 +13,8 @@ if $function == 'CanMove'
   $srcCap = $src -> get max amount of ware $ware that can be stored in cargo bay
   $dstAmt = $dst -> get amount of ware $ware in cargo bay
   $dstCap = $dst -> get max amount of ware $ware that can be stored in cargo bay
-  $srcCfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$src, ware=$ware
-  $dstCfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$dst, ware=$ware
+  $srcCfg = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$src, ware=$ware
+  $dstCfg = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$dst, ware=$ware
   $srcNew = ($srcAmt - $amount) * 100 / $srcCap
   $dstNew = ($dstAmt + $amount) * 100 / $dstCap
   $srcMinPct = $srcCfg[$MIN_PCT]

--- a/src/scripts/plugin.slx.manager.tick.x3s
+++ b/src/scripts/plugin.slx.manager.tick.x3s
@@ -10,7 +10,7 @@ $MAX_PCT = 2
 $CHUNK_PCT = 3
 
 while [TRUE]
-  $stations = call script 'lib.slx.query' : function='ListEnrolledStations'
+  $stations = null -> call script 'lib.slx.query' : function='ListEnrolledStations'
   $scount = size of array $stations
   while $scount
     dec $scount
@@ -20,12 +20,12 @@ while [TRUE]
     while $wcount
       dec $wcount
       $ware = $wares[$wcount]
-      $cfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$st, ware=$ware
+      $cfg = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$st, ware=$ware
       $role = $cfg[$ROLE]
       if not $role
         continue
       end
-      $pct = call script 'lib.slx.query' : function='GetStationWarePct', station=$st, ware=$ware
+      $pct = null -> call script 'lib.slx.query' : function='GetStationWarePct', station=$st, ware=$ware
       $auto = [FALSE]
       if $role == 'auto'
         $auto = [TRUE]
@@ -62,19 +62,19 @@ ProducerLoop:
   $cfgMinPct = $cfg[$MIN_PCT]
   if $pct > $cfgMaxPct
     $dst = null
-    $sec = call script 'lib.slx.query' : function='GetSector', station=$st
+    $sec = null -> call script 'lib.slx.query' : function='GetSector', station=$st
     $idx2 = size of array $stations
     while $idx2
       dec $idx2
       $other = $stations[$idx2]
       skip if $other == $st
-      $cfg2 = call script 'lib.slx.query' : function='GetStationWareConfig', station=$other, ware=$ware
+      $cfg2 = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$other, ware=$ware
       $cfg2Role = $cfg2[$ROLE]
       skip if $cfg2Role != 'store'
-      $pct2 = call script 'lib.slx.query' : function='GetStationWarePct', station=$other, ware=$ware
+      $pct2 = null -> call script 'lib.slx.query' : function='GetStationWarePct', station=$other, ware=$ware
       $cfg2MaxPct = $cfg2[$MAX_PCT]
       if $pct2 < $cfg2MaxPct
-        $sec2 = call script 'lib.slx.query' : function='GetSector', station=$other
+        $sec2 = null -> call script 'lib.slx.query' : function='GetSector', station=$other
         if $sec == $sec2
           $dst = $other
           break
@@ -90,18 +90,18 @@ ProducerLoop:
       $srcCap = $st -> get max amount of ware $ware that can be stored in cargo bay
       $dstAmt = $dst -> get amount of ware $ware in cargo bay
       $dstCap = $dst -> get max amount of ware $ware that can be stored in cargo bay
-      $dstCfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$dst, ware=$ware
+      $dstCfg = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$dst, ware=$ware
       $srcChunk = $srcCap * $cfg[$CHUNK_PCT] / 100
       $dstChunk = $dstCap * $dstCfg[$CHUNK_PCT] / 100
       $available = $srcAmt - ($cfg[$MAX_PCT] * $srcCap / 100)
       $room = ($dstCfg[$MAX_PCT] * $dstCap / 100) - $dstAmt
-      $amt = call script 'lib.slx.util' : function='Min', a=$srcChunk, b=$dstChunk
-      $amt = call script 'lib.slx.util' : function='Min', a=$amt, b=$available
-      $amt = call script 'lib.slx.util' : function='Min', a=$amt, b=$room
+      $amt = null -> call script 'lib.slx.util' : function='Min', a=$srcChunk, b=$dstChunk
+      $amt = null -> call script 'lib.slx.util' : function='Min', a=$amt, b=$available
+      $amt = null -> call script 'lib.slx.util' : function='Min', a=$amt, b=$room
       if $amt > 0
-        $ok = call script 'lib.slx.transfer' : function='CanMove', src=$st, dst=$dst, ware=$ware, amount=$amt
+        $ok = null -> call script 'lib.slx.transfer' : function='CanMove', src=$st, dst=$dst, ware=$ware, amount=$amt
         if $ok
-          call script 'lib.slx.transfer' : function='ApplyMove', src=$st, dst=$dst, ware=$ware, amount=$amt
+          null -> call script 'lib.slx.transfer' : function='ApplyMove', src=$st, dst=$dst, ware=$ware, amount=$amt
 
           * merged: nuanced codes + auto prefix
           if $amt == $available
@@ -126,44 +126,44 @@ ProducerLoop:
               $dstCode = 'A_P2S_RECV'
             end
           end
-          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$srcCode
-          call script 'lib.slx.query' : function='SetLastReason', station=$dst, ware=$ware, text=$dstCode
+          null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$srcCode
+          null -> call script 'lib.slx.query' : function='SetLastReason', station=$dst, ware=$ware, text=$dstCode
         else
           $txt = 'NO_STORE'
           if $auto
             $txt = 'A_NO_STORE'
           end
-          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+          null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
         end
       else
         $txt = 'NO_STORE'
         if $auto
           $txt = 'A_NO_STORE'
         end
-        call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+        null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
       end
     else
       $txt = 'NO_STORE'
       if $auto
         $txt = 'A_NO_STORE'
       end
-      call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+      null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
     end
   else if $pct > $cfgMinPct
     $dst = null
-    $sec = call script 'lib.slx.query' : function='GetSector', station=$st
+    $sec = null -> call script 'lib.slx.query' : function='GetSector', station=$st
     $idx2 = size of array $stations
     while $idx2
       dec $idx2
       $other = $stations[$idx2]
       skip if $other == $st
-      $cfg2 = call script 'lib.slx.query' : function='GetStationWareConfig', station=$other, ware=$ware
+      $cfg2 = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$other, ware=$ware
       $cfg2Role = $cfg2[$ROLE]
       skip if $cfg2Role != 'consumer'
-      $pct2 = call script 'lib.slx.query' : function='GetStationWarePct', station=$other, ware=$ware
+      $pct2 = null -> call script 'lib.slx.query' : function='GetStationWarePct', station=$other, ware=$ware
       $cfg2MaxPct = $cfg2[$MAX_PCT]
       if $pct2 < $cfg2MaxPct
-        $sec2 = call script 'lib.slx.query' : function='GetSector', station=$other
+        $sec2 = null -> call script 'lib.slx.query' : function='GetSector', station=$other
         if $sec == $sec2
           $dst = $other
           break
@@ -179,18 +179,18 @@ ProducerLoop:
       $srcCap = $st -> get max amount of ware $ware that can be stored in cargo bay
       $dstAmt = $dst -> get amount of ware $ware in cargo bay
       $dstCap = $dst -> get max amount of ware $ware that can be stored in cargo bay
-      $dstCfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$dst, ware=$ware
+      $dstCfg = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$dst, ware=$ware
       $srcChunk = $srcCap * $cfg[$CHUNK_PCT] / 100
       $dstChunk = $dstCap * $dstCfg[$CHUNK_PCT] / 100
       $available = $srcAmt - ($cfg[$MIN_PCT] * $srcCap / 100)
       $room = ($dstCfg[$MAX_PCT] * $dstCap / 100) - $dstAmt
-      $amt = call script 'lib.slx.util' : function='Min', a=$srcChunk, b=$dstChunk
-      $amt = call script 'lib.slx.util' : function='Min', a=$amt, b=$available
-      $amt = call script 'lib.slx.util' : function='Min', a=$amt, b=$room
+      $amt = null -> call script 'lib.slx.util' : function='Min', a=$srcChunk, b=$dstChunk
+      $amt = null -> call script 'lib.slx.util' : function='Min', a=$amt, b=$available
+      $amt = null -> call script 'lib.slx.util' : function='Min', a=$amt, b=$room
       if $amt > 0
-        $ok = call script 'lib.slx.transfer' : function='CanMove', src=$st, dst=$dst, ware=$ware, amount=$amt
+        $ok = null -> call script 'lib.slx.transfer' : function='CanMove', src=$st, dst=$dst, ware=$ware, amount=$amt
         if $ok
-          call script 'lib.slx.transfer' : function='ApplyMove', src=$st, dst=$dst, ware=$ware, amount=$amt
+          null -> call script 'lib.slx.transfer' : function='ApplyMove', src=$st, dst=$dst, ware=$ware, amount=$amt
 
           * merged: nuanced codes + auto prefix
           if $amt == $available
@@ -215,35 +215,35 @@ ProducerLoop:
               $dstCode = 'A_P2C'
             end
           end
-          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$srcCode
-          call script 'lib.slx.query' : function='SetLastReason', station=$dst, ware=$ware, text=$dstCode
+          null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$srcCode
+          null -> call script 'lib.slx.query' : function='SetLastReason', station=$dst, ware=$ware, text=$dstCode
         else
           $txt = 'AT_MIN'
           if $auto
             $txt = 'A_AT_MIN'
           end
-          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+          null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
         end
       else
         $txt = 'AT_MIN'
         if $auto
           $txt = 'A_AT_MIN'
         end
-        call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+        null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
       end
     else
       $txt = 'AT_MIN'
       if $auto
         $txt = 'A_AT_MIN'
       end
-      call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+      null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
     end
   else
     $txt = 'AT_MIN'
     if $auto
       $txt = 'A_AT_MIN'
     end
-    call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+    null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
   end
   return null
 
@@ -251,19 +251,19 @@ ConsumerLoop:
   $cfgMinPct = $cfg[$MIN_PCT]
   if $pct < $cfgMinPct
     $src = null
-    $sec = call script 'lib.slx.query' : function='GetSector', station=$st
+    $sec = null -> call script 'lib.slx.query' : function='GetSector', station=$st
     $idx2 = size of array $stations
     while $idx2
       dec $idx2
       $other = $stations[$idx2]
       skip if $other == $st
-      $cfg2 = call script 'lib.slx.query' : function='GetStationWareConfig', station=$other, ware=$ware
+      $cfg2 = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$other, ware=$ware
       $cfg2Role = $cfg2[$ROLE]
       skip if $cfg2Role != 'store'
-      $pct2 = call script 'lib.slx.query' : function='GetStationWarePct', station=$other, ware=$ware
+      $pct2 = null -> call script 'lib.slx.query' : function='GetStationWarePct', station=$other, ware=$ware
       $cfg2MinPct = $cfg2[$MIN_PCT]
       if $pct2 > $cfg2MinPct
-        $sec2 = call script 'lib.slx.query' : function='GetSector', station=$other
+        $sec2 = null -> call script 'lib.slx.query' : function='GetSector', station=$other
         if $sec == $sec2
           $src = $other
           break
@@ -279,18 +279,18 @@ ConsumerLoop:
       $srcCap = $src -> get max amount of ware $ware that can be stored in cargo bay
       $dstAmt = $st -> get amount of ware $ware in cargo bay
       $dstCap = $st -> get max amount of ware $ware that can be stored in cargo bay
-      $srcCfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$src, ware=$ware
+      $srcCfg = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$src, ware=$ware
       $srcChunk = $srcCap * $srcCfg[$CHUNK_PCT] / 100
       $dstChunk = $dstCap * $cfg[$CHUNK_PCT] / 100
       $available = $srcAmt - ($srcCfg[$MIN_PCT] * $srcCap / 100)
       $room = ($cfg[$MIN_PCT] * $dstCap / 100) - $dstAmt
-      $amt = call script 'lib.slx.util' : function='Min', a=$srcChunk, b=$dstChunk
-      $amt = call script 'lib.slx.util' : function='Min', a=$amt, b=$available
-      $amt = call script 'lib.slx.util' : function='Min', a=$amt, b=$room
+      $amt = null -> call script 'lib.slx.util' : function='Min', a=$srcChunk, b=$dstChunk
+      $amt = null -> call script 'lib.slx.util' : function='Min', a=$amt, b=$available
+      $amt = null -> call script 'lib.slx.util' : function='Min', a=$amt, b=$room
       if $amt > 0
-        $ok = call script 'lib.slx.transfer' : function='CanMove', src=$src, dst=$st, ware=$ware, amount=$amt
+        $ok = null -> call script 'lib.slx.transfer' : function='CanMove', src=$src, dst=$st, ware=$ware, amount=$amt
         if $ok
-          call script 'lib.slx.transfer' : function='ApplyMove', src=$src, dst=$st, ware=$ware, amount=$amt
+          null -> call script 'lib.slx.transfer' : function='ApplyMove', src=$src, dst=$st, ware=$ware, amount=$amt
 
           * merged: nuanced codes + auto prefix
           if $amt == $room
@@ -315,28 +315,28 @@ ConsumerLoop:
               $srcCode = 'A_S2C'
             end
           end
-          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$dstCode
-          call script 'lib.slx.query' : function='SetLastReason', station=$src, ware=$ware, text=$srcCode
+          null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$dstCode
+          null -> call script 'lib.slx.query' : function='SetLastReason', station=$src, ware=$ware, text=$srcCode
         else
           $txt = 'NO_STORE'
           if $auto
             $txt = 'A_NO_STORE'
           end
-          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+          null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
         end
       else
         $txt = 'NO_STORE'
         if $auto
           $txt = 'A_NO_STORE'
         end
-        call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+        null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
       end
     else
       $txt = 'NO_STORE'
       if $auto
         $txt = 'A_NO_STORE'
       end
-      call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+      null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
     end
   end
   return null
@@ -351,10 +351,10 @@ StoreLoop:
       dec $idx2
       $other = $stations[$idx2]
       skip if $other == $st
-      $cfg2 = call script 'lib.slx.query' : function='GetStationWareConfig', station=$other, ware=$ware
+      $cfg2 = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$other, ware=$ware
       $cfg2Role = $cfg2[$ROLE]
       skip if $cfg2Role != 'store'
-      $pct2 = call script 'lib.slx.query' : function='GetStationWarePct', station=$other, ware=$ware
+      $pct2 = null -> call script 'lib.slx.query' : function='GetStationWarePct', station=$other, ware=$ware
       $cfg2MinPct = $cfg2[$MIN_PCT]
       if $pct2 < $cfg2MinPct
         $dst = $other
@@ -367,44 +367,44 @@ StoreLoop:
       $srcCap = $st -> get max amount of ware $ware that can be stored in cargo bay
       $dstAmt = $dst -> get amount of ware $ware in cargo bay
       $dstCap = $dst -> get max amount of ware $ware that can be stored in cargo bay
-      $dstCfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$dst, ware=$ware
+      $dstCfg = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$dst, ware=$ware
       $srcChunk = $srcCap * $cfg[$CHUNK_PCT] / 100
       $dstChunk = $dstCap * $dstCfg[$CHUNK_PCT] / 100
       $available = $srcAmt - ($cfg[$MAX_PCT] * $srcCap / 100)
       $room = ($dstCfg[$MIN_PCT] * $dstCap / 100) - $dstAmt
-      $amt = call script 'lib.slx.util' : function='Min', a=$srcChunk, b=$dstChunk
-      $amt = call script 'lib.slx.util' : function='Min', a=$amt, b=$available
-      $amt = call script 'lib.slx.util' : function='Min', a=$amt, b=$room
+      $amt = null -> call script 'lib.slx.util' : function='Min', a=$srcChunk, b=$dstChunk
+      $amt = null -> call script 'lib.slx.util' : function='Min', a=$amt, b=$available
+      $amt = null -> call script 'lib.slx.util' : function='Min', a=$amt, b=$room
       if $amt > 0
-        $ok = call script 'lib.slx.transfer' : function='CanMove', src=$st, dst=$dst, ware=$ware, amount=$amt
+        $ok = null -> call script 'lib.slx.transfer' : function='CanMove', src=$st, dst=$dst, ware=$ware, amount=$amt
         if $ok
-          call script 'lib.slx.transfer' : function='ApplyMove', src=$st, dst=$dst, ware=$ware, amount=$amt
+          null -> call script 'lib.slx.transfer' : function='ApplyMove', src=$st, dst=$dst, ware=$ware, amount=$amt
           $txt = 'S2S'
           if $auto
             $txt = 'A_S2S'
           end
-          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
-          call script 'lib.slx.query' : function='SetLastReason', station=$dst, ware=$ware, text='S2S_RECV'
+          null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+          null -> call script 'lib.slx.query' : function='SetLastReason', station=$dst, ware=$ware, text='S2S_RECV'
         else
           $txt = 'NO_PEER'
           if $auto
             $txt = 'A_NO_PEER'
           end
-          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+          null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
         end
       else
         $txt = 'NO_PEER'
         if $auto
           $txt = 'A_NO_PEER'
         end
-        call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+        null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
       end
     else
       $txt = 'NO_PEER'
       if $auto
         $txt = 'A_NO_PEER'
       end
-      call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+      null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
     end
   else if $pct < $cfgMinPct
     $src = null
@@ -413,10 +413,10 @@ StoreLoop:
       dec $idx2
       $other = $stations[$idx2]
       skip if $other == $st
-      $cfg2 = call script 'lib.slx.query' : function='GetStationWareConfig', station=$other, ware=$ware
+      $cfg2 = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$other, ware=$ware
       $cfg2Role = $cfg2[$ROLE]
       skip if $cfg2Role != 'store'
-      $pct2 = call script 'lib.slx.query' : function='GetStationWarePct', station=$other, ware=$ware
+      $pct2 = null -> call script 'lib.slx.query' : function='GetStationWarePct', station=$other, ware=$ware
       $cfg2MaxPct = $cfg2[$MAX_PCT]
       if $pct2 > $cfg2MaxPct
         $src = $other
@@ -429,50 +429,50 @@ StoreLoop:
       $srcCap = $src -> get max amount of ware $ware that can be stored in cargo bay
       $dstAmt = $st -> get amount of ware $ware in cargo bay
       $dstCap = $st -> get max amount of ware $ware that can be stored in cargo bay
-      $srcCfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$src, ware=$ware
+      $srcCfg = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$src, ware=$ware
       $srcChunk = $srcCap * $srcCfg[$CHUNK_PCT] / 100
       $dstChunk = $dstCap * $cfg[$CHUNK_PCT] / 100
       $available = $srcAmt - ($srcCfg[$MAX_PCT] * $srcCap / 100)
       $room = ($cfg[$MIN_PCT] * $dstCap / 100) - $dstAmt
-      $amt = call script 'lib.slx.util' : function='Min', a=$srcChunk, b=$dstChunk
-      $amt = call script 'lib.slx.util' : function='Min', a=$amt, b=$available
-      $amt = call script 'lib.slx.util' : function='Min', a=$amt, b=$room
+      $amt = null -> call script 'lib.slx.util' : function='Min', a=$srcChunk, b=$dstChunk
+      $amt = null -> call script 'lib.slx.util' : function='Min', a=$amt, b=$available
+      $amt = null -> call script 'lib.slx.util' : function='Min', a=$amt, b=$room
       if $amt > 0
-        $ok = call script 'lib.slx.transfer' : function='CanMove', src=$src, dst=$st, ware=$ware, amount=$amt
+        $ok = null -> call script 'lib.slx.transfer' : function='CanMove', src=$src, dst=$st, ware=$ware, amount=$amt
         if $ok
-          call script 'lib.slx.transfer' : function='ApplyMove', src=$src, dst=$st, ware=$ware, amount=$amt
+          null -> call script 'lib.slx.transfer' : function='ApplyMove', src=$src, dst=$st, ware=$ware, amount=$amt
           $txt = 'S2S_RECV'
           if $auto
             $txt = 'A_S2S_RECV'
           end
-          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
-          call script 'lib.slx.query' : function='SetLastReason', station=$src, ware=$ware, text='S2S'
+          null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+          null -> call script 'lib.slx.query' : function='SetLastReason', station=$src, ware=$ware, text='S2S'
         else
           $txt = 'NO_PEER'
           if $auto
             $txt = 'A_NO_PEER'
           end
-          call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+          null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
         end
       else
         $txt = 'NO_PEER'
         if $auto
           $txt = 'A_NO_PEER'
         end
-        call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+        null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
       end
     else
       $txt = 'NO_PEER'
       if $auto
         $txt = 'A_NO_PEER'
       end
-      call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+      null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
     end
   else
     $txt = 'BAL_OK'
     if $auto
       $txt = 'A_BAL_OK'
     end
-    call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
+    null -> call script 'lib.slx.query' : function='SetLastReason', station=$st, ware=$ware, text=$txt
   end
   return null

--- a/src/scripts/plugin.slx.station.menu.x3s
+++ b/src/scripts/plugin.slx.station.menu.x3s
@@ -34,10 +34,10 @@ while [TRUE]
   while $wcount
     dec $wcount
     $ware = $wares[$wcount]
-    $cfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$station, ware=$ware
+    $cfg = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$station, ware=$ware
     $last = $station -> get local variable: name='slx.ware.last_reason'
     $code = $last[$ware]
-    $reason = call script 'lib.slx.ui' : function='FormatReason', code=$code
+    $reason = null -> call script 'lib.slx.ui' : function='FormatReason', code=$code
     $row = sprintf: pageid=$PageId textid=214, $ware, $cfg[$ROLE], $cfg[$MIN_PCT], $cfg[$MAX_PCT], $cfg[$CHUNK_PCT], $reason
     add custom menu item to array $menu: text=$row returnvalue=$ware
     wait 1 ms
@@ -64,13 +64,13 @@ while [TRUE]
       while $idx
         dec $idx
         $w = $all[$idx]
-        call script 'lib.slx.query' : function='SetStationWareConfig', station=$station, ware=$w, cfg=$def
+        null -> call script 'lib.slx.query' : function='SetStationWareConfig', station=$station, ware=$w, cfg=$def
         wait 1 ms
       end
     end
     continue
   end
-  $cfg = call script 'lib.slx.query' : function='GetStationWareConfig', station=$station, ware=$sel
+  $cfg = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$station, ware=$sel
   $txtRole = read text: page=$PageId id=210
   $role = null  ->  get user input: type=Var/String, title=$txtRole
   if not $role
@@ -96,7 +96,7 @@ while [TRUE]
   $new[$MIN_PCT] = $min
   $new[$MAX_PCT] = $max
   $new[$CHUNK_PCT] = $chunk
-  call script 'lib.slx.query' : function='SetStationWareConfig', station=$station, ware=$sel, cfg=$new
+  null -> call script 'lib.slx.query' : function='SetStationWareConfig', station=$station, ware=$sel, cfg=$new
   wait 1 ms
 end
 

--- a/tools/fixtures/known_good/rule_examples.x3s
+++ b/tools/fixtures/known_good/rule_examples.x3s
@@ -29,9 +29,9 @@ dec $s
 
 = wait 5 s
 
-call script 'lib.slx.query' : function='GetSector', station=$st
-call script 'lib.slx.util' : function='Min', a=$srcChunk, b=$dstChunk
-call script 'lib.slx.transfer' : function='ApplyMove', src=$src, dst=$dst, ware=$ware, amount=10
+null -> call script 'lib.slx.query' : function='GetSector', station=$st
+null -> call script 'lib.slx.util' : function='Min', a=$srcChunk, b=$dstChunk
+null -> call script 'lib.slx.transfer' : function='ApplyMove', src=$src, dst=$dst, ware=$ware, amount=10
 
 gosub init
 gosub do_cleanup

--- a/tools/tests/test_call_script_object.py
+++ b/tools/tests/test_call_script_object.py
@@ -1,0 +1,20 @@
+import tempfile
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import x3s_lint
+
+class CallScriptObjectTests(unittest.TestCase):
+    def test_missing_object_raises_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "bad.x3s"
+            p.write_text("call script 'lib.slx.query' : function='GetSector', station=$st\n", encoding='utf-8')
+            msgs = x3s_lint.lint_file(p)
+            self.assertTrue(
+                any("call script missing object reference" in m for m in msgs), msgs
+            )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/x3s_lint.py
+++ b/tools/x3s_lint.py
@@ -200,6 +200,8 @@ def lint_file(path: Path, patterns: list[Rule] | None = None) -> list[str]:
       errors.append(f"{path.name}:{ln}: negative amounts in 'add' require temp variable")
 
     # line-shape validation (warn on unknown shapes)
+    if re.match(r'^\s*(?:\$[A-Za-z0-9_.]+\s*=\s*)?call script\b', low) and "-> call script" not in low:
+      errors.append(f"{path.name}:{ln}: call script missing object reference")
     recognizable = any(pat.regex.match(line.strip()) for pat in patterns)
     if not recognizable and not (re.match(r'^if\b', low) or re.match(r'^else\s+if\b', low) or low == "else" or low == "end" or re.match(r'^while\b', low)):
       # Allow variable assignments and general calls as free-form to reduce false positives

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -122,12 +122,14 @@
     },
     {
       "name": "call script",
-      "pattern": "call script <string> : function=<string>(, <namedArg>)*",
-      "options": {},
+      "pattern": "<obj> -> call script <string> : function=<string>(, <namedArg>)*",
+      "options": {
+        "<obj>": "(?:<var>|\\[THIS\\]|null)"
+      },
       "examples": [
-        "call script 'lib.slx.query' : function='GetSector', station=$st",
-        "call script 'lib.slx.util' : function='Min', a=$srcChunk, b=$dstChunk",
-        "call script 'lib.slx.transfer' : function='ApplyMove', src=$src, dst=$dst, ware=$ware, amount=10"
+        "null -> call script 'lib.slx.query' : function='GetSector', station=$st",
+        "[THIS] -> call script 'lib.slx.util' : function='Min', a=$srcChunk, b=$dstChunk",
+        "$ship -> call script 'lib.slx.transfer' : function='ApplyMove', src=$src, dst=$dst, ware=$ware, amount=10"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- require explicit object (like `null ->`) before all `call script` invocations and update existing scripts
- extend linter to flag missing object references and adjust call-script rule
- add regression test for missing `call script` object usage

## Testing
- `python tools/test_x3s.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7b6ffbad083269cde46c3f3ae11a5