### PR TITLE
Fix plugin config registration and extend linter rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## 0.1.9-internal
+- Registered the plugin config entry through `plugin.config.addscript` and provided default menu text fallbacks.
+- Expanded linter coverage for custom menu item commands and flexible `call script` argument formats.
 - Enforced explicit object reference for all `call script` invocations and updated linter to flag omissions.
 - Cached array indices before conditional checks to avoid invalid direct indexing in transfer and manager scripts.
 - Linter now flags array indexing inside conditional statements, enforcing variable caching before comparisons.

--- a/src/scripts/plugin.slx.init.x3s
+++ b/src/scripts/plugin.slx.init.x3s
@@ -9,7 +9,13 @@ load text: id=$PageId
 $section = read text: page=$PageId id=101
 $txt = read text: page=$PageId id=102
 
-add custom menu item to plugin config: heading=$section text=$txt script='plugin.slx.station.menu'
+skip if $section
+$section = 'SLX'
+
+skip if $txt
+$txt = 'Open SLX'
+
+= [THIS] -> call script plugin.config.addscript : Plugin Name=$txt, Author=null, Script Name='plugin.slx.station.menu', Display author=[FALSE], Add to section=$section, Menu=null
 
 $running = get global variable: name='g.slx.manager.running'
 if not $running

--- a/tools/x3s_rules.json
+++ b/tools/x3s_rules.json
@@ -6,10 +6,14 @@
     "<number>": "-?\\d+",
     "<bool>": "\\[(?:TRUE|FALSE)\\]",
     "<string>": "'(?:[^'\\\\]|\\\\.)*'",
+    "<script>": "(?:<string>|[A-Za-z0-9_.]+)",
     "<time_unit>": "(?:ms|s|sec|secs|seconds|m|min|mins|minutes)",
     "<const>": "(?:\\[[^\\]]+\\]|\\{[^\\}]+\\})",
     "<value>": "(?:<var>|<number>|<string>|<bool>|<const>)",
+    "<valueOrNull>": "(?:<value>|null)",
     "<namedArg>": "<ident>\\s*=\\s*<value>",
+    "<argName>": "<ident>(?:\\s+<ident>)*",
+    "<namedArgOrNull>": "<argName>\\s*=\\s*<valueOrNull>",
     "<expr>": ".+",
     "<label>": "[A-Za-z0-9_.]+"
   },
@@ -122,14 +126,19 @@
     },
     {
       "name": "call script",
-      "pattern": "<obj> -> call script <string> : function=<string>(, <namedArg>)*",
+      "pattern": "(?:<assign>\\s*)?(?:START\\s*(?:=\\s*)?)?<obj> -> call script <script>(\\s*:\\s*<arg_list>)?",
       "options": {
-        "<obj>": "(?:<var>|\\[THIS\\]|null)"
+        "<obj>": "(?:<var>|\\[THIS\\]|null)",
+        "<assign>": "(?:<var>\\s*=|=)",
+        "<arg_list>": "(?:<arg>(?:, <arg>| <arg>)*)?",
+        "<arg>": "<namedArgOrNull>"
       },
       "examples": [
-        "null -> call script 'lib.slx.query' : function='GetSector', station=$st",
+        "$cfg = null -> call script 'lib.slx.query' : function='GetSector', station=$st",
         "[THIS] -> call script 'lib.slx.util' : function='Min', a=$srcChunk, b=$dstChunk",
-        "$ship -> call script 'lib.slx.transfer' : function='ApplyMove', src=$src, dst=$dst, ware=$ware, amount=10"
+        "= [THIS] -> call script plugin.config.addscript : Plugin Name=$txt  Author=null  Script Name='plugin.slx.station.menu'  Display author=[FALSE]  Add to section=$section  Menu=null",
+        "START [THIS] -> call script plugin.slx.manager.tick :",
+        "START  = null -> call script plugin.LI.FDN.Supply.Factory.Check :"
       ]
     },
     {
@@ -152,6 +161,31 @@
         "open custom menu: title=$Ware description=$Text.Version option array=$Menu.Limits.Ware",
         "  open custom menu: title='Foo' description=$Desc option array=$Opts",
         "open custom menu: title=$Title description='Bar' option array=$Arr"
+      ]
+    },
+    {
+      "name": "add custom menu item text",
+      "pattern": "add custom menu item to array <var>: text=<menu_text> returnvalue=<retval>",
+      "options": {
+        "<menu_text>": "<value>",
+        "<retval>": "<valueOrNull>"
+      },
+      "examples": [
+        "add custom menu item to array $menu: text=$toggle returnvalue='toggle'",
+        "add custom menu item to array $menu: text=$row returnvalue=$ware",
+        "add custom menu item to array $menu: text=$exit returnvalue=null"
+      ]
+    },
+    {
+      "name": "add custom menu item page",
+      "pattern": "add custom menu item to array <var>: page=<idref> id=<idref> returnvalue=<retval>",
+      "options": {
+        "<idref>": "(?:<number>|<var>)",
+        "<retval>": "<valueOrNull>"
+      },
+      "examples": [
+        "add custom menu item to array $menu: page=89055 id=102 returnvalue='toggle'",
+        "add custom menu item to array $menu: page=$PageId id=$TextId returnvalue=$value"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- replace the invalid plugin config registration command with a call to `plugin.config.addscript` and provide default text fallbacks
- expand the linter call-script handling to accept optional assignments, START prefixes, and multi-word named arguments
- add explicit lint rules for both text- and page-based custom menu items

## Testing
- python tools/test_x3s.py

------
https://chatgpt.com/codex/tasks/task_e_68c8cc83e79c83269ae562e7a0f117a1