### PR TITLE
Add documentation examples for jump targeting script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,11 @@
 ## Mission
 Automate safe, mechanical X3TC work using **.x3s** source files only. Write scripts, keep IDs organized, lint syntax/structure, and ship docs—no XML build required (use your local compiler when needed).
 
+## Script Archive Requirement
+- Save every provided or third-party reference script verbatim under `scripts/provided/` with a descriptive `.x3s` filename before extracting examples for documentation updates.
+- Keep archived snippets separate from production gameplay scripts in `src/scripts/`.
+- Record any assumptions about archived snippets directly inside the saved file as comments when needed.
+
 ## Roles
 - **Architect** – repo layout, `docs/ids.md`, PR templates.
 - **Scriptor (X3S)** – writes `src/scripts/*.x3s` (setup/lib/commands/AL).

--- a/docs/language/Ship Property Commands.md
+++ b/docs/language/Ship Property Commands.md
@@ -92,6 +92,9 @@ This reference covers ship property commands available in X3TC scripting. Each e
 - `<RefObj> set follow mode <Var/Number>`
 - `<RefObj> set formation <Var/Number>`
 - `<RefObj> set homebase to <Var/Ship/Station>`
+- **Examples:**
+  - `$drone-> set homebase to $dock`
+- **Edge Cases:** _None._
 - `<RefObj> set homesector to <Var/Sector>`
 - `<RefObj> set jumpdrive fuel resupply: amount=<Var/Number>`
 - `<RefObj> set laser energy to <Var/Number>`

--- a/docs/language/Ship Trading Commands.md
+++ b/docs/language/Ship Trading Commands.md
@@ -13,10 +13,15 @@ This reference covers ship trading commands available in X3TC scripting. Each en
 - **Examples:**
   - `if [THIS]-> get amount of ware {Advanced Jumpdrive} in cargo bay`
   - `if [THIS]-> get amount of ware {FTL Jumpdrive Extension} in cargo bay`
+  - `$physical.avialable = $source-> get amount of ware $ware in cargo bay`
 - **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get cargo bay size`
 - `<RetVar/IF> <RefObj> get defined amount of ware <Var/Ware> as ship hardware`
 - `<RetVar/IF> <RefObj> get free amount of ware <Var/Ware> in cargo bay`
+- **Examples:**
+  - `if not $destination-> get free amount of ware $ware in cargo bay`
+  - `if $destination-> get free amount of ware $ware in cargo bay`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get free volume of cargo bay`
 - `<RetVar/IF> <RefObj> get free volume of ware <Var/Ware> in cargo bay`
 - `<RetVar/IF> <RefObj> get max. ware transport class`

--- a/docs/language/Ship Trading Commands.md
+++ b/docs/language/Ship Trading Commands.md
@@ -3,6 +3,8 @@
 This reference covers ship trading commands available in X3TC scripting. Each entry shows the basic syntax.
 
 - `<RetVar/IF> <RefObj> add <Var/Number> units of <Var/Ware>`
+- **Examples:**
+  - `= $drone-> add $sell.amount units of $ware`
 - `<RetVar/IF> <RefObj> buy <Var/Number> units of <Var/Ware>`
 - `<RetVar/IF> <RefObj> buy <Var/Number1> units of <Var/Ware> to a max. price of <Var/Number2> cr`
 - `<RetVar/IF> <RefObj> can buy ware <Var/Ware> at station <Var/Station>`
@@ -14,6 +16,7 @@ This reference covers ship trading commands available in X3TC scripting. Each en
   - `if [THIS]-> get amount of ware {Advanced Jumpdrive} in cargo bay`
   - `if [THIS]-> get amount of ware {FTL Jumpdrive Extension} in cargo bay`
   - `$physical.avialable = $source-> get amount of ware $ware in cargo bay`
+  - `$physical.stock = $dock-> get amount of ware $ware in cargo bay`
 - **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get cargo bay size`
 - `<RetVar/IF> <RefObj> get defined amount of ware <Var/Ware> as ship hardware`
@@ -26,6 +29,9 @@ This reference covers ship trading commands available in X3TC scripting. Each en
 - `<RetVar/IF> <RefObj> get free volume of ware <Var/Ware> in cargo bay`
 - `<RetVar/IF> <RefObj> get max. ware transport class`
 - `<RetVar/IF> <RefObj> get max amount of ware <Var/Ware> that can be stored in cargo bay`
+- **Examples:**
+  - `$drone.max = $drone-> get max amount of ware $ware that can be stored in cargo bay`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get ship hardware as array`
 - `<RetVar/IF> <RefObj> get total volume in cargo bay`
 - `<RetVar/IF> <RefObj> get tradeable ware array from ship`
@@ -40,6 +46,9 @@ This reference covers ship trading commands available in X3TC scripting. Each en
 - `<RetVar/IF> <RefObj> install <Var/Number> units of <Var/Ware>`
 - `<RetVar/IF> <RefObj> load <Var/Number> units of <Var/Ware>`
 - `<RetVar/IF> <RefObj> sell ware <Var/Ware>`
+- **Examples:**
+  - `$sold = $drone-> sell $sell.amount units of $ware`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> set defined amount of ware <Var/Ware> as ship hardware`
 - `<RetVar/IF> <RefObj> set wanted ware count to <Var/Number>`
 - `<RetVar/IF> <RefObj> set wanted ware to <Var/Ware>`

--- a/docs/language/Ship Trading Commands.md
+++ b/docs/language/Ship Trading Commands.md
@@ -8,7 +8,12 @@ This reference covers ship trading commands available in X3TC scripting. Each en
 - `<RetVar/IF> <RefObj> can buy ware <Var/Ware> at station <Var/Station>`
 - `<RetVar/IF> <RefObj> can buy ware <Var/Ware> from race <Var/Race>`
 - `<RetVar/IF> <RefObj> can transport ware <Var/Ware>`
-- `<RetVar/IF> <RefObj> get amount of ware <Var/Ware> in cargo bay`
+- #### Rule: `<RetVar/IF> <RefObj> get amount of ware <Var/Ware> in cargo bay`
+- **Full Description:** `<RetVar/IF> <RefObj> get amount of ware <Var/Ware> in cargo bay`
+- **Examples:**
+  - `if [THIS]-> get amount of ware {Advanced Jumpdrive} in cargo bay`
+  - `if [THIS]-> get amount of ware {FTL Jumpdrive Extension} in cargo bay`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get cargo bay size`
 - `<RetVar/IF> <RefObj> get defined amount of ware <Var/Ware> as ship hardware`
 - `<RetVar/IF> <RefObj> get free amount of ware <Var/Ware> in cargo bay`

--- a/docs/language/Ship Trading Commands.md
+++ b/docs/language/Ship Trading Commands.md
@@ -5,6 +5,9 @@ This reference covers ship trading commands available in X3TC scripting. Each en
 - `<RetVar/IF> <RefObj> add <Var/Number> units of <Var/Ware>`
 - **Examples:**
   - `= $drone-> add $sell.amount units of $ware`
+  - `= $value-> add $remove units of $ware`
+  - `= $value-> add $virtual units of $ware`
+  - `= $value-> add $amount units of $ware`
 - `<RetVar/IF> <RefObj> buy <Var/Number> units of <Var/Ware>`
 - `<RetVar/IF> <RefObj> buy <Var/Number1> units of <Var/Ware> to a max. price of <Var/Number2> cr`
 - `<RetVar/IF> <RefObj> can buy ware <Var/Ware> at station <Var/Station>`
@@ -17,6 +20,7 @@ This reference covers ship trading commands available in X3TC scripting. Each en
   - `if [THIS]-> get amount of ware {FTL Jumpdrive Extension} in cargo bay`
   - `$physical.avialable = $source-> get amount of ware $ware in cargo bay`
   - `$physical.stock = $dock-> get amount of ware $ware in cargo bay`
+  - `$amount = $value-> get amount of ware $ware in cargo bay`
 - **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get cargo bay size`
 - `<RetVar/IF> <RefObj> get defined amount of ware <Var/Ware> as ship hardware`
@@ -24,6 +28,7 @@ This reference covers ship trading commands available in X3TC scripting. Each en
 - **Examples:**
   - `if not $destination-> get free amount of ware $ware in cargo bay`
   - `if $destination-> get free amount of ware $ware in cargo bay`
+  - `$amount = $value-> get free amount of ware $ware in cargo bay`
 - **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get free volume of cargo bay`
 - `<RetVar/IF> <RefObj> get free volume of ware <Var/Ware> in cargo bay`

--- a/docs/language/Station Property Commands.md
+++ b/docs/language/Station Property Commands.md
@@ -16,10 +16,20 @@ This reference covers station property commands available in X3TC scripting. Eac
 - `<RetVar> <RefObj> get number of resources per cycle for ware <Var/Ware>`
 - `<RetVar/IF> <RefObj> get number of secondary resources`
 - `<RetVar/IF> <RefObj> get production cycle time: account for secondary resources=<Var/Number>`
+- #### Rule: `<RetVar/IF> <RefObj> get production cycle time: account for secondary resources=<Var/Number>`
+- **Full Description:** `<RetVar/IF> <RefObj> get production cycle time: account for secondary resources=<Var/Number>`
+- **Examples:**
+  - `$full.time = $factory-> get production cycle time: account for secondary resources=[FALSE]`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get production status: as percentage=<Var/Number>`
 - `<RetVar/IF> <RefObj> get products`
 - `<RetVar/IF> <RefObj> get product ware`
 - `<RetVar/IF> <RefObj> get remaining production cycle time`
+- #### Rule: `<RetVar/IF> <RefObj> get remaining production cycle time`
+- **Full Description:** `<RetVar/IF> <RefObj> get remaining production cycle time`
+- **Examples:**
+  - `$check.time = $factory-> get remaining production cycle time`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get serial name of station`
 - #### Rule: `<RetVar/IF> <RefObj> get tradeable ware array from station`
 - **Full Description:** `<RetVar/IF> <RefObj> get tradeable ware array from station`

--- a/docs/language/Station Property Commands.md
+++ b/docs/language/Station Property Commands.md
@@ -21,7 +21,11 @@ This reference covers station property commands available in X3TC scripting. Eac
 - `<RetVar/IF> <RefObj> get product ware`
 - `<RetVar/IF> <RefObj> get remaining production cycle time`
 - `<RetVar/IF> <RefObj> get serial name of station`
-- `<RetVar/IF> <RefObj> get tradeable ware array from station`
+- #### Rule: `<RetVar/IF> <RefObj> get tradeable ware array from station`
+- **Full Description:** `<RetVar/IF> <RefObj> get tradeable ware array from station`
+- **Examples:**
+  - `$ware.Array = $station-> get tradeable ware array from station`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> is docking possible of <Value>`
 - `<RetVar/IF> <RefObj> is military outpost`
 - `<RetVar/IF> <RefObj> only player own ships can trade with`

--- a/docs/language/Station Trading Commands.md
+++ b/docs/language/Station Trading Commands.md
@@ -22,6 +22,7 @@ This reference covers station trading-related commands available in X3TC scripti
 - `<RetVar/IF> find factory: buys <Var/Ware> with best price: min.price=<Var/Number1>, amount=<Var/Number2>, max.jumps=<Var/Number3>, startsector=<Var/Sector>, trader=<Var/Ship/Station>, exclude array=<Var/Array>`
 - **Examples:**
   - `$sell.Station = find factory: buys $ware with best price: min.price=$sell.at, amount=null, max.jumps=0, startsector=$sector, trader=null, exclude array=$exclude.array`
+- **Optional Parameter Definitions:** See [Station Trading Search Optional Parameters](../options/station-trading-search-options.md).
 - **Edge Cases:** _None._
 - `<RetVar/IF> find factory: buys <Var/Ware> with min jumps: min.price=<Var/Number1>, amount=<Var/Number2>, max.jumps=<Var/Number3>, startsector=<Var/Sector>, trader=<Var/Ship/Station>, exclude array=<Var/Array>`
 - `<RetVar/IF> find factory: sells <Var/Ware> with best chance: max.price=<Var/Number1>, amount=<Var/Number2>, max.jumps=<Var/Number3>, startsector=<Var/Sector>, trader=<Var/Ship/Station>, exclude array=<Var/Array>`

--- a/docs/language/Station Trading Commands.md
+++ b/docs/language/Station Trading Commands.md
@@ -34,6 +34,8 @@ This reference covers station trading-related commands available in X3TC scripti
 - `<RetVar/IF> order ship in next shipyard: owner=<Var/Race> sector=<Var/Sector> class=<Var/Class> optional: default shiptype for race:<Var/Race>`
 - `<RefObj> remove primary resource from factory: <Var/Ware>`
 - `<RefObj> remove product from factory or dock: <Var/Ware>`
+- **Examples:**
+  - `$value-> remove product from factory or dock: $ware`
 - `<RefObj> remove second resource from factory: <Var/Ware>`
 - `station <Var/Station>: lock ware <Var/Ware> for race <Var/Race>`
 - `station <Var/Station>: unlock ware <Var/Ware> for race <Var/Race>`

--- a/docs/language/Station Trading Commands.md
+++ b/docs/language/Station Trading Commands.md
@@ -20,6 +20,9 @@ This reference covers station trading-related commands available in X3TC scripti
 - `<RetVar/IF> find dock: sells <Var/Ware> with min. jumps: max.price=<Var/Number1>, amount=<Var/Number2>, max.jumps=<Var/Number3>, startsector=<Var/Sector>, trader=<Var/Ship/Station>, exclude array=<Var/Array>`
 - `<RetVar/IF> find factory: buys <Var/Ware> with best chance: min.price=<Var/Number1>, amount=<Var/Number2>, max.jumps=<Var/Number3>, startsector=<Var/Sector>, trader=<Var/Ship/Station>, exclude array=<Var/Array>`
 - `<RetVar/IF> find factory: buys <Var/Ware> with best price: min.price=<Var/Number1>, amount=<Var/Number2>, max.jumps=<Var/Number3>, startsector=<Var/Sector>, trader=<Var/Ship/Station>, exclude array=<Var/Array>`
+- **Examples:**
+  - `$sell.Station = find factory: buys $ware with best price: min.price=$sell.at, amount=null, max.jumps=0, startsector=$sector, trader=null, exclude array=$exclude.array`
+- **Edge Cases:** _None._
 - `<RetVar/IF> find factory: buys <Var/Ware> with min jumps: min.price=<Var/Number1>, amount=<Var/Number2>, max.jumps=<Var/Number3>, startsector=<Var/Sector>, trader=<Var/Ship/Station>, exclude array=<Var/Array>`
 - `<RetVar/IF> find factory: sells <Var/Ware> with best chance: max.price=<Var/Number1>, amount=<Var/Number2>, max.jumps=<Var/Number3>, startsector=<Var/Sector>, trader=<Var/Ship/Station>, exclude array=<Var/Array>`
 - `<RetVar/IF> find factory: sells <Var/Ware> with best price: max.price=<Var/Number1>, amount=<Var/Number2>, max.jumps=<Var/Number3>, startsector=<Var/Sector>, trader=<Var/Ship/Station>, exclude array=<Var/Array>`

--- a/docs/language/System Property Commands.md
+++ b/docs/language/System Property Commands.md
@@ -10,4 +10,5 @@ This reference lists system property commands available in X3TC scripting.
 - `write to log file <Var/Number> append=<Var/Number> value=<Value>`
 - **Examples:**
   - `write to log file $DebugID append=[TRUE] value=$txt`
+  - `write to log file $DebugID append=[FALSE] value=$txt`
 - **Edge Cases:** _None._

--- a/docs/language/System Property Commands.md
+++ b/docs/language/System Property Commands.md
@@ -8,3 +8,6 @@ This reference lists system property commands available in X3TC scripting.
 - `write to log file <Var/Number> append=<Var/Number> printf: fmt=<Var/String>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
 - `write to log file <Var/Number> append=<Var/Number> printf: pageid=<Var/Number2> textid=<Var/Number3>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
 - `write to log file <Var/Number> append=<Var/Number> value=<Value>`
+- **Examples:**
+  - `write to log file $DebugID append=[TRUE] value=$txt`
+- **Edge Cases:** _None._

--- a/docs/language/Universe Data Commands.md
+++ b/docs/language/Universe Data Commands.md
@@ -39,7 +39,11 @@ This reference lists universe data commands available in X3TC scripting.
 - `<RetVar/IF> <RefObj> get factory array from sector`
 - `<RetVar/IF> <RefObj> get gate destination: return sector=<Var/Number>`
 - `<RetVar/IF> <RefObj> get gate id`
-- `<RetVar/IF> get jumps from sector <Var/Sector1> to sector <Var/Sector2>`
+- #### Rule: `<RetVar/IF> get jumps from sector <Var/Sector1> to sector <Var/Sector2>`
+- **Full Description:** `<RetVar/IF> get jumps from sector <Var/Sector1> to sector <Var/Sector2>`
+- **Examples:**
+  - `$jumps.needed = get jumps from sector $this.sector to sector $target.sector`
+- **Edge Cases:** _None._
 - `<RetVar/IF> get max sectors in x direction`
 - `<RetVar/IF> get max sectors in y direction`
 - `<RetVar/IF> get next gate on route from <Var/Sector1> to <Var/Sector2>`

--- a/docs/language/Universe Data Commands.md
+++ b/docs/language/Universe Data Commands.md
@@ -10,6 +10,9 @@ This reference lists universe data commands available in X3TC scripting.
 - `<RetVar> create nebula: type=<Var/Number> addto=<Var/Sector> x=<Var/Number1> y=<Var/Number2> z=<Var/Number3>`
 - `<RetVar> create planet: subtype=<Var/Number> addto=<Var/Sector> x=<Var/Number1> y=<Var/Number2> z=<Var/Number3>`
 - `<RetVar> create ship: type=<Var/Ship Type> owner=<Var/Race> addto=<value> x=<Var/Number1> y=<Var/Number2> z=<Var/Number3>`
+- **Examples:**
+  - `$drone = create ship: type={Argon Mercury Super Freighter XL} owner=[Player] addto=$sell.Station x=null y=null z=null`
+- **Edge Cases:** _None._
 - `<RetVar> create special: type=<Var/Number> addto=<Var/Sector> x=<Var/Number1> y=<Var/Number2> z=<Var/Number3>`
 - `<RetVar> create station: type=<Var/Station Type> owner=<Var/Race> addto=<Var/Sector> x=<Var/Number1> y=<Var/Number2> z=<Var/Number3>`
 - `<RetVar> create sun: subtype=<Var/Number> r=<Var/Number1> g=<Var/Number2> b=<Var/Number3> addto=<Var/Sector>`

--- a/docs/language/Universe Data Commands.md
+++ b/docs/language/Universe Data Commands.md
@@ -58,7 +58,11 @@ This reference lists universe data commands available in X3TC scripting.
 - `<RetVar/IF> <RefObj> get ship array from sector/ship/station`
 - `<RetVar/IF> get ship type array: maker race=<Var/Race> class=<value>`
 - `<RetVar/IF> <RefObj> get south warp gate`
-- `<RetVar/IF> get station array: of race <Var/Race> class/type=<value>`
+- #### Rule: `<RetVar/IF> get station array: of race <Var/Race> class/type=<value>`
+- **Full Description:** `<RetVar/IF> get station array: of race <Var/Race> class/type=<value>`
+- **Examples:**
+  - `$dock.array = get station array: of race [Player] class/type=[Dock]`
+- **Edge Cases:** _None._
 - `<RetVar/IF> get station array: product=<Var/Ware> include empty=<Var/Boolean>`
 - `<RetVar/IF> get station array: resource=<Var/Ware> include empty=<Var/Boolean>`
 - `<RetVar/IF> <RefObj> get station array from sector`

--- a/docs/language/Universe Data Commands.md
+++ b/docs/language/Universe Data Commands.md
@@ -24,7 +24,12 @@ This reference lists universe data commands available in X3TC scripting.
 - `<RetVar> find nebula: sector=<Var/Sector> type=<Var/Number> effect=<Var/Number> flags=<Var/Number> refobj=<value> maxdist=<Var/Number> maxnum=<Var/Number> refpos=<Var/Array>`
 - `<RetVar/IF> <RefObj> find ship: class or type=<value> race=<Var/Race> flags=<Var/Number> refobj=<value> maxnum=<Var/Number> with homebase=<value>`
 - `<RetVar/IF> find ship: sector=<Var/Sector> class or type=<value> race=<Var/Race> flags=<Var/Number> refobj=<value> maxdist=<Var/Number2> maxnum=<Var/Number> refpos=<Var/Array>`
-- `<RetVar/IF> find station: sector=<Var/Sector> class or type=<value> race=<Var/Race> flags=<Var/Number> refobj=<value> maxdist=<Var/Number2> maxnum=<Var/Number> refpos=<Var/Array>`
+- #### Rule: `<RetVar/IF> find station: sector=<Var/Sector> class or type=<value> race=<Var/Race> flags=<Var/Number> refobj=<value> maxdist=<Var/Number2> maxnum=<Var/Number> refpos=<Var/Array>`
+- **Full Description:** `<RetVar/IF> find station: sector=<Var/Sector> class or type=<value> race=<Var/Race> flags=<Var/Number> refobj=<value> maxdist=<Var/Number2> maxnum=<Var/Number> refpos=<Var/Array>`
+- **Examples:**
+  - `$factory.array = find station: sector=$sector class or type=[Factory] race=[Player] flags=$flags refobj=null maxdist=null maxnum=999 refpos=null`
+  - `$dock.array = find station: sector=$sector class or type=[Dock] race=[Player] flags=$flags refobj=null maxdist=null maxnum=999 refpos=null`
+- **Edge Cases:** _None._
 - `<RetVar/IF> find station in galaxy: startsector=<Var/Sector> class or type=<value> race=<Var/Race> flags=<Var/Number> refobj=<value> serial=<Var/Stations Serial> max.jumps=<Var/Number2>`
 - `<RetVar/IF> find station in galaxy: startsector=<Var/Sector> class or type=<value> race=<Var/Race> flags=<Var/Number> refobj=<value> serial=<Var/Stations Serial> max.jumps=<Var/Number2> num=<Var/Number>`
 - `<RetVar/IF> <RefObj> get all stationary objects: include asteroids=<Var/Boolean>`

--- a/docs/language/User Interface Commands.md
+++ b/docs/language/User Interface Commands.md
@@ -2,15 +2,24 @@
 
 This reference covers user interface-related commands available in X3TC scripting. Each entry shows the basic syntax.
 
-- `add custom menu heading to array <value>: title=<Var/String>`
+- #### Rule: `add custom menu heading to array <Var/Array>: title=<Var/String>`
+- **Full Description:** `add custom menu heading to array <Var/Array>: title=<Var/String>`
+- **Examples:**
+  - `add custom menu heading to array $menu: title=$txt`
+- **Edge Cases:** _None._
 - #### Rule: `add custom menu info line to array <value>: text=<Var/String>`
 - **Full Description:** `add custom menu info line to array <value>: text=<Var/String>`
 - **Examples:**
   - `add custom menu info line to array $menu: text=' '`
   - `add custom menu info line to array $menu: text=$temp.array`
+  - `add custom menu info line to array $menu: text=$txt`
 - **Edge Cases:** _None._
 - `add custom menu item to array <value>: text=<Var/String> returnvalue=<value>`
-- `add section to custom menu: <Var/Array>`
+- #### Rule: `add section to custom menu: <Var/Array>`
+- **Full Description:** `add section to custom menu: <Var/Array>`
+- **Examples:**
+  - `add section to custom menu: $menu`
+- **Edge Cases:** _None._
 - `add value selection to menu: <Var/Array>, text=<Var/String>, value array=<Var/Array>, default=<Var/Number>, return id=<Var/String>`
 - `<RetVar> create custom menu array`
 - `<RetVar> create custom menu array, info lines=<Var/String>, <Var/String>, <Var/String>, <Var/String>`

--- a/docs/language/User Interface Commands.md
+++ b/docs/language/User Interface Commands.md
@@ -30,7 +30,14 @@ This reference covers user interface-related commands available in X3TC scriptin
 - **Edge Cases:** _None._
 - `<RetVar> create text for custom menu, left=<Var/String>, right=<Var/String>`
 - `display subtitle text: text=<Var/String> duration=<Var/Number> ms`
+- **Examples:**
+  - `display subtitle text: text=$txt duration=2000 ms`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get user input: type=<Script Reference Type>, title=<Var/String>`
+- **Examples:**
+  - `$destination = null-> get user input: type=[Var/Ship/Station owned by Player], title=$txt`
+  - `$amount = null-> get user input: type=[Var/Number], title=$txt`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get user input <Script Reference Type>, title=<Var/String>, sector=<Var/Sector>`
 - `<RetVar/IF> get user input without sector type=<Script Reference Type>, title=<Var/String>`
 - `<RetVar/IF> open custom info menu: title=<Var/String> description=<Var/String> option array=<Var/Array> maxoptions=<Var/Number>`

--- a/docs/language/User Interface Commands.md
+++ b/docs/language/User Interface Commands.md
@@ -3,13 +3,22 @@
 This reference covers user interface-related commands available in X3TC scripting. Each entry shows the basic syntax.
 
 - `add custom menu heading to array <value>: title=<Var/String>`
-- `add custom menu info line to array <value>: text=<Var/String>`
+- #### Rule: `add custom menu info line to array <value>: text=<Var/String>`
+- **Full Description:** `add custom menu info line to array <value>: text=<Var/String>`
+- **Examples:**
+  - `add custom menu info line to array $menu: text=' '`
+  - `add custom menu info line to array $menu: text=$temp.array`
+- **Edge Cases:** _None._
 - `add custom menu item to array <value>: text=<Var/String> returnvalue=<value>`
 - `add section to custom menu: <Var/Array>`
 - `add value selection to menu: <Var/Array>, text=<Var/String>, value array=<Var/Array>, default=<Var/Number>, return id=<Var/String>`
 - `<RetVar> create custom menu array`
 - `<RetVar> create custom menu array, info lines=<Var/String>, <Var/String>, <Var/String>, <Var/String>`
-- `<RetVar> create custom menu array: heading=<Var/String>`
+- #### Rule: `<RetVar> create custom menu array: heading=<Var/String>`
+- **Full Description:** `<RetVar> create custom menu array: heading=<Var/String>`
+- **Examples:**
+  - `$menu = create custom menu array: heading=$txt`
+- **Edge Cases:** _None._
 - `<RetVar> create text for custom menu, left=<Var/String>, right=<Var/String>`
 - `display subtitle text: text=<Var/String> duration=<Var/Number> ms`
 - `<RetVar/IF> <RefObj> get user input: type=<Script Reference Type>, title=<Var/String>`

--- a/docs/language/User Interface Commands.md
+++ b/docs/language/User Interface Commands.md
@@ -15,6 +15,8 @@ This reference covers user interface-related commands available in X3TC scriptin
   - `add custom menu info line to array $menu: text=$txt`
 - **Edge Cases:** _None._
 - `add custom menu item to array <value>: text=<Var/String> returnvalue=<value>`
+- **Examples:**
+  - `add custom menu item to array $menu: text=$txt returnvalue='switch.menu'`
 - #### Rule: `add section to custom menu: <Var/Array>`
 - **Full Description:** `add section to custom menu: <Var/Array>`
 - **Examples:**
@@ -37,11 +39,17 @@ This reference covers user interface-related commands available in X3TC scriptin
 - **Examples:**
   - `$destination = null-> get user input: type=[Var/Ship/Station owned by Player], title=$txt`
   - `$amount = null-> get user input: type=[Var/Number], title=$txt`
+  - `$ware = null-> get user input: type=[Var/Ware], title=$txt`
+  - `$confirm = null-> get user input: type=[Var/Boolean], title=$txt`
 - **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get user input <Script Reference Type>, title=<Var/String>, sector=<Var/Sector>`
 - `<RetVar/IF> get user input without sector type=<Script Reference Type>, title=<Var/String>`
 - `<RetVar/IF> open custom info menu: title=<Var/String> description=<Var/String> option array=<Var/Array> maxoptions=<Var/Number>`
+- **Examples:**
+  - `$return = open custom info menu: title=$txt description=null option array=$menu maxoptions=2`
 - `<RetVar/IF> open custom menu: title=<Var/String> description=<Var/String> option array=<Var/Array>`
+- **Examples:**
+  - `$return = open custom menu: title=$txt description=null option array=$menu`
 - `play sample <Var/Number>`
 - `play sample: incoming transmission <Var/Number>, from object <value>`
 - `<RefObj> send audio message <Var/Number> to player`

--- a/docs/language/array-commands.md
+++ b/docs/language/array-commands.md
@@ -52,6 +52,8 @@ This reference lists array commands available in X3TC scripting.
   - `$temp.array[4] = -200`
   - `$temp.array[6] = -1`
   - `$temp.array[1] = ''`
+  - `$al.Settings[12] = 1`
+  - `$al.Settings[12] = null`
 - **Edge Cases:** _None._
 - `<Var/Array1>[<Var/Number1>] = <Var/Array2>[<Var/Number2>]`
 - #### Rule: `append <Value> to array <Var/Array>`
@@ -133,6 +135,7 @@ This reference lists array commands available in X3TC scripting.
 - **Examples:**
   - `remove element from array $config.Array at index $s`
   - `remove element from array $dock.array at index $s`
+  - `remove element from array $factory.array at index $s`
 - **Edge Cases:** _None._
 - #### Rule: `resize array <Var/Array> to <Var/Number>`
 - **Full Description:** `resize array <Var/Array> to <Var/Number>`
@@ -158,6 +161,7 @@ This reference lists array commands available in X3TC scripting.
 - **Full Description:** `<RetVar/IF> size of array <Var/Array>`
 - **Examples:**
   - `$s = size of array $dock.array`
+  - `$s = size of array $factory.array`
   - `$s = size of array $glb.Array`
   - `$s = size of array $sector.array`
   - `$sf = size of array $factory.array`

--- a/docs/language/array-commands.md
+++ b/docs/language/array-commands.md
@@ -10,6 +10,10 @@ This reference lists array commands available in X3TC scripting.
   - `$is.dynamic = $al.Settings[6]`
   - `$dock = $dock.array[$s]`
   - `$var = $glb.Array[$s]`
+  - `$sector = $sector.array[$s]`
+  - `$factory = $factory.array[$sf]`
+  - `$dock = $dock.array[$sd]`
+  - `$check = $factory.show.array[$s]`
 - **Edge Cases:** _None._
 - `<RetVar/IF> = <Var/Array>[<Var/Number1>][<Var/Number2>]`
 - `<Var/Array>[<Var/Number1>][<Var/Number2>] = <Value>`
@@ -20,6 +24,17 @@ This reference lists array commands available in X3TC scripting.
   - `$temp.array[1] = $txt`
   - `$temp.array[2] = -1`
   - `$temp.array[3] = $txt`
+  - `$factory.show.array[$s] = 1`
+  - `$temp.array[5] = $txt`
+  - `$temp.array[7] = $txt`
+  - `$settings.array[2] = 1`
+  - `$settings.array[0] = 1`
+  - `$settings.array[1] = 1`
+  - `$temp.array[2] = 5`
+  - `$temp.array[3] = $name`
+  - `$temp.array[4] = -200`
+  - `$temp.array[6] = -1`
+  - `$temp.array[1] = ''`
 - **Edge Cases:** _None._
 - `<Var/Array1>[<Var/Number1>] = <Var/Array2>[<Var/Number2>]`
 - #### Rule: `append <Value> to array <Var/Array>`
@@ -37,6 +52,9 @@ This reference lists array commands available in X3TC scripting.
 - **Full Description:** `<RetVar> array alloc: size=<Var/Number>`
 - **Examples:**
   - `$temp.array = array alloc: size=4`
+  - `$factory.show.array = array alloc: size=$s`
+  - `$settings.array = array alloc: size=6`
+  - `$temp.array = array alloc: size=8`
 - **Edge Cases:** _None._
 - `<RetVar/IF> arrays <Value1> and <Value2> are equal`
 - `<RetVar> clone array <Var/Array> : index <Var/Number1> ... <Var/Number2>`
@@ -58,12 +76,25 @@ This reference lists array commands available in X3TC scripting.
 - **Examples:**
   - `resize array $target.pos to 0`
 - **Edge Cases:** _None._
-- `<RetVar/IF> reverse array <Value>`
+- #### Rule: `<RetVar/IF> reverse array <Value>`
+- **Full Description:** `<RetVar/IF> reverse array <Value>`
+- **Examples:**
+  - `$factory.array = reverse array $factory.array`
+  - `$dock.array = reverse array $dock.array`
+- **Edge Cases:** _None._
 - #### Rule: `<RetVar/IF> size of array <Var/Array>`
 - **Full Description:** `<RetVar/IF> size of array <Var/Array>`
 - **Examples:**
   - `$s = size of array $dock.array`
   - `$s = size of array $glb.Array`
+  - `$s = size of array $sector.array`
+  - `$sf = size of array $factory.array`
+  - `$sd = size of array $dock.array`
 - **Edge Cases:** _None._
-- `<RetVar> sort array <Value>`
+- #### Rule: `<RetVar> sort array <Value>`
+- **Full Description:** `<RetVar> sort array <Value>`
+- **Examples:**
+  - `$factory.array = sort array $factory.array`
+  - `$dock.array = sort array $dock.array`
+- **Edge Cases:** _None._
 - `<RetVar> sort array: data=<Value> sort values=<Value>`

--- a/docs/language/array-commands.md
+++ b/docs/language/array-commands.md
@@ -10,6 +10,8 @@ This reference lists array commands available in X3TC scripting.
   - `$dc = $al.Settings[2]`
   - `$is.dynamic = $al.Settings[6]`
   - `$exclude.array = $al.Settings[8]`
+  - `$dock.array = $al.Settings[4]`
+  - `$debug = $al.Settings[7]`
   - `$dock = $dock.array[$s]`
   - `$var = $glb.Array[$s]`
   - `$sector = $sector.array[$s]`
@@ -123,6 +125,7 @@ This reference lists array commands available in X3TC scripting.
 - **Full Description:** `remove element from array <Var/Array> at index <Var/Number>`
 - **Examples:**
   - `remove element from array $config.Array at index $s`
+  - `remove element from array $dock.array at index $s`
 - **Edge Cases:** _None._
 - #### Rule: `resize array <Var/Array> to <Var/Number>`
 - **Full Description:** `resize array <Var/Array> to <Var/Number>`

--- a/docs/language/array-commands.md
+++ b/docs/language/array-commands.md
@@ -8,6 +8,7 @@ This reference lists array commands available in X3TC scripting.
   - `$PageID = $al.Settings[1]`
   - `$dc = $al.Settings[2]`
   - `$is.dynamic = $al.Settings[6]`
+  - `$exclude.array = $al.Settings[8]`
   - `$dock = $dock.array[$s]`
   - `$var = $glb.Array[$s]`
   - `$sector = $sector.array[$s]`
@@ -15,6 +16,9 @@ This reference lists array commands available in X3TC scripting.
   - `$dock = $dock.array[$sd]`
   - `$check = $factory.show.array[$s]`
   - `$ware = $ware.Array[$s]`
+  - `$sell.at = $ware.settings[6]`
+  - `$virtual.stock = $ware.settings[0]`
+  - `$sell = $ware.settings[5]`
 - **Edge Cases:** _None._
 - `<RetVar/IF> = <Var/Array>[<Var/Number1>][<Var/Number2>]`
 - `<Var/Array>[<Var/Number1>][<Var/Number2>] = <Value>`

--- a/docs/language/array-commands.md
+++ b/docs/language/array-commands.md
@@ -12,6 +12,7 @@ This reference lists array commands available in X3TC scripting.
   - `$exclude.array = $al.Settings[8]`
   - `$dock.array = $al.Settings[4]`
   - `$debug = $al.Settings[7]`
+  - `$factory.array = $al.Settings[3]`
   - `$dock = $dock.array[$s]`
   - `$var = $glb.Array[$s]`
   - `$sector = $sector.array[$s]`
@@ -24,8 +25,14 @@ This reference lists array commands available in X3TC scripting.
   - `$sell.at = $ware.settings[6]`
   - `$virtual.stock = $ware.settings[0]`
   - `$sell = $ware.settings[5]`
+  - `$virtual = $ware.array[0]`
+  - `$menu = $return.array[0]`
+  - `$factory.show.array = $return.array[1]`
 - **Edge Cases:** _None._
 - `<RetVar/IF> = <Var/Array>[<Var/Number1>][<Var/Number2>]`
+- **Examples:**
+  - `$count = $return[1][0]`
+  - `$value = $return[1][1]`
 - `<Var/Array>[<Var/Number1>][<Var/Number2>] = <Value>`
 - #### Rule: `<Var/Array>[<Var/Number>] = <Value>`
 - **Full Description:** `<Var/Array>[<Var/Number>] = <Value>`
@@ -154,6 +161,7 @@ This reference lists array commands available in X3TC scripting.
   - `$s = size of array $glb.Array`
   - `$s = size of array $sector.array`
   - `$sf = size of array $factory.array`
+  - `$s = size of array $factory.array`
   - `$sd = size of array $dock.array`
   - `$s = size of array $ware.Array`
   - `$s = size of array $config.Array`

--- a/docs/language/array-commands.md
+++ b/docs/language/array-commands.md
@@ -14,6 +14,7 @@ This reference lists array commands available in X3TC scripting.
   - `$factory = $factory.array[$sf]`
   - `$dock = $dock.array[$sd]`
   - `$check = $factory.show.array[$s]`
+  - `$ware = $ware.Array[$s]`
 - **Edge Cases:** _None._
 - `<RetVar/IF> = <Var/Array>[<Var/Number1>][<Var/Number2>]`
 - `<Var/Array>[<Var/Number1>][<Var/Number2>] = <Value>`
@@ -47,6 +48,26 @@ This reference lists array commands available in X3TC scripting.
   - `append 0 to array $target.pos`
   - `append $target to array $target.pos`
   - `append $format to array $menu`
+  - `append $ware to array $tlaser.Array`
+  - `append $ware to array $tshield.Array`
+  - `append $ware to array $tmissile.Array`
+  - `append $ware to array $tenergy.Array`
+  - `append $ware to array $tnatural.Array`
+  - `append $ware to array $tbio.Array`
+  - `append $ware to array $tfood.Array`
+  - `append $ware to array $tmineral.Array`
+  - `append $ware to array $ttech.Array`
+  - `append $ware to array $tequip.Array`
+  - `append $equip.Array to array $main.ware.Array`
+  - `append $tech.Array to array $main.ware.Array`
+  - `append $mineral.Array to array $main.ware.Array`
+  - `append $food.Array to array $main.ware.Array`
+  - `append $bio.Array to array $main.ware.Array`
+  - `append $natural.Array to array $main.ware.Array`
+  - `append $energy.Array to array $main.ware.Array`
+  - `append $missile.Array to array $main.ware.Array`
+  - `append $shield.Array to array $main.ware.Array`
+  - `append $laser.Array to array $main.ware.Array`
 - **Edge Cases:** _None._
 - #### Rule: `<RetVar> array alloc: size=<Var/Number>`
 - **Full Description:** `<RetVar> array alloc: size=<Var/Number>`
@@ -55,6 +76,17 @@ This reference lists array commands available in X3TC scripting.
   - `$factory.show.array = array alloc: size=$s`
   - `$settings.array = array alloc: size=6`
   - `$temp.array = array alloc: size=8`
+  - `$tlaser.Array = array alloc: size=0`
+  - `$tshield.Array = array alloc: size=0`
+  - `$tmissile.Array = array alloc: size=0`
+  - `$tenergy.Array = array alloc: size=0`
+  - `$tnatural.Array = array alloc: size=0`
+  - `$tbio.Array = array alloc: size=0`
+  - `$tfood.Array = array alloc: size=0`
+  - `$tmineral.Array = array alloc: size=0`
+  - `$ttech.Array = array alloc: size=0`
+  - `$tequip.Array = array alloc: size=0`
+  - `$main.ware.Array = array alloc: size=0`
 - **Edge Cases:** _None._
 - `<RetVar/IF> arrays <Value1> and <Value2> are equal`
 - `<RetVar> clone array <Var/Array> : index <Var/Number1> ... <Var/Number2>`
@@ -65,6 +97,16 @@ This reference lists array commands available in X3TC scripting.
   - `$format = create new array, arguments=$temp.array, $return.array, null, null, null`
   - `$format = create new array, arguments=$temp.array, 'dynamic.dc', null, null, null`
   - `$format = create new array, arguments=$temp.array, 'dynamic.dock', null, null, null`
+  - `$laser.Array = create new array, arguments=8, $tlaser.Array, null, null, null`
+  - `$shield.Array = create new array, arguments=9, $tshield.Array, null, null, null`
+  - `$missile.Array = create new array, arguments=10, $tmissile.Array, null, null, null`
+  - `$energy.Array = create new array, arguments=11, $tenergy.Array, null, null, null`
+  - `$natural.Array = create new array, arguments=12, $tnatural.Array, null, null, null`
+  - `$bio.Array = create new array, arguments=13, $tbio.Array, null, null, null`
+  - `$food.Array = create new array, arguments=14, $tfood.Array, null, null, null`
+  - `$mineral.Array = create new array, arguments=15, $tmineral.Array, null, null, null`
+  - `$tech.Array = create new array, arguments=16, $ttech.Array, null, null, null`
+  - `$equip.Array = create new array, arguments=17, $tequip.Array, null, null, null`
 - **Edge Cases:** _None._
 - `<RetVar/IF> find <Value> in array: <Value>`
 - `<RetVar> get index of <Value> in array <Var/Array> offset=<Var/Number>`
@@ -81,6 +123,15 @@ This reference lists array commands available in X3TC scripting.
 - **Examples:**
   - `$factory.array = reverse array $factory.array`
   - `$dock.array = reverse array $dock.array`
+  - `$tequip.Array = reverse array $tequip.Array`
+  - `$ttech.Array = reverse array $ttech.Array`
+  - `$tmineral.Array = reverse array $tmineral.Array`
+  - `$tfood.Array = reverse array $tfood.Array`
+  - `$tbio.Array = reverse array $tbio.Array`
+  - `$tnatural.Array = reverse array $tnatural.Array`
+  - `$tmissile.Array = reverse array $tmissile.Array`
+  - `$tshield.Array = reverse array $tshield.Array`
+  - `$tlaser.Array = reverse array $tlaser.Array`
 - **Edge Cases:** _None._
 - #### Rule: `<RetVar/IF> size of array <Var/Array>`
 - **Full Description:** `<RetVar/IF> size of array <Var/Array>`
@@ -90,11 +141,21 @@ This reference lists array commands available in X3TC scripting.
   - `$s = size of array $sector.array`
   - `$sf = size of array $factory.array`
   - `$sd = size of array $dock.array`
+  - `$s = size of array $ware.Array`
 - **Edge Cases:** _None._
 - #### Rule: `<RetVar> sort array <Value>`
 - **Full Description:** `<RetVar> sort array <Value>`
 - **Examples:**
   - `$factory.array = sort array $factory.array`
   - `$dock.array = sort array $dock.array`
+  - `$tequip.Array = sort array $tequip.Array`
+  - `$ttech.Array = sort array $ttech.Array`
+  - `$tmineral.Array = sort array $tmineral.Array`
+  - `$tfood.Array = sort array $tfood.Array`
+  - `$tbio.Array = sort array $tbio.Array`
+  - `$tnatural.Array = sort array $tnatural.Array`
+  - `$tmissile.Array = sort array $tmissile.Array`
+  - `$tshield.Array = sort array $tshield.Array`
+  - `$tlaser.Array = sort array $tlaser.Array`
 - **Edge Cases:** _None._
 - `<RetVar> sort array: data=<Value> sort values=<Value>`

--- a/docs/language/array-commands.md
+++ b/docs/language/array-commands.md
@@ -7,7 +7,16 @@ This reference lists array commands available in X3TC scripting.
 - `<Var/Array>[<Var/Number1>][<Var/Number2>] = <Value>`
 - `<Var/Array>[<Var/Number>] = <Value>`
 - `<Var/Array1>[<Var/Number1>] = <Var/Array2>[<Var/Number2>]`
-- `append <Value> to array <Var/Array>`
+- #### Rule: `append <Value> to array <Var/Array>`
+- **Full Description:** `append <Value> to array <Var/Array>`
+- **Examples:**
+  - `append $target.sector to array $target.pos`
+  - `append $target.sector to array $target.pos`
+  - `append 0 to array $target.pos`
+  - `append 0 to array $target.pos`
+  - `append 0 to array $target.pos`
+  - `append $target to array $target.pos`
+- **Edge Cases:** _None._
 - `<RetVar> array alloc: size=<Var/Number>`
 - `<RetVar/IF> arrays <Value1> and <Value2> are equal`
 - `<RetVar> clone array <Var/Array> : index <Var/Number1> ... <Var/Number2>`
@@ -18,7 +27,11 @@ This reference lists array commands available in X3TC scripting.
 - `<RetVar/IF> <RefObj> get object name array`
 - `insert <Value> into array <Var/Array> at index <Var/Number>`
 - `remove element from array <Var/Array> at index <Var/Number>`
-- `resize array <Var/Array> to <Var/Number>`
+- #### Rule: `resize array <Var/Array> to <Var/Number>`
+- **Full Description:** `resize array <Var/Array> to <Var/Number>`
+- **Examples:**
+  - `resize array $target.pos to 0`
+- **Edge Cases:** _None._
 - `<RetVar/IF> reverse array <Value>`
 - `<RetVar/IF> size of array <Var/Array>`
 - `<RetVar> sort array <Value>`

--- a/docs/language/array-commands.md
+++ b/docs/language/array-commands.md
@@ -2,10 +2,25 @@
 
 This reference lists array commands available in X3TC scripting.
 
-- `<RetVar/IF> = <Var/Array>[<Var/Number>]`
+- #### Rule: `<RetVar/IF> = <Var/Array>[<Var/Number>]`
+- **Full Description:** `<RetVar/IF> = <Var/Array>[<Var/Number>]`
+- **Examples:**
+  - `$PageID = $al.Settings[1]`
+  - `$dc = $al.Settings[2]`
+  - `$is.dynamic = $al.Settings[6]`
+  - `$dock = $dock.array[$s]`
+  - `$var = $glb.Array[$s]`
+- **Edge Cases:** _None._
 - `<RetVar/IF> = <Var/Array>[<Var/Number1>][<Var/Number2>]`
 - `<Var/Array>[<Var/Number1>][<Var/Number2>] = <Value>`
-- `<Var/Array>[<Var/Number>] = <Value>`
+- #### Rule: `<Var/Array>[<Var/Number>] = <Value>`
+- **Full Description:** `<Var/Array>[<Var/Number>] = <Value>`
+- **Examples:**
+  - `$temp.array[0] = 1`
+  - `$temp.array[1] = $txt`
+  - `$temp.array[2] = -1`
+  - `$temp.array[3] = $txt`
+- **Edge Cases:** _None._
 - `<Var/Array1>[<Var/Number1>] = <Var/Array2>[<Var/Number2>]`
 - #### Rule: `append <Value> to array <Var/Array>`
 - **Full Description:** `append <Value> to array <Var/Array>`
@@ -16,12 +31,23 @@ This reference lists array commands available in X3TC scripting.
   - `append 0 to array $target.pos`
   - `append 0 to array $target.pos`
   - `append $target to array $target.pos`
+  - `append $format to array $menu`
 - **Edge Cases:** _None._
-- `<RetVar> array alloc: size=<Var/Number>`
+- #### Rule: `<RetVar> array alloc: size=<Var/Number>`
+- **Full Description:** `<RetVar> array alloc: size=<Var/Number>`
+- **Examples:**
+  - `$temp.array = array alloc: size=4`
+- **Edge Cases:** _None._
 - `<RetVar/IF> arrays <Value1> and <Value2> are equal`
 - `<RetVar> clone array <Var/Array> : index <Var/Number1> ... <Var/Number2>`
 - `copy array <Var/Array1> index <Var/Number1> ... <Var/Number2> into array <Var/Array2> at index <Var/Number3>`
-- `<RetVar> create new array, arguments=<Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
+- #### Rule: `<RetVar> create new array, arguments=<Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
+- **Full Description:** `<RetVar> create new array, arguments=<Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
+- **Examples:**
+  - `$format = create new array, arguments=$temp.array, $return.array, null, null, null`
+  - `$format = create new array, arguments=$temp.array, 'dynamic.dc', null, null, null`
+  - `$format = create new array, arguments=$temp.array, 'dynamic.dock', null, null, null`
+- **Edge Cases:** _None._
 - `<RetVar/IF> find <Value> in array: <Value>`
 - `<RetVar> get index of <Value> in array <Var/Array> offset=<Var/Number>`
 - `<RetVar/IF> <RefObj> get object name array`
@@ -33,6 +59,11 @@ This reference lists array commands available in X3TC scripting.
   - `resize array $target.pos to 0`
 - **Edge Cases:** _None._
 - `<RetVar/IF> reverse array <Value>`
-- `<RetVar/IF> size of array <Var/Array>`
+- #### Rule: `<RetVar/IF> size of array <Var/Array>`
+- **Full Description:** `<RetVar/IF> size of array <Var/Array>`
+- **Examples:**
+  - `$s = size of array $dock.array`
+  - `$s = size of array $glb.Array`
+- **Edge Cases:** _None._
 - `<RetVar> sort array <Value>`
 - `<RetVar> sort array: data=<Value> sort values=<Value>`

--- a/docs/language/array-commands.md
+++ b/docs/language/array-commands.md
@@ -5,6 +5,7 @@ This reference lists array commands available in X3TC scripting.
 - #### Rule: `<RetVar/IF> = <Var/Array>[<Var/Number>]`
 - **Full Description:** `<RetVar/IF> = <Var/Array>[<Var/Number>]`
 - **Examples:**
+  - `$status = $al.Settings[0]`
   - `$PageID = $al.Settings[1]`
   - `$dc = $al.Settings[2]`
   - `$is.dynamic = $al.Settings[6]`
@@ -13,6 +14,8 @@ This reference lists array commands available in X3TC scripting.
   - `$var = $glb.Array[$s]`
   - `$sector = $sector.array[$s]`
   - `$factory = $factory.array[$sf]`
+  - `$script.Array = $config.Array[$s]`
+  - `$script = $script.Array[0]`
   - `$dock = $dock.array[$sd]`
   - `$check = $factory.show.array[$s]`
   - `$ware = $ware.Array[$s]`
@@ -116,7 +119,11 @@ This reference lists array commands available in X3TC scripting.
 - `<RetVar> get index of <Value> in array <Var/Array> offset=<Var/Number>`
 - `<RetVar/IF> <RefObj> get object name array`
 - `insert <Value> into array <Var/Array> at index <Var/Number>`
-- `remove element from array <Var/Array> at index <Var/Number>`
+- #### Rule: `remove element from array <Var/Array> at index <Var/Number>`
+- **Full Description:** `remove element from array <Var/Array> at index <Var/Number>`
+- **Examples:**
+  - `remove element from array $config.Array at index $s`
+- **Edge Cases:** _None._
 - #### Rule: `resize array <Var/Array> to <Var/Number>`
 - **Full Description:** `resize array <Var/Array> to <Var/Number>`
 - **Examples:**
@@ -146,6 +153,7 @@ This reference lists array commands available in X3TC scripting.
   - `$sf = size of array $factory.array`
   - `$sd = size of array $dock.array`
   - `$s = size of array $ware.Array`
+  - `$s = size of array $config.Array`
 - **Edge Cases:** _None._
 - #### Rule: `<RetVar> sort array <Value>`
 - **Full Description:** `<RetVar> sort array <Value>`

--- a/docs/language/flow-control-commands.md
+++ b/docs/language/flow-control-commands.md
@@ -16,6 +16,8 @@ This reference covers flow control commands available in X3TC scripting. Each en
   - `= null-> call script 'plugin.LI.FDN.Update.Ware' : ware=$ware amount=$amount station=$source action='remove'`
   - `= null-> call script 'plugin.LI.FDN.Update.Ware' : ware=$ware amount=$sold station=$dock action='remove'`
   - `= [THIS]-> call script 'plugin.config.addscript' : argument1=$txt argument2=null argument3='plugin.LI.FDN.Main.Menu' argument4=[FALSE] argument5=$section argument6=null`
+  - `START null-> call script 'plugin.LI.FDN.Supply.Dock' : dock=$dc flag=1`
+  - `START null-> call script 'plugin.LI.FDN.Supply.Dock' : dock=$dock flag=null`
 - **Edge Cases:** _None._
 - `START <RefObj> command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
 - `START <RefObj> delayed command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
@@ -51,6 +53,7 @@ This reference covers flow control commands available in X3TC scripting. Each en
 - `<RetVar/IF> wait randomly from <Var/Number> to <Var/Number> ms`
 - **Examples:**
   - `= wait randomly from 500 to 1000 ms`
+  - `= wait randomly from 1000 to 2000 ms`
 - **Edge Cases:** _None._
 - `START <RefObj> wing command <Var/Wing Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
 

--- a/docs/language/flow-control-commands.md
+++ b/docs/language/flow-control-commands.md
@@ -11,6 +11,8 @@ This reference covers flow control commands available in X3TC scripting. Each en
   - `$txt = [THIS]-> call script 'plugin.LI.FDN.Format.Name' : object=$dock`
   - `$sector.array = null-> call script 'plugin.LI.FDN.Sector.Array' : search=4`
   - `$name = null-> call script 'plugin.LI.FDN.Format.Name' : object=$dock`
+  - `$amount.added = null-> call script 'plugin.LI.FDN.Update.Ware' : ware=$ware amount=$amount station=$destination action='add'`
+  - `= null-> call script 'plugin.LI.FDN.Update.Ware' : ware=$ware amount=$amount station=$source action='remove'`
 - **Edge Cases:** _None._
 - `START <RefObj> command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
 - `START <RefObj> delayed command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`

--- a/docs/language/flow-control-commands.md
+++ b/docs/language/flow-control-commands.md
@@ -10,9 +10,11 @@ This reference covers flow control commands available in X3TC scripting. Each en
   - `$txt = [THIS]-> call script 'plugin.LI.FDN.Format.Name' : object=$dc`
   - `$txt = [THIS]-> call script 'plugin.LI.FDN.Format.Name' : object=$dock`
   - `$sector.array = null-> call script 'plugin.LI.FDN.Sector.Array' : search=4`
+  - `$sector.array = null-> call script 'plugin.LI.FDN.Sector.Array' : search=3`
   - `$name = null-> call script 'plugin.LI.FDN.Format.Name' : object=$dock`
   - `$amount.added = null-> call script 'plugin.LI.FDN.Update.Ware' : ware=$ware amount=$amount station=$destination action='add'`
   - `= null-> call script 'plugin.LI.FDN.Update.Ware' : ware=$ware amount=$amount station=$source action='remove'`
+  - `= null-> call script 'plugin.LI.FDN.Update.Ware' : ware=$ware amount=$sold station=$dock action='remove'`
 - **Edge Cases:** _None._
 - `START <RefObj> command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
 - `START <RefObj> delayed command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
@@ -32,6 +34,7 @@ This reference covers flow control commands available in X3TC scripting. Each en
   - `gosub Reset.Menu.Sub:`
   - `gosub Factory.Summary.Sub:`
   - `gosub Dock.Summary.Sub:`
+  - `gosub Debug.Sub:`
 - **Edge Cases:** _None._
 - `goto label <Label Name>:`
 - `<RefObj> interrupt task <Var/Number> with script <Script Name> and priority <Var/Number>: arg1=<Value0> arg2=<Value1> arg3=<Value2> arg4=<Value3>`
@@ -45,5 +48,8 @@ This reference covers flow control commands available in X3TC scripting. Each en
 - `<RefObj> launch named script: task=<Var/Number> scriptname=<Var/String> prio=<Var/Number>, <Value>, <Value>, <Value>, <Value>, <Value>`
 - `<RetVar/IF> wait <Var/Number> ms`
 - `<RetVar/IF> wait randomly from <Var/Number> to <Var/Number> ms`
+- **Examples:**
+  - `= wait randomly from 500 to 1000 ms`
+- **Edge Cases:** _None._
 - `START <RefObj> wing command <Var/Wing Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
 

--- a/docs/language/flow-control-commands.md
+++ b/docs/language/flow-control-commands.md
@@ -18,6 +18,23 @@ This reference covers flow control commands available in X3TC scripting. Each en
   - `= [THIS]-> call script 'plugin.config.addscript' : argument1=$txt argument2=null argument3='plugin.LI.FDN.Main.Menu' argument4=[FALSE] argument5=$section argument6=null`
   - `START null-> call script 'plugin.LI.FDN.Supply.Dock' : dock=$dc flag=1`
   - `START null-> call script 'plugin.LI.FDN.Supply.Dock' : dock=$dock flag=null`
+  - `$is.AP = null-> call script 'lib.BW.isAP' :`
+  - `$menu = null-> call script 'plugin.LI.FDN.Menu.AP.DC.Details' : menu=$menu`
+  - `$menu = null-> call script 'plugin.LI.FDN.Menu.DC.Details' : menu=$menu`
+  - `$menu = null-> call script 'plugin.LI.FDN.Menu.AP.Factory.List' : menu=$menu`
+  - `$return.array = null-> call script 'plugin.LI.FDN.Menu.Factory.List' : menu=$menu factory.show.array=null`
+  - `$return.array = null-> call script 'plugin.LI.FDN.Menu.Factory.List' : menu=$menu factory.show.array=$factory.show.array`
+  - `$menu = null-> call script 'plugin.LI.FDN.Menu.Factory.Details' : menu=$menu value=$value`
+  - `START null-> call script 'plugin.LI.FDN.Menu.DC.Details_D' :`
+  - `START null-> call script 'plugin.LI.FDN.Menu.Dock.Details_D' : value=$value`
+  - `$menu = null-> call script 'plugin.LI.FDN.Menu.AP.Dock.Details' : menu=$menu value=$value`
+  - `$menu = null-> call script 'plugin.LI.FDN.Menu.Dock.Details' : menu=$menu value=$value`
+  - `$menu = null-> call script 'plugin.LI.FDN.Menu.Ware.Details' : menu=$menu value=$value ware=$ware`
+  - `$menu = null-> call script 'plugin.LI.FDN.Config.Menu' : menu=$menu`
+  - `$dummy = null-> call script 'plugin.LI.FDN.Move.Ware' : ware=$ware source=$value`
+  - `= null-> call script 'plugin.LI.FDN.Update.Ware' : ware=$ware amount=null station=$value action='create'`
+  - `= null-> call script 'plugin.LI.FDN.Reset' :`
+  - `START null-> call script 'plugin.LI.FDN.Cleanup' :`
 - **Edge Cases:** _None._
 - `START <RefObj> command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
 - `START <RefObj> delayed command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
@@ -38,6 +55,19 @@ This reference covers flow control commands available in X3TC scripting. Each en
   - `gosub Factory.Summary.Sub:`
   - `gosub Dock.Summary.Sub:`
   - `gosub Debug.Sub:`
+  - `gosub Menu.View.Header.Sub:`
+  - `gosub Config.View.Sub:`
+  - `gosub Menu.View.Footer.Sub:`
+  - `gosub Ware.User.Input.Sub:`
+  - `gosub DC.Details.View.Sub:`
+  - `gosub Factory.List.View.Sub:`
+  - `gosub Factory.Details.View.Sub:`
+  - `gosub Dock.Details.View.Sub:`
+  - `gosub Ware.Details.View.Sub:`
+  - `gosub Add.Ware.Sub:`
+  - `gosub Regroom.Ware.Sub:`
+  - `gosub Remove.Ware.Sub:`
+  - `gosub Global.Factory.Sub:`
 - **Edge Cases:** _None._
 - `goto label <Label Name>:`
 - `<RefObj> interrupt task <Var/Number> with script <Script Name> and priority <Var/Number>: arg1=<Value0> arg2=<Value1> arg3=<Value2> arg4=<Value3>`

--- a/docs/language/flow-control-commands.md
+++ b/docs/language/flow-control-commands.md
@@ -12,7 +12,12 @@ This reference covers flow control commands available in X3TC scripting. Each en
 - `goto label <Label Name>:`
 - `<RefObj> interrupt task <Var/Number> with script <Script Name> and priority <Var/Number>: arg1=<Value0> arg2=<Value1> arg3=<Value2> arg4=<Value3>`
 - `<RefObj> interrupt with script <Script Name> and priority <Var/Number>`
-- `<RefObj> interrupt with script <Script Name> and priority <Var/Number>: arg1=<Value> arg2=<Value> arg3=<Value> arg4=<Value>`
+- #### Rule: `<RefObj> interrupt with script <Script Name> and priority <Var/Number>: arg1=<Value> arg2=<Value> arg3=<Value> arg4=<Value>`
+- **Full Description:** `<RefObj> interrupt with script <Script Name> and priority <Var/Number>: arg1=<Value> arg2=<Value> arg3=<Value> arg4=<Value>`
+- **Examples:**
+  - `[THIS]-> interrupt with script 'plugin.advjump.jump' and priority 40: arg1=$target.pos arg2=null arg3=null arg4=null`
+  - `[THIS]-> interrupt with script 'plugin.advjump.jump' and priority 40: arg1=$target.sector arg2=null arg3=null arg4=null`
+- **Edge Cases:** _None._
 - `<RefObj> launch named script: task=<Var/Number> scriptname=<Var/String> prio=<Var/Number>, <Value>, <Value>, <Value>, <Value>, <Value>`
 - `<RetVar/IF> wait <Var/Number> ms`
 - `<RetVar/IF> wait randomly from <Var/Number> to <Var/Number> ms`

--- a/docs/language/flow-control-commands.md
+++ b/docs/language/flow-control-commands.md
@@ -35,6 +35,8 @@ This reference covers flow control commands available in X3TC scripting. Each en
   - `= null-> call script 'plugin.LI.FDN.Update.Ware' : ware=$ware amount=null station=$value action='create'`
   - `= null-> call script 'plugin.LI.FDN.Reset' :`
   - `START null-> call script 'plugin.LI.FDN.Cleanup' :`
+  - `START null-> call script 'plugin.LI.FDN.Supply.Factory' : factory=$factory flag=1`
+  - `START null-> call script 'plugin.LI.FDN.Supply.Factory' : factory=$factory flag=null`
 - **Edge Cases:** _None._
 - `START <RefObj> command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
 - `START <RefObj> delayed command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
@@ -84,6 +86,7 @@ This reference covers flow control commands available in X3TC scripting. Each en
 - **Examples:**
   - `= wait randomly from 500 to 1000 ms`
   - `= wait randomly from 1000 to 2000 ms`
+  - `= wait randomly from $wait.1 to $wait.2 ms`
 - **Edge Cases:** _None._
 - `START <RefObj> wing command <Var/Wing Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
 

--- a/docs/language/flow-control-commands.md
+++ b/docs/language/flow-control-commands.md
@@ -4,11 +4,29 @@ This reference covers flow control commands available in X3TC scripting. Each en
 
 - `<RefObj> begin task <Var/Number> with script <Script Name> and priority <Var/Number>: arg1=<Value0> arg2=<Value1> arg3=<Value2> arg4=<Value3> arg5=<Value4>`
 - `<RetVar/IF> <RefObj> call named script: script=<Var/String>, <Value>, <Value>, <Value>, <Value>, <Value>`
-- `<RetVar/IF/START> <RefObj> call script <Script Name> : [ arg1=<Value> arg2=<Value> ... arga=<Value> ]`
+- #### Rule: `<RetVar/IF/START> <RefObj> call script <Script Name> : [ arg1=<Value> arg2=<Value> ... arga=<Value> ]`
+- **Full Description:** `<RetVar/IF/START> <RefObj> call script <Script Name> : [ arg1=<Value> arg2=<Value> ... arga=<Value> ]`
+- **Examples:**
+  - `$txt = [THIS]-> call script 'plugin.LI.FDN.Format.Name' : object=$dc`
+  - `$txt = [THIS]-> call script 'plugin.LI.FDN.Format.Name' : object=$dock`
+- **Edge Cases:** _None._
 - `START <RefObj> command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
 - `START <RefObj> delayed command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
-- `endsub`
-- `gosub <Label Name>:`
+- #### Rule: `endsub`
+- **Full Description:** `endsub`
+- **Examples:**
+  - `endsub`
+- **Edge Cases:** _None._
+- #### Rule: `gosub <Label Name>:`
+- **Full Description:** `gosub <Label Name>:`
+- **Examples:**
+  - `gosub Add.DC.Menu.Sub:`
+  - `gosub Change.DC.Menu.Sub:`
+  - `gosub Global.Options.Sub:`
+  - `gosub Dynamic.Menu.Sub:`
+  - `gosub Debug.Menu.Sub:`
+  - `gosub Reset.Menu.Sub:`
+- **Edge Cases:** _None._
 - `goto label <Label Name>:`
 - `<RefObj> interrupt task <Var/Number> with script <Script Name> and priority <Var/Number>: arg1=<Value0> arg2=<Value1> arg3=<Value2> arg4=<Value3>`
 - `<RefObj> interrupt with script <Script Name> and priority <Var/Number>`

--- a/docs/language/flow-control-commands.md
+++ b/docs/language/flow-control-commands.md
@@ -9,6 +9,8 @@ This reference covers flow control commands available in X3TC scripting. Each en
 - **Examples:**
   - `$txt = [THIS]-> call script 'plugin.LI.FDN.Format.Name' : object=$dc`
   - `$txt = [THIS]-> call script 'plugin.LI.FDN.Format.Name' : object=$dock`
+  - `$sector.array = null-> call script 'plugin.LI.FDN.Sector.Array' : search=4`
+  - `$name = null-> call script 'plugin.LI.FDN.Format.Name' : object=$dock`
 - **Edge Cases:** _None._
 - `START <RefObj> command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
 - `START <RefObj> delayed command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
@@ -26,6 +28,8 @@ This reference covers flow control commands available in X3TC scripting. Each en
   - `gosub Dynamic.Menu.Sub:`
   - `gosub Debug.Menu.Sub:`
   - `gosub Reset.Menu.Sub:`
+  - `gosub Factory.Summary.Sub:`
+  - `gosub Dock.Summary.Sub:`
 - **Edge Cases:** _None._
 - `goto label <Label Name>:`
 - `<RefObj> interrupt task <Var/Number> with script <Script Name> and priority <Var/Number>: arg1=<Value0> arg2=<Value1> arg3=<Value2> arg4=<Value3>`

--- a/docs/language/flow-control-commands.md
+++ b/docs/language/flow-control-commands.md
@@ -73,12 +73,14 @@ This reference covers flow control commands available in X3TC scripting. Each en
 - **Edge Cases:** _None._
 - `goto label <Label Name>:`
 - `<RefObj> interrupt task <Var/Number> with script <Script Name> and priority <Var/Number>: arg1=<Value0> arg2=<Value1> arg3=<Value2> arg4=<Value3>`
+  - **Optional Parameter Definitions:** See [Flow Control Interrupt Optional Parameters](../options/flow-control-interrupt-options.md).
 - `<RefObj> interrupt with script <Script Name> and priority <Var/Number>`
 - #### Rule: `<RefObj> interrupt with script <Script Name> and priority <Var/Number>: arg1=<Value> arg2=<Value> arg3=<Value> arg4=<Value>`
 - **Full Description:** `<RefObj> interrupt with script <Script Name> and priority <Var/Number>: arg1=<Value> arg2=<Value> arg3=<Value> arg4=<Value>`
 - **Examples:**
   - `[THIS]-> interrupt with script 'plugin.advjump.jump' and priority 40: arg1=$target.pos arg2=null arg3=null arg4=null`
   - `[THIS]-> interrupt with script 'plugin.advjump.jump' and priority 40: arg1=$target.sector arg2=null arg3=null arg4=null`
+- **Optional Parameter Definitions:** See [Flow Control Interrupt Optional Parameters](../options/flow-control-interrupt-options.md).
 - **Edge Cases:** _None._
 - `<RefObj> launch named script: task=<Var/Number> scriptname=<Var/String> prio=<Var/Number>, <Value>, <Value>, <Value>, <Value>, <Value>`
 - `<RetVar/IF> wait <Var/Number> ms`

--- a/docs/language/flow-control-commands.md
+++ b/docs/language/flow-control-commands.md
@@ -15,6 +15,7 @@ This reference covers flow control commands available in X3TC scripting. Each en
   - `$amount.added = null-> call script 'plugin.LI.FDN.Update.Ware' : ware=$ware amount=$amount station=$destination action='add'`
   - `= null-> call script 'plugin.LI.FDN.Update.Ware' : ware=$ware amount=$amount station=$source action='remove'`
   - `= null-> call script 'plugin.LI.FDN.Update.Ware' : ware=$ware amount=$sold station=$dock action='remove'`
+  - `= [THIS]-> call script 'plugin.config.addscript' : argument1=$txt argument2=null argument3='plugin.LI.FDN.Main.Menu' argument4=[FALSE] argument5=$section argument6=null`
 - **Edge Cases:** _None._
 - `START <RefObj> command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`
 - `START <RefObj> delayed command <Object Command> : arg1=<Value>, arg2=<Value>, arg3=<Value>, arg4=<Value>`

--- a/docs/language/game-engine-commands.md
+++ b/docs/language/game-engine-commands.md
@@ -16,6 +16,7 @@ This reference summarizes various game engine and quest commands available in X3
 - **Full Description:** Retrieves the value of a named global variable.
 - **Examples:**
   - `$al.Settings = get global variable: name='al.LI.FDN.event'`
+  - `$config.Array = get global variable: name='config.scripts'`
 - **Edge Cases:** _None._
 - `register god event: script=<Script Name> mask=<Var/Number>`: Registers a script to run as a god event with a condition mask.
 - `register quest script <Script Name> instance multiple=<Var/Number>`: Registers a quest script, allowing multiple instances when needed.

--- a/docs/language/game-engine-commands.md
+++ b/docs/language/game-engine-commands.md
@@ -12,14 +12,22 @@ This reference summarizes various game engine and quest commands available in X3
 - `change event news availability`: Controls news article availability based on race, sector, and jump range.
 - `<RetVar/IF> display news article`: Shows a news article with optional placeholders and display limits.
 - `finish god event`: Marks a god event as completed and triggers post-event logic.
-- `<RetVar/IF> get global variable: name=<Var/String>`: Retrieves the value of a named global variable.
+- #### Rule: `<RetVar/IF> get global variable: name=<Var/String>`
+- **Full Description:** Retrieves the value of a named global variable.
+- **Examples:**
+  - `$al.Settings = get global variable: name='al.LI.FDN.event'`
+- **Edge Cases:** _None._
 - `register god event: script=<Script Name> mask=<Var/Number>`: Registers a script to run as a god event with a condition mask.
 - `register quest script <Script Name> instance multiple=<Var/Number>`: Registers a quest script, allowing multiple instances when needed.
 - `remove encyclopedia custom article: id=<Var/String>`: Deletes a custom encyclopedia entry.
 - `<RefObj> remove event listener: quest/event=<Var/Quest>`: Detaches an event listener script from an object.
 - `<RetVar> script engine version`: Returns the script engine's version number.
 - `set encyclopedia custom article sectors: id=<Var/String>, sector array=<Var/Array>`: Restricts a custom article to specified sectors.
-- `set global variable: name=<Var/String> value=<Value>`: Sets or creates a global variable.
+- #### Rule: `set global variable: name=<Var/String> value=<Value>`
+- **Full Description:** Sets or creates a global variable.
+- **Examples:**
+  - `set global variable: name=$var value=null`
+- **Edge Cases:** _None._
 - `set quest/event <Var/Quest> alive=<Var/Number>`: Enables or disables a quest/event.
 - `set quest/event <Var/Quest> timer to <Var/Number>`: Sets a countdown before a quest/event triggers or expires.
 - `set quest/event <Var/Quest> timeout to <Var/Number>`: Defines how long a quest/event remains active before auto-completion or failure.

--- a/docs/language/game-engine-commands.md
+++ b/docs/language/game-engine-commands.md
@@ -28,6 +28,7 @@ This reference summarizes various game engine and quest commands available in X3
 - **Full Description:** Sets or creates a global variable.
 - **Examples:**
   - `set global variable: name=$var value=null`
+  - `set global variable: name='al.LI.FDN.event' value=$al.Settings`
 - **Edge Cases:** _None._
 - `set quest/event <Var/Quest> alive=<Var/Number>`: Enables or disables a quest/event.
 - `set quest/event <Var/Quest> timer to <Var/Number>`: Sets a countdown before a quest/event triggers or expires.

--- a/docs/language/macro-commands.md
+++ b/docs/language/macro-commands.md
@@ -11,6 +11,7 @@ This reference lists macro commands available in X3TC scripting.
   - `add custom menu heading to array $menu: page=$PageID id=108`
   - `add custom menu heading to array $menu: page=$PageID id=126`
   - `add custom menu heading to array $menu: page=$PageID id=127`
+  - `add custom menu heading to array $menu: page=$PageID id=157`
 - **Edge Cases:** _None._
 - #### Rule: `add custom menu info line to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
 - **Full Description:** `add custom menu info line to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
@@ -22,12 +23,23 @@ This reference lists macro commands available in X3TC scripting.
 - **Full Description:** `add custom menu item to array <Var/Array>: page=<Var/Number1> id=<Var/Number2> returnvalue=<Value>`
 - **Examples:**
   - `add custom menu item to array $menu: page=$PageID id=128 returnvalue='master.reset'`
+  - `add custom menu item to array $menu: page=$PageID id=1000 returnvalue=$return.array`
+  - `add custom menu item to array $menu: page=$PageID id=1001 returnvalue=$return.array`
+  - `add custom menu item to array $menu: page=$PageID id=158 returnvalue='product.all.on'`
+  - `add custom menu item to array $menu: page=$PageID id=159 returnvalue='resource.all.on'`
+  - `add custom menu item to array $menu: page=$PageID id=166 returnvalue='product.all.off'`
+  - `add custom menu item to array $menu: page=$PageID id=167 returnvalue='resource.all.off'`
 - **Edge Cases:** _None._
 - #### Rule: `dim <Var/Array> = <Value> [, <Value> ] [, <Value> ] ... [, <Value> ]`
 - **Full Description:** `dim <Var/Array> = <Value> [, <Value> ] [, <Value> ] ... [, <Value> ]`
 - **Examples:**
   - `dim $return.array = 'add.dc', $dock`
   - `dim $return.array = 'change.dc', $dock`
+  - `dim $return.array = 'show.factory', $s`
+  - `dim $return.array = 'open.dock', $dock`
+  - `dim $temp.array = 1, '', 5, $name, -1, ' '`
+  - `dim $return.array = 'open.factory', $factory`
+  - `dim $return.array = $menu, $factory.show.array`
 - **Edge Cases:** _None._
 - `for <Var> = <Var/Number1> to <Var/Number2> step <Number>`
 - `for each <Var> in array <Var/Array>`

--- a/docs/language/macro-commands.md
+++ b/docs/language/macro-commands.md
@@ -2,10 +2,33 @@
 
 This reference lists macro commands available in X3TC scripting.
 
-- `add custom menu heading to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
-- `add custom menu info line to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
-- `add custom menu item to array <Var/Array>: page=<Var/Number1> id=<Var/Number2> returnvalue=<Value>`
-- `dim <Var/Array> = <Value> [, <Value> ] [, <Value> ] ... [, <Value> ]`
+- #### Rule: `add custom menu heading to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
+- **Full Description:** `add custom menu heading to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
+- **Examples:**
+  - `add custom menu heading to array $menu: page=$PageID id=123`
+  - `add custom menu heading to array $menu: page=$PageID id=124`
+  - `add custom menu heading to array $menu: page=$PageID id=125`
+  - `add custom menu heading to array $menu: page=$PageID id=108`
+  - `add custom menu heading to array $menu: page=$PageID id=126`
+  - `add custom menu heading to array $menu: page=$PageID id=127`
+- **Edge Cases:** _None._
+- #### Rule: `add custom menu info line to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
+- **Full Description:** `add custom menu info line to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
+- **Examples:**
+  - `add custom menu info line to array $menu: page=$PageID id=119`
+  - `add custom menu info line to array $menu: page=$PageID id=129`
+- **Edge Cases:** _None._
+- #### Rule: `add custom menu item to array <Var/Array>: page=<Var/Number1> id=<Var/Number2> returnvalue=<Value>`
+- **Full Description:** `add custom menu item to array <Var/Array>: page=<Var/Number1> id=<Var/Number2> returnvalue=<Value>`
+- **Examples:**
+  - `add custom menu item to array $menu: page=$PageID id=128 returnvalue='master.reset'`
+- **Edge Cases:** _None._
+- #### Rule: `dim <Var/Array> = <Value> [, <Value> ] [, <Value> ] ... [, <Value> ]`
+- **Full Description:** `dim <Var/Array> = <Value> [, <Value> ] [, <Value> ] ... [, <Value> ]`
+- **Examples:**
+  - `dim $return.array = 'add.dc', $dock`
+  - `dim $return.array = 'change.dc', $dock`
+- **Edge Cases:** _None._
 - `for <Var> = <Var/Number1> to <Var/Number2> step <Number>`
 - `for each <Var> in array <Var/Array>`
 - `for each <Var1> in array <Var/Array> using counter <Var2>`

--- a/docs/language/macro-commands.md
+++ b/docs/language/macro-commands.md
@@ -8,6 +8,7 @@ This reference lists macro commands available in X3TC scripting.
   - `add custom menu heading to array $menu: page=$PageID id=123`
   - `add custom menu heading to array $menu: page=$PageID id=124`
   - `add custom menu heading to array $menu: page=$PageID id=125`
+  - `add custom menu heading to array $menu: page=$PageID id=110`
   - `add custom menu heading to array $menu: page=$PageID id=108`
   - `add custom menu heading to array $menu: page=$PageID id=126`
   - `add custom menu heading to array $menu: page=$PageID id=127`

--- a/docs/language/math-commands.md
+++ b/docs/language/math-commands.md
@@ -2,7 +2,11 @@
 
 This reference lists math operations and random number commands in X3TC scripting. Each entry shows the basic syntax.
 
-- `dec <Var>`
+- #### Rule: `dec <Var>`
+- **Full Description:** `dec <Var>`
+- **Examples:**
+  - `dec $s`
+- **Edge Cases:** _None._
 - `<RetVar> fixed cos <Var/Number>`
 - `<RetVar> fixed sin <Var/Number>`
 - `<RetVar> get maximum, <Var/Number0>, <Var/Number1>, <Var/Number2>, <Var/Number3>, <Var/Number4>`

--- a/docs/language/math-commands.md
+++ b/docs/language/math-commands.md
@@ -6,11 +6,21 @@ This reference lists math operations and random number commands in X3TC scriptin
 - **Full Description:** `dec <Var>`
 - **Examples:**
   - `dec $s`
+  - `dec $sf`
+  - `dec $sd`
 - **Edge Cases:** _None._
 - `<RetVar> fixed cos <Var/Number>`
 - `<RetVar> fixed sin <Var/Number>`
 - `<RetVar> get maximum, <Var/Number0>, <Var/Number1>, <Var/Number2>, <Var/Number3>, <Var/Number4>`
-- `inc <Var>`
+- #### Rule: `inc <Var>`
+- **Full Description:** `inc <Var>`
+- **Examples:**
+  - `inc $sector.count`
+  - `inc $factory.count`
+  - `inc $dock.count`
+  - `inc $product.count`
+  - `inc $resource.count`
+- **Edge Cases:** _None._
 - `<RetVar> random value between <Var/Number1> and <Var/Number2>`
 - `<RetVar/IF> random value from zero to <Var/Number>`
 - `<RetVar> square root of <Var/Number>`

--- a/docs/language/object-action-commands.md
+++ b/docs/language/object-action-commands.md
@@ -6,6 +6,9 @@ This reference lists object-related action commands available in X3TC scripting.
 - `<RefObj> add shields per value=<Var/Number>`
 - `<RefObj> destroy object: killer=<value>, show no explosion=<Var/Number>`
 - `<RefObj> destruct: show no explosion=<Var/Number>`
+- **Examples:**
+  - `$drone-> destruct: show no explosion=[TRUE]`
+- **Edge Cases:** _None._
 - `<RefObj> force position: x=<Var/Number> y=<Var/Number> z=<Var/Number>`
 - `<RefObj> put into environment <RefObj>`
 - `<RefObj> send signal <Object Signal> : arg1=<value>, arg2=<value>, arg3=<value>, arg4=<value>`

--- a/docs/language/object-property-commands.md
+++ b/docs/language/object-property-commands.md
@@ -40,7 +40,11 @@ This reference covers object property commands available in X3TC scripting. Each
   - `$id = $object-> get ID code`
 - **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get laser type in bay <Var/Number>`
-- `<RetVar/IF> <RefObj> get local variable: name=<Var/String>`
+- #### Rule: `<RetVar/IF> <RefObj> get local variable: name=<Var/String>`
+- **Full Description:** `<RetVar/IF> <RefObj> get local variable: name=<Var/String>`
+- **Examples:**
+  - `$settings.array = $factory-> get local variable: name=$pointer`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get local variables: regular expression=<Var/String>`
 - `<RetVar/IF> <RefObj> get maintype`
 - `<RetVar/IF> <RefObj> get maker race`
@@ -101,7 +105,11 @@ This reference covers object property commands available in X3TC scripting. Each
 - `<RetVar/IF> <RefObj> is <Var/Ship/Station> a enemy`
 - `<RetVar/IF> <RefObj> is <Var/Ship/Station> a friend`
 - `<RetVar/IF> <RefObj> is asteroid scanned`
-- `<RetVar/IF> <RefObj> is detectable`
+- #### Rule: `<RetVar/IF> <RefObj> is detectable`
+- **Full Description:** `<RetVar/IF> <RefObj> is detectable`
+- **Examples:**
+  - `$detectable = $factory-> is detectable`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> is disabled`
 - `<RetVar/IF> <RefObj> is docking allowed at <Var/Ship/Station>`
 - `<RetVar/IF> <RefObj> is hidden`
@@ -118,6 +126,8 @@ This reference covers object property commands available in X3TC scripting. Each
 - **Full Description:** `<RetVar/IF> <RefObj> is of class <Var/Class>`
 - **Examples:**
   - `if $target-> is of class [Moveable Ship]`
+  - `if $factory-> is of class [Factory]`
+  - `if not $factory-> is of class [Complex Hub]`
 - **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> is of type <Var/Ship Type/Station Type>`
 - `<RetVar/IF> <RefObj> is starting`
@@ -131,7 +141,11 @@ This reference covers object property commands available in X3TC scripting. Each
 - `set discovered status: type=<Value> status=<Var/Boolean>`
 - `<RefObj> set hull to <Var/Number>`
 - `<RefObj> set known status to <Var/Number>`
-- `<RefObj> set local variable: name=<Var/String> value=<Value>`
+- #### Rule: `<RefObj> set local variable: name=<Var/String> value=<Value>`
+- **Full Description:** `<RefObj> set local variable: name=<Var/String> value=<Value>`
+- **Examples:**
+  - `$factory-> set local variable: name=$pointer value=$settings.array`
+- **Edge Cases:** _None._
 - `<RefObj> set name to <Var/String>`
 - `<RefObj> set owner race to <Var/Race>`
 - `<RefObj> set position: x=<Var/Number> y=<Var/Number> z=<Var/Number>`

--- a/docs/language/object-property-commands.md
+++ b/docs/language/object-property-commands.md
@@ -44,6 +44,7 @@ This reference covers object property commands available in X3TC scripting. Each
 - **Full Description:** `<RetVar/IF> <RefObj> get local variable: name=<Var/String>`
 - **Examples:**
   - `$settings.array = $factory-> get local variable: name=$pointer`
+  - `$ware.array = $source-> get local variable: name=$pointer`
 - **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get local variables: regular expression=<Var/String>`
 - `<RetVar/IF> <RefObj> get maintype`
@@ -128,6 +129,7 @@ This reference covers object property commands available in X3TC scripting. Each
   - `if $target-> is of class [Moveable Ship]`
   - `if $factory-> is of class [Factory]`
   - `if not $factory-> is of class [Complex Hub]`
+  - `if not $destination-> is of class [Dock]`
 - **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> is of type <Var/Ship Type/Station Type>`
 - `<RetVar/IF> <RefObj> is starting`

--- a/docs/language/object-property-commands.md
+++ b/docs/language/object-property-commands.md
@@ -34,7 +34,11 @@ This reference covers object property commands available in X3TC scripting. Each
 - `<RetVar/IF> <RefObj> get flying ware count`
 - `<RetVar/IF> <RefObj> get hull`
 - `<RetVar/IF> <RefObj> get hull percent`
-- `<RetVar/IF> <RefObj> get ID code`
+- #### Rule: `<RetVar/IF> <RefObj> get ID code`
+- **Full Description:** `<RetVar/IF> <RefObj> get ID code`
+- **Examples:**
+  - `$id = $object-> get ID code`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get laser type in bay <Var/Number>`
 - `<RetVar/IF> <RefObj> get local variable: name=<Var/String>`
 - `<RetVar/IF> <RefObj> get local variables: regular expression=<Var/String>`
@@ -44,7 +48,11 @@ This reference covers object property commands available in X3TC scripting. Each
 - `<RetVar/IF> <RefObj> get max. shield type that can be installed`
 - `<RetVar/IF> <RefObj> get maximum laser strength`
 - `<RetVar/IF> <RefObj> get maximum shield strength`
-- `<RetVar/IF> <RefObj> get name`
+- #### Rule: `<RetVar/IF> <RefObj> get name`
+- **Full Description:** `<RetVar/IF> <RefObj> get name`
+- **Examples:**
+  - `$name = $object-> get name`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get notoriety percentage to race <Var/Race>`
 - `<RetVar/IF> <RefObj> get notoriety title to race <Var/Race>: text=<Var/Boolean>`
 - `<RetVar/IF> <RefObj> get notoriety to race <Var/Race>`
@@ -72,6 +80,8 @@ This reference covers object property commands available in X3TC scripting. Each
 - **Examples:**
   - `$target.sector = $target-> get sector`
   - `$this.sector = [THIS]-> get sector`
+  - `$txt = $dc-> get sector`
+  - `$txt = $dock-> get sector`
 - **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get shield and hull percent`
 - `<RetVar/IF> <RefObj> get shield percent`

--- a/docs/language/object-property-commands.md
+++ b/docs/language/object-property-commands.md
@@ -45,6 +45,7 @@ This reference covers object property commands available in X3TC scripting. Each
 - **Examples:**
   - `$settings.array = $factory-> get local variable: name=$pointer`
   - `$ware.array = $source-> get local variable: name=$pointer`
+  - `$ware.settings = $dock-> get local variable: name=$pointer`
 - **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get local variables: regular expression=<Var/String>`
 - `<RetVar/IF> <RefObj> get maintype`
@@ -75,6 +76,9 @@ This reference covers object property commands available in X3TC scripting. Each
 - **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get power generator`
 - `<RetVar/IF> <RefObj> get relation to object <Var/Ship/Station>`
+- **Examples:**
+  - `$relation = $dock-> get relation to object $sell.Station`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get relation to race <Var/Race>`
 - `<RetVar/IF> <RefObj> get resource waretype of asteroid`
 - `<RetVar/IF> <RefObj> get rot alpha`

--- a/docs/language/object-property-commands.md
+++ b/docs/language/object-property-commands.md
@@ -13,8 +13,17 @@ This reference covers object property commands available in X3TC scripting. Each
 - `<RetVar/IF> <RefObj> get array of missiles aiming to me`
 - `<RetVar/IF> <RefObj> get asteroid yield`
 - `<RetVar/IF> <RefObj> get attacker`
-- `<RetVar/IF> <RefObj> get command`
-- `<RetVar/IF> <RefObj> get command target`
+- #### Rule: `<RetVar/IF> <RefObj> get command`
+- **Full Description:** `<RetVar/IF> <RefObj> get command`
+- **Examples:**
+  - `$target.command = $target-> get command`
+- **Edge Cases:** _None._
+
+- #### Rule: `<RetVar/IF> <RefObj> get command target`
+- **Full Description:** `<RetVar/IF> <RefObj> get command target`
+- **Examples:**
+  - `$target.pos = $target-> get command target`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get command target2`
 - `<RetVar/IF> <RefObj> get current action`
 - `<RetVar/IF> <RefObj> get current laser strength`
@@ -45,7 +54,12 @@ This reference covers object property commands available in X3TC scripting. Each
 - `<RetVar/IF> <RefObj> get number of subtypes of maintype <Var/Number>`
 - `<RetVar/IF> <RefObj> get object class`
 - `<RetVar/IF> <RefObj> get owner race`
-- `<RetVar/IF> <RefObj> get position as array`
+- #### Rule: `<RetVar/IF> <RefObj> get position as array`
+- **Full Description:** `<RetVar/IF> <RefObj> get position as array`
+- **Examples:**
+  - `$target.pos = $target-> get position as array`
+  - `$target.pos = $target-> get position as array`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get power generator`
 - `<RetVar/IF> <RefObj> get relation to object <Var/Ship/Station>`
 - `<RetVar/IF> <RefObj> get relation to race <Var/Race>`
@@ -53,7 +67,12 @@ This reference covers object property commands available in X3TC scripting. Each
 - `<RetVar/IF> <RefObj> get rot alpha`
 - `<RetVar/IF> <RefObj> get rot beta`
 - `<RetVar/IF> <RefObj> get rot gamma`
-- `<RetVar/IF> <RefObj> get sector`
+- #### Rule: `<RetVar/IF> <RefObj> get sector`
+- **Full Description:** `<RetVar/IF> <RefObj> get sector`
+- **Examples:**
+  - `$target.sector = $target-> get sector`
+  - `$this.sector = [THIS]-> get sector`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get shield and hull percent`
 - `<RetVar/IF> <RefObj> get shield percent`
 - `<RetVar/IF> <RefObj> get shield type in bay <Var/Number>`
@@ -85,7 +104,11 @@ This reference covers object property commands available in X3TC scripting. Each
 - `<RetVar/IF> <RefObj> is known`
 - `<RetVar/IF> <RefObj> is landing`
 - `<RetVar/IF> <RefObj> is <Var/Ship/Station> neutral to me`
-- `<RetVar/IF> <RefObj> is of class <Var/Class>`
+- #### Rule: `<RetVar/IF> <RefObj> is of class <Var/Class>`
+- **Full Description:** `<RetVar/IF> <RefObj> is of class <Var/Class>`
+- **Examples:**
+  - `if $target-> is of class [Moveable Ship]`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> is of type <Var/Ship Type/Station Type>`
 - `<RetVar/IF> <RefObj> is starting`
 - `<RetVar/IF> <RefObj> is target visible <Var/Ship/Station>`

--- a/docs/language/object-property-commands.md
+++ b/docs/language/object-property-commands.md
@@ -9,6 +9,7 @@ This reference covers object property commands available in X3TC scripting. Each
 - **Examples:**
   - `if $dc-> exists`
   - `if $dock-> exists`
+  - `if $factory-> exists`
 - **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> find nearest enemy ship: max.dist=<Var/Number>`
 - `<RetVar/IF> <RefObj> find nearest enemy ship in range: class=<Var/Class>`
@@ -56,6 +57,7 @@ This reference covers object property commands available in X3TC scripting. Each
   - `$settings.array = $value-> get local variable: name=$pointer`
   - `$ware.settings = $value-> get local variable: name=$pointer`
   - `$ware.array = $value-> get local variable: name=$pointer`
+  - `if not $factory-> get local variable: name=$pointer`
 - **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get local variables: regular expression=<Var/String>`
 - `<RetVar/IF> <RefObj> get maintype`

--- a/docs/language/object-property-commands.md
+++ b/docs/language/object-property-commands.md
@@ -4,7 +4,12 @@ This reference covers object property commands available in X3TC scripting. Each
 
 - `<RetVar/IF> <RefObj> can be controlled by race logic`
 - `<RetVar/IF> <RefObj> can execute StartAction`
-- `<RetVar/IF> <RefObj> exists`
+- #### Rule: `<RetVar/IF> <RefObj> exists`
+- **Full Description:** `<RetVar/IF> <RefObj> exists`
+- **Examples:**
+  - `if $dc-> exists`
+  - `if $dock-> exists`
+- **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> find nearest enemy ship: max.dist=<Var/Number>`
 - `<RetVar/IF> <RefObj> find nearest enemy ship in range: class=<Var/Class>`
 - `<RetVar/IF> <RefObj> find nearest enemy station: max.dist=<Var/Number>`

--- a/docs/language/object-property-commands.md
+++ b/docs/language/object-property-commands.md
@@ -51,6 +51,11 @@ This reference covers object property commands available in X3TC scripting. Each
   - `$settings.array = $factory-> get local variable: name=$pointer`
   - `$ware.array = $source-> get local variable: name=$pointer`
   - `$ware.settings = $dock-> get local variable: name=$pointer`
+  - `$show.type.array = $dc-> get local variable: name=$pointer`
+  - `$show.type.array = $value-> get local variable: name=$pointer`
+  - `$settings.array = $value-> get local variable: name=$pointer`
+  - `$ware.settings = $value-> get local variable: name=$pointer`
+  - `$ware.array = $value-> get local variable: name=$pointer`
 - **Edge Cases:** _None._
 - `<RetVar/IF> <RefObj> get local variables: regular expression=<Var/String>`
 - `<RetVar/IF> <RefObj> get maintype`
@@ -156,6 +161,12 @@ This reference covers object property commands available in X3TC scripting. Each
 - **Full Description:** `<RefObj> set local variable: name=<Var/String> value=<Value>`
 - **Examples:**
   - `$factory-> set local variable: name=$pointer value=$settings.array`
+  - `$value-> set local variable: name=$pointer value=$settings.array`
+  - `$dc-> set local variable: name=$pointer value=$show.type.array`
+  - `$value-> set local variable: name=$pointer value=$show.type.array`
+  - `$value-> set local variable: name=$pointer value=$ware.settings`
+  - `$value-> set local variable: name=$pointer value=$ware.array`
+  - `$value-> set local variable: name=$pointer value=null`
 - **Edge Cases:** _None._
 - `<RefObj> set name to <Var/String>`
 - `<RefObj> set owner race to <Var/Race>`

--- a/docs/language/script-property-commands.md
+++ b/docs/language/script-property-commands.md
@@ -21,6 +21,9 @@ This reference lists script property commands available in X3TC scripting.
 - `<RetVar/IF> player HQ has blueprints for: type=<Var/Ship Type>`
 - `player loses police licence for race <Var/Race>`
 - `<RetVar/IF> playing time`
+- **Examples:**
+  - `$d.time = playing time`
+- **Edge Cases:** _None._
 - `remove blueprints from player HQ: type=<Var/Ship Type>`
 - `set mission rank: name=<Var/String> rank=<Var/Number>`
 - `set player tracking aim to <RefObj>`

--- a/docs/language/string-commands.md
+++ b/docs/language/string-commands.md
@@ -8,14 +8,26 @@ This reference lists string commands available in X3TC scripting.
 - `<RetVar> format time: <Var/Number>`
 - `<RetVar/IF> get length of string <Var/String>`
 - `<RetVar/IF> get string font length: <Var/String>`
-- `<RetVar> get substring of <Var/String> offset=<Var/Number1> length=<Var/Number2>`
+- #### Rule: `<RetVar> get substring of <Var/String> offset=<Var/Number1> length=<Var/Number2>`
+- **Full Description:** `<RetVar> get substring of <Var/String> offset=<Var/Number1> length=<Var/Number2>`
+- **Examples:**
+  - `$check = get substring of $var offset=0 length=5`
+- **Edge Cases:** _None._
 - `<RetVar/IF> get text id: ware=<Var/Ware>`
 - `load text: id=<Var/Number>`
 - `<RetVar/IF> match regular expression: <Var/String1> to string <Var/String2>`
-- `<RetVar> read text: page=<Var/Number1> id=<Var/Number2>`
+- #### Rule: `<RetVar> read text: page=<Var/Number1> id=<Var/Number2>`
+- **Full Description:** `<RetVar> read text: page=<Var/Number1> id=<Var/Number2>`
+- **Examples:**
+  - `$txt = read text: page=$PageID id=103`
+- **Edge Cases:** _None._
 - `<RetVar/IF> read text: page id=<Var/Number1>, from <Var/Number2> to <Var/Number3> to array, include empty=<Var/Number4>`
 - `<RetVar/IF> read text: page id=<Var/Number>, id=<Var/Number> exists`
 - `<RetVar> sprintf: fmt=<Var/String>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
-- `<RetVar> sprintf: pageid=<Var/Number> textid=<Var/Number>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
+- #### Rule: `<RetVar> sprintf: pageid=<Var/Number> textid=<Var/Number>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
+- **Full Description:** `<RetVar> sprintf: pageid=<Var/Number> textid=<Var/Number>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
+- **Examples:**
+  - `$return = sprintf: pageid=$PageID textid=134, $name, $id, null, null, null`
+- **Edge Cases:** _None._
 - `<RetVar> string <Var/String> to integer`
 - `<RetVar> substitute in string <Var/String1>: pattern <Var/String2> with <Var/String3>`

--- a/docs/language/string-commands.md
+++ b/docs/language/string-commands.md
@@ -6,6 +6,9 @@ This reference lists string commands available in X3TC scripting.
 - `<RetVar> find position of pattern <Var/String1> in <Var/String2>`
 - `<RetVar> format seconds=<Var/String> to Zura time string`
 - `<RetVar> format time: <Var/Number>`
+- **Examples:**
+  - `$d.time = format time: $d.time`
+- **Edge Cases:** _None._
 - `<RetVar/IF> get length of string <Var/String>`
 - `<RetVar/IF> get string font length: <Var/String>`
 - #### Rule: `<RetVar> get substring of <Var/String> offset=<Var/Number1> length=<Var/Number2>`
@@ -27,6 +30,8 @@ This reference lists string commands available in X3TC scripting.
   - `$txt = read text: page=$PageID id=160`
   - `$txt = read text: page=$PageID id=163`
   - `$txt = read text: page=$PageID id=161`
+  - `$txt = read text: page=$PageID id=184`
+  - `$txt = read text: page=$PageID id=178`
 - **Edge Cases:** _None._
 - `<RetVar/IF> read text: page id=<Var/Number1>, from <Var/Number2> to <Var/Number3> to array, include empty=<Var/Number4>`
 - `<RetVar/IF> read text: page id=<Var/Number>, id=<Var/Number> exists`
@@ -41,6 +46,10 @@ This reference lists string commands available in X3TC scripting.
   - `$txt = sprintf: pageid=$PageID textid=2000, $sector.count, null, null, null, null`
   - `$txt = sprintf: pageid=$PageID textid=2002, $factory.count, $product.count, $resource.count, null, null`
   - `$txt = sprintf: pageid=$PageID textid=2001, $dock.count, null, null, null, null`
+  - `$pointer = sprintf: pageid=$PageID textid=4000, $ware, null, null, null, null`
+  - `$txt = sprintf: pageid=$PageID textid=194, $destination, $ware, null, null, null`
+  - `$txt = sprintf: pageid=$PageID textid=192, $destination, null, null, null, null`
+  - `$txt = sprintf: pageid=$PageID textid=193, $amount, $ware, null, null, null`
 - **Edge Cases:** _None._
 - `<RetVar> string <Var/String> to integer`
 - `<RetVar> substitute in string <Var/String1>: pattern <Var/String2> with <Var/String3>`

--- a/docs/language/string-commands.md
+++ b/docs/language/string-commands.md
@@ -20,6 +20,13 @@ This reference lists string commands available in X3TC scripting.
 - **Full Description:** `<RetVar> read text: page=<Var/Number1> id=<Var/Number2>`
 - **Examples:**
   - `$txt = read text: page=$PageID id=103`
+  - `$txt = read text: page=$PageID id=180`
+  - `$txt = read text: page=$PageID id=181`
+  - `$pointer = read text: page=$PageID id=4001`
+  - `$txt = read text: page=$PageID id=162`
+  - `$txt = read text: page=$PageID id=160`
+  - `$txt = read text: page=$PageID id=163`
+  - `$txt = read text: page=$PageID id=161`
 - **Edge Cases:** _None._
 - `<RetVar/IF> read text: page id=<Var/Number1>, from <Var/Number2> to <Var/Number3> to array, include empty=<Var/Number4>`
 - `<RetVar/IF> read text: page id=<Var/Number>, id=<Var/Number> exists`
@@ -28,6 +35,12 @@ This reference lists string commands available in X3TC scripting.
 - **Full Description:** `<RetVar> sprintf: pageid=<Var/Number> textid=<Var/Number>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
 - **Examples:**
   - `$return = sprintf: pageid=$PageID textid=134, $name, $id, null, null, null`
+  - `$txt = sprintf: pageid=$PageID textid=9000, $sector, null, null, null, null`
+  - `$name = sprintf: pageid=$PageID textid=9000, $name, null, null, null, null`
+  - `$pre = sprintf: pageid=$PageID textid=9000, '- ', null, null, null, null`
+  - `$txt = sprintf: pageid=$PageID textid=2000, $sector.count, null, null, null, null`
+  - `$txt = sprintf: pageid=$PageID textid=2002, $factory.count, $product.count, $resource.count, null, null`
+  - `$txt = sprintf: pageid=$PageID textid=2001, $dock.count, null, null, null, null`
 - **Edge Cases:** _None._
 - `<RetVar> string <Var/String> to integer`
 - `<RetVar> substitute in string <Var/String1>: pattern <Var/String2> with <Var/String3>`

--- a/docs/language/string-commands.md
+++ b/docs/language/string-commands.md
@@ -22,6 +22,9 @@ This reference lists string commands available in X3TC scripting.
 - #### Rule: `<RetVar> read text: page=<Var/Number1> id=<Var/Number2>`
 - **Full Description:** `<RetVar> read text: page=<Var/Number1> id=<Var/Number2>`
 - **Examples:**
+  - `$section = read text: page=$PageID id=101`
+  - `$txt = read text: page=$PageID id=102`
+  - `$menu = read text: page=$PageID id=102`
   - `$txt = read text: page=$PageID id=103`
   - `$txt = read text: page=$PageID id=180`
   - `$txt = read text: page=$PageID id=181`

--- a/docs/language/string-commands.md
+++ b/docs/language/string-commands.md
@@ -3,6 +3,10 @@
 This reference lists string commands available in X3TC scripting.
 
 - `<RetVar> convert number <Var/Number> to string`
+- **Examples:**
+  - `$min.txt = convert number $min to string`
+  - `$avg.txt = convert number $avg to string`
+  - `$max.txt = convert number $max to string`
 - `<RetVar> find position of pattern <Var/String1> in <Var/String2>`
 - `<RetVar> format seconds=<Var/String> to Zura time string`
 - `<RetVar> format time: <Var/Number>`
@@ -26,15 +30,33 @@ This reference lists string commands available in X3TC scripting.
   - `$txt = read text: page=$PageID id=102`
   - `$menu = read text: page=$PageID id=102`
   - `$txt = read text: page=$PageID id=103`
+  - `$txt = read text: page=$PageID id=104`
+  - `$txt = read text: page=$PageID id=106`
+  - `$txt = read text: page=$PageID id=107`
+  - `$txt = read text: page=$PageID id=108`
+  - `$txt = read text: page=$PageID id=109`
   - `$txt = read text: page=$PageID id=180`
   - `$txt = read text: page=$PageID id=181`
+  - `$txt = read text: page=$PageID id=111`
+  - `$txt = read text: page=$PageID id=112`
+  - `$pre.txt = read text: page=$PageID id=114`
   - `$pointer = read text: page=$PageID id=4001`
+  - `$pointer = read text: page=$PageID id=4003`
+  - `$pointer = read text: page=$PageID id=4004`
   - `$txt = read text: page=$PageID id=162`
   - `$txt = read text: page=$PageID id=160`
   - `$txt = read text: page=$PageID id=163`
   - `$txt = read text: page=$PageID id=161`
   - `$txt = read text: page=$PageID id=184`
   - `$txt = read text: page=$PageID id=178`
+  - `$txt = read text: page=$PageID id=186`
+  - `$txt = read text: page=$PageID id=197`
+  - `$txt = read text: page=$PageID id=148`
+  - `$txt = read text: page=$PageID id=149`
+  - `$txt = read text: page=$PageID id=125`
+  - `$txt = read text: page=$PageID id=126`
+  - `$txt = read text: page=$PageID id=127`
+  - `$txt = read text: page=$PageID id=133`
 - **Edge Cases:** _None._
 - `<RetVar/IF> read text: page id=<Var/Number1>, from <Var/Number2> to <Var/Number3> to array, include empty=<Var/Number4>`
 - `<RetVar/IF> read text: page id=<Var/Number>, id=<Var/Number> exists`
@@ -53,6 +75,8 @@ This reference lists string commands available in X3TC scripting.
   - `$txt = sprintf: pageid=$PageID textid=194, $destination, $ware, null, null, null`
   - `$txt = sprintf: pageid=$PageID textid=192, $destination, null, null, null, null`
   - `$txt = sprintf: pageid=$PageID textid=193, $amount, $ware, null, null, null`
+  - `$txt = sprintf: pageid=$PageID textid=182, $ware, null, null, null, null`
+  - `$txt = sprintf: pageid=$PageID textid=183, $min.txt, $avg.txt, $max.txt, null, null`
 - **Edge Cases:** _None._
 - `<RetVar> string <Var/String> to integer`
 - `<RetVar> substitute in string <Var/String1>: pattern <Var/String2> with <Var/String3>`

--- a/docs/language/universe-property-commands.md
+++ b/docs/language/universe-property-commands.md
@@ -5,7 +5,11 @@ This reference covers universe property commands available in X3TC scripting. Ea
 - `<Var/Race> add notoriety: race=<Var/Race> value=<Var/Number>`
 - `<RetVar> get all global variable keys, starting with=<Var/String>`
 - `<RetVar/IF> <RefObj> get current galaxy flight timestep in ms`
-- `<RetVar/IF> get global variables: regular expression=<Var/String>`
+- #### Rule: `<RetVar/IF> get global variables: regular expression=<Var/String>`
+- **Full Description:** `<RetVar/IF> get global variables: regular expression=<Var/String>`
+- **Examples:**
+  - `$glb.Array = get global variables: regular expression='FDND.*'`
+- **Edge Cases:** _None._
 - `<RetVar> get Kha\`ak aggression level`
 - `<RetVar/IF> get notoriety from race <Var/Race> to race <Var/Race>`
 - `<RetVar> get notoriety required to buy ware: <Var/Ware>`

--- a/docs/language/ware-property-commands.md
+++ b/docs/language/ware-property-commands.md
@@ -3,14 +3,20 @@
 This reference lists ware property commands available in X3TC scripting.
 
 - `<RetVar> get average price of ware <Var/Ware>`
+- **Examples:**
+  - `$avg = get average price of ware $ware`
 - #### Rule: `<RetVar> get maintype of ware <Var/Ware>`
 - **Full Description:** `<RetVar> get maintype of ware <Var/Ware>`
 - **Examples:**
   - `$main.t = get maintype of ware $ware`
 - **Edge Cases:** _None._
 - `<RetVar> get max price of ware <Var/Ware>`
+- **Examples:**
+  - `$max = get max price of ware $ware`
 - `<RetVar> get max price of ware <Var/Ware> as secondary resource`
 - `<RetVar> get min price of ware <Var/Ware>`
+- **Examples:**
+  - `$min = get min price of ware $ware`
 - `<RetVar> get min price of ware <Var/Ware> as secondary resource`
 - `<RetVar> get missile flags of <Var/Ware>`
 - `<RetVar/IF> <RefObj> get price of ware <Var/Ware>`

--- a/docs/language/ware-property-commands.md
+++ b/docs/language/ware-property-commands.md
@@ -3,7 +3,11 @@
 This reference lists ware property commands available in X3TC scripting.
 
 - `<RetVar> get average price of ware <Var/Ware>`
-- `<RetVar> get maintype of ware <Var/Ware>`
+- #### Rule: `<RetVar> get maintype of ware <Var/Ware>`
+- **Full Description:** `<RetVar> get maintype of ware <Var/Ware>`
+- **Examples:**
+  - `$main.t = get maintype of ware $ware`
+- **Edge Cases:** _None._
 - `<RetVar> get max price of ware <Var/Ware>`
 - `<RetVar> get max price of ware <Var/Ware> as secondary resource`
 - `<RetVar> get min price of ware <Var/Ware>`
@@ -15,7 +19,11 @@ This reference lists ware property commands available in X3TC scripting.
 - `<RetVar> get transport class of ware <Var/Ware>`
 - `<RetVar> get volume of ware <Var/Ware>`
 - `<RetVar> get ware from maintype <Var/Number1> and subtype <Var/Number2>`
-- `<RetVar/IF> is equipment: ware=<Var/Ware>`
+- #### Rule: `<RetVar/IF> is equipment: ware=<Var/Ware>`
+- **Full Description:** `<RetVar/IF> is equipment: ware=<Var/Ware>`
+- **Examples:**
+  - `if not is equipment: ware=$ware`
+- **Edge Cases:** _None._
 - `<RetVar/IF> is inventory: ware=<Var/Ware>`
 - `<RetVar/IF> is upgrade: ware=<Var/Ware>`
 - `<RetVar/IF> is ware <Var/Ware> illegal in <Var/Race> sectors`

--- a/docs/options/flow-control-interrupt-options.md
+++ b/docs/options/flow-control-interrupt-options.md
@@ -1,0 +1,15 @@
+# Flow Control Interrupt Optional Parameters
+
+This reference tracks the optional arguments accepted by interrupt-based flow-control commands.
+
+## `<RefObj> interrupt with script <Script Name> and priority <Var/Number>: arg1=<Value> arg2=<Value> arg3=<Value> arg4=<Value>`
+- **arg1** – First optional value passed to the interrupted script. Commonly carries a position array or object reference (e.g. `$target.pos`).
+- **arg2** – Second optional value. Use `null` when no additional data is needed.
+- **arg3** – Third optional value provided to the script; set to `null` when unused.
+- **arg4** – Fourth optional value. Typically omitted by setting it to `null` when the script only expects one argument.
+
+## `<RefObj> interrupt task <Var/Number> with script <Script Name> and priority <Var/Number>: arg1=<Value0> arg2=<Value1> arg3=<Value2> arg4=<Value3>`
+- **arg1** – First optional argument forwarded to the script that replaces the running task.
+- **arg2** – Second optional argument available to the script.
+- **arg3** – Third optional argument for additional context.
+- **arg4** – Fourth optional argument for the task switch.

--- a/docs/options/station-trading-search-options.md
+++ b/docs/options/station-trading-search-options.md
@@ -1,0 +1,10 @@
+# Station Trading Search Optional Parameters
+
+Definitions for optional keywords shared by factory and dock search commands.
+
+- **min.price / max.price** – Price filter for the ware. Use `min.price` when searching buyers and `max.price` when searching sellers.
+- **amount** – Quantity of the ware the trader must be able to buy or sell.
+- **max.jumps** – Maximum number of sector jumps allowed for the search.
+- **startsector** – Sector used as the origin of the search algorithm.
+- **trader** – Ship or station performing the trade; can be `null` when no trader is involved.
+- **exclude array** – Array of stations or docks that should be ignored by the search.

--- a/docs/unmatched_examples.md
+++ b/docs/unmatched_examples.md
@@ -183,3 +183,9 @@
 - `if $status == [TRUE]` – could not be matched to any documented rule.
 - `if $config.Array` – could not be matched to any documented rule.
 - `if $script == $menu` – could not be matched to any documented rule.
+- `* This script is called by LI.FDN.Menu.Supply.Start script if there is a valid` – could not be matched to any documented rule.
+- `* dock array stored in the AL Plugin variable` – could not be matched to any documented rule.
+- `* The script contains the checks made on the docks before calling LI.FDN.Menu.Dock.Factory` – could not be matched to any documented rule.
+- `* The script will also remove any non-existing Docks from the stored array` – could not be matched to any documented rule.
+- `* - N/A the Factory array is stored in the AL Plugin variable` – could not be matched to any documented rule.
+- `* - dock array - holds all the know player factories` – could not be matched to any documented rule.

--- a/docs/unmatched_examples.md
+++ b/docs/unmatched_examples.md
@@ -330,3 +330,43 @@
 - `$txt = $value` – could not be matched to any documented rule.
 - `$txt = $pre.txt + $txt` – could not be matched to any documented rule.
 - `if $menu.view == 1 OR $menu.view == 2 OR $menu.view == 5` – could not be matched to any documented rule.
+- `* Version: 2.0` – could not be matched to any documented rule.
+- `* Date: 27/07/2012` – could not be matched to any documented rule.
+- `* Tested: 27/07/2012` – could not be matched to any documented rule.
+- `* - factory array - holds all the know player factories` – could not be matched to any documented rule.
+- `* v2 change - Check to reverse array every other call` – could not be matched to any documented rule.
+- `* v2 - modify wait depending on number of factories` – could not be matched to any documented rule.
+- `* start of While Loop - Loop is for Factories` – could not be matched to any documented rule.
+- `* check if this is a new factory and flag as found` – could not be matched to any documented rule.
+- `* I use this to only manage the setting on first find and not every search` – could not be matched to any documented rule.
+- `* so player can still change settings with auto manage on` – could not be matched to any documented rule.
+- `* check auto manage setting if set turn on at factory` – could not be matched to any documented rule.
+- `* if product is managed call plugin.LI.FDN.Supply.Factory:` – could not be matched to any documented rule.
+- `* factory` – could not be matched to any documented rule.
+- `* call the supply factory script, flag one for the factory to pass its product to the DC` – could not be matched to any documented rule.
+- `* check.time and full.time is used to see if the factory is stalled` – could not be matched to any documented rule.
+- `* If stalled` – could not be matched to any documented rule.
+- `* if productuion time left is less than 45 seconds call plugin.LI.FDN.Supply.Factory` – could not be matched to any documented rule.
+- `* call the supply factory script to supply resources to the factory` – could not be matched to any documented rule.
+- `if not $al.Settings[12]` – could not be matched to any documented rule.
+- `if $s > 500` – could not be matched to any documented rule.
+- `$wait.1 = 20` – could not be matched to any documented rule.
+- `$wait.2 = 50` – could not be matched to any documented rule.
+- `else if $s > 300` – could not be matched to any documented rule.
+- `$wait.1 = 50` – could not be matched to any documented rule.
+- `$wait.2 = 100` – could not be matched to any documented rule.
+- `$wait.1 = 100` – could not be matched to any documented rule.
+- `$wait.2 = 200` – could not be matched to any documented rule.
+- `* debug` – could not be matched to any documented rule.
+- `$txt.debug = ' Supply Factort called flag = 1'` – could not be matched to any documented rule.
+- `if $settings.array[0]` – could not be matched to any documented rule.
+- `if $settings.array[1]` – could not be matched to any documented rule.
+- `$txt.debug = ' Check time = ' + $check.time + ' Full Time = ' + $full.time` – could not be matched to any documented rule.
+- `if $check.time == $full.time` – could not be matched to any documented rule.
+- `$txt.debug = ' Prdouction stalled - Supply Resource called'` – could not be matched to any documented rule.
+- `* if factory does not exist remove from array` – could not be matched to any documented rule.
+- `$txt.debug = ' Prdouction near completion - Supply Resource called'` – could not be matched to any documented rule.
+- `if $check.time < 45` – could not be matched to any documented rule.
+- `$txt.debug = ' Clean from Factory Array'` – could not be matched to any documented rule.
+- `* wait` – could not be matched to any documented rule.
+- `* v2 - clear is.running flag` – could not be matched to any documented rule.

--- a/docs/unmatched_examples.md
+++ b/docs/unmatched_examples.md
@@ -170,3 +170,16 @@
 - `$txt.debug = 'Sold ' + $sold + ' for ' + $ware` – could not be matched to any documented rule.
 - `$txt.debug = 'To sell amount is now ' + $amount + ' for ' + $ware` – could not be matched to any documented rule.
 - `$txt = $d.time + ';' + $script + ';' + $dock + ';' + $txt.debug` – could not be matched to any documented rule.
+- `* setup handles the srart and stop actions for FDN` – could not be matched to any documented rule.
+- `* Setup` – could not be matched to any documented rule.
+- `* Create debug log` – could not be matched to any documented rule.
+- `* add fdn menu to config` – could not be matched to any documented rule.
+- `* remove fdn from config` – could not be matched to any documented rule.
+- `* To Do - N/A` – could not be matched to any documented rule.
+- `* - dock` – could not be matched to any documented rule.
+- `* Date: 23/05/2012` – could not be matched to any documented rule.
+- `$txt = 'FDN Debug Log:'` – could not be matched to any documented rule.
+- `$DebugID = 0 + $PageID` – could not be matched to any documented rule.
+- `if $status == [TRUE]` – could not be matched to any documented rule.
+- `if $config.Array` – could not be matched to any documented rule.
+- `if $script == $menu` – could not be matched to any documented rule.

--- a/docs/unmatched_examples.md
+++ b/docs/unmatched_examples.md
@@ -1,0 +1,10 @@
+# Unmatched Script Examples
+
+- `if not $target.class == [Sector (X3TC)]` – could not be matched to any documented rule.
+- `else` – could not be matched to any documented rule.
+- `end` – could not be matched to any documented rule.
+- `* target is a sector` – could not be matched to any documented rule.
+- `$target.sector = $target` – could not be matched to any documented rule.
+- `if $target.sector != $this.sector` – could not be matched to any documented rule.
+- `if $jumps.needed > 1` – could not be matched to any documented rule.
+- `return null` – could not be matched to any documented rule.

--- a/docs/unmatched_examples.md
+++ b/docs/unmatched_examples.md
@@ -58,6 +58,40 @@
 - `* FOR NOW EXCLUDE COMPLEX HUBS` – could not be matched to any documented rule.
 - `* find docks in sector` – could not be matched to any documented rule.
 - `* loop docks` – could not be matched to any documented rule.
+- `* Author: Logain Abler` – could not be matched to any documented rule.
+- `* This script sorts wares into their main type` – could not be matched to any documented rule.
+- `* Called by:` – could not be matched to any documented rule.
+- `* - plugin.LI.FDN.Main.DC.Details` – could not be matched to any documented rule.
+- `* - plugin.LI.FDN.Main.Dock.Details` – could not be matched to any documented rule.
+- `* - plugin.LI.FDN.Main.Dock.List` – could not be matched to any documented rule.
+- `* Expected values:` – could not be matched to any documented rule.
+- `* - station` – could not be matched to any documented rule.
+- `* Return values:` – could not be matched to any documented rule.
+- `* - return.array[Array[MainType][Array[sorted ware for main type]]]` – could not be matched to any documented rule.
+- `* ToDo:` – could not be matched to any documented rule.
+- `* - ?` – could not be matched to any documented rule.
+- `* Version: 1.0` – could not be matched to any documented rule.
+- `* Date: 22/05/2012` – could not be matched to any documented rule.
+- `* Tested: 22/05/2012` – could not be matched to any documented rule.
+- `* Get the ware array for the DC or dock` – could not be matched to any documented rule.
+- `* Create temp arrays to hold the wares` – could not be matched to any documented rule.
+- `* Create array to hold the results` – could not be matched to any documented rule.
+- `* Loop the wares and add to the appropriate temp array` – could not be matched to any documented rule.
+- `* sort the tenp arrays` – could not be matched to any documented rule.
+- `* create  an array[main type][ware array for the main type]` – could not be matched to any documented rule.
+- `* Add the created array to the main.ware.array` – could not be matched to any documented rule.
+- `* return the main.ware.array` – could not be matched to any documented rule.
+- `if is datatype[$ware] == [DATATYPE_WARE]` – could not be matched to any documented rule.
+- `if $main.t == [SSTYPE_LASER]` – could not be matched to any documented rule.
+- `else if $main.t == [SSTYPE_SHIELD]` – could not be matched to any documented rule.
+- `else if $main.t == [SSTYPE_MISSILE]` – could not be matched to any documented rule.
+- `else if $main.t == [SSTYPE_W_ENERGY]` – could not be matched to any documented rule.
+- `else if $main.t == [SSTYPE_W_NATURAL]` – could not be matched to any documented rule.
+- `else if $main.t == [SSTYPE_W_BIO]` – could not be matched to any documented rule.
+- `else if $main.t == [SSTYPE_W_FOOD]` – could not be matched to any documented rule.
+- `else if $main.t == [SSTYPE_W_MINERALS]` – could not be matched to any documented rule.
+- `else if $main.t == [SSTYPE_W_TECH]` – could not be matched to any documented rule.
+- `return $main.ware.Array` – could not be matched to any documented rule.
 - `if $sector.count > 0` – could not be matched to any documented rule.
 - `if $factory.count > 0` – could not be matched to any documented rule.
 - `if $dock.count > 0` – could not be matched to any documented rule.

--- a/docs/unmatched_examples.md
+++ b/docs/unmatched_examples.md
@@ -8,3 +8,41 @@
 - `if $target.sector != $this.sector` – could not be matched to any documented rule.
 - `if $jumps.needed > 1` – could not be matched to any documented rule.
 - `return null` – could not be matched to any documented rule.
+- `return $return` – could not be matched to any documented rule.
+- `* -----------------------------------------------------------------------------------` – could not be matched to any documented rule.
+- `* Get save values from AL` – could not be matched to any documented rule.
+- `if $al.Settings` – could not be matched to any documented rule.
+- `if $dc == null` – could not be matched to any documented rule.
+- `Add.DC.Menu.Sub:` – could not be matched to any documented rule.
+- `Change.DC.Menu.Sub:` – could not be matched to any documented rule.
+- `Dynamic.Menu.Sub:` – could not be matched to any documented rule.
+- `Global.Options.Sub:` – could not be matched to any documented rule.
+- `Debug.Menu.Sub:` – could not be matched to any documented rule.
+- `Reset.Menu.Sub:` – could not be matched to any documented rule.
+- `if $s > 0` – could not be matched to any documented rule.
+- `while $s > 0` – could not be matched to any documented rule.
+- `if $dock` – could not be matched to any documented rule.
+- `if not $dock == $dc` – could not be matched to any documented rule.
+- `if $is.dynamic[0]` – could not be matched to any documented rule.
+- `if $is.dynamic[2]` – could not be matched to any documented rule.
+- `if $al.Settings[9]` – could not be matched to any documented rule.
+- `if $al.Settings[7]` – could not be matched to any documented rule.
+- `* Call add DC Menu` – could not be matched to any documented rule.
+- `* Calls script to format name` – could not be matched to any documented rule.
+- `* Call change DC Menu` – could not be matched to any documented rule.
+- `* Call dynamic Menu` – could not be matched to any documented rule.
+- `* $temp.array = array alloc: size=4` – could not be matched to any documented rule.
+- `* $temp.array[0] = 1` – could not be matched to any documented rule.
+- `* $txt = read text: page=$PageID id=105` – could not be matched to any documented rule.
+- `* $temp.array[1] = $txt` – could not be matched to any documented rule.
+- `* $temp.array[2] = -1` – could not be matched to any documented rule.
+- `* if $is.dynamic[1]` – could not be matched to any documented rule.
+- `* $txt = read text: page=$PageID id=148` – could not be matched to any documented rule.
+- `* else` – could not be matched to any documented rule.
+- `* $txt = read text: page=$PageID id=149` – could not be matched to any documented rule.
+- `* end` – could not be matched to any documented rule.
+- `* $temp.array[3] = $txt` – could not be matched to any documented rule.
+- `* $format = create new array, arguments=$temp.array, 'dynamic.dock.list', null, null, null` – could not be matched to any documented rule.
+- `* append $format to array $menu` – could not be matched to any documented rule.
+- `return $menu` – could not be matched to any documented rule.
+- `if $check == 'FDND.'` – could not be matched to any documented rule.

--- a/docs/unmatched_examples.md
+++ b/docs/unmatched_examples.md
@@ -46,3 +46,32 @@
 - `* append $format to array $menu` – could not be matched to any documented rule.
 - `return $menu` – could not be matched to any documented rule.
 - `if $check == 'FDND.'` – could not be matched to any documented rule.
+- `if $factory.show.array == null` – could not be matched to any documented rule.
+- `if not $factory.show.array[$s]` – could not be matched to any documented rule.
+- `if $check == 1` – could not be matched to any documented rule.
+- `$flags = [Find.Multiple]` – could not be matched to any documented rule.
+- `while $sf > 0` – could not be matched to any documented rule.
+- `while $sd > 0` – could not be matched to any documented rule.
+- `if $detectable == 0` – could not be matched to any documented rule.
+- `* find factories in sector` – could not be matched to any documented rule.
+- `* loop factories` – could not be matched to any documented rule.
+- `* FOR NOW EXCLUDE COMPLEX HUBS` – could not be matched to any documented rule.
+- `* find docks in sector` – could not be matched to any documented rule.
+- `* loop docks` – could not be matched to any documented rule.
+- `if $sector.count > 0` – could not be matched to any documented rule.
+- `if $factory.count > 0` – could not be matched to any documented rule.
+- `if $dock.count > 0` – could not be matched to any documented rule.
+- `return $return.array` – could not be matched to any documented rule.
+- `Dock.Summary.Sub:` – could not be matched to any documented rule.
+- `* dock summary` – could not be matched to any documented rule.
+- `$name = '- ' + $name` – could not be matched to any documented rule.
+- `* format display line` – could not be matched to any documented rule.
+- `* open factory` – could not be matched to any documented rule.
+- `Factory.Summary.Sub:` – could not be matched to any documented rule.
+- `* factory summary` – could not be matched to any documented rule.
+- `* get factory settings` – could not be matched to any documented rule.
+- `* auto manage check` – could not be matched to any documented rule.
+- `if not $settings.array[2]` – could not be matched to any documented rule.
+- `if $settings.array[0]` – could not be matched to any documented rule.
+- `if $settings.array[1]` – could not be matched to any documented rule.
+- `$name = $pre + $name` – could not be matched to any documented rule.

--- a/docs/unmatched_examples.md
+++ b/docs/unmatched_examples.md
@@ -189,3 +189,144 @@
 - `* The script will also remove any non-existing Docks from the stored array` – could not be matched to any documented rule.
 - `* - N/A the Factory array is stored in the AL Plugin variable` – could not be matched to any documented rule.
 - `* - dock array - holds all the know player factories` – could not be matched to any documented rule.
+- `* if AP use AP menus` – could not be matched to any documented rule.
+- `$return = null` – could not be matched to any documented rule.
+- `$called.by = null` – could not be matched to any documented rule.
+- `$factory.show.array = null` – could not be matched to any documented rule.
+- `$menu.view = 1` – could not be matched to any documented rule.
+- `* Start Menu` – could not be matched to any documented rule.
+- `while [TRUE]` – could not be matched to any documented rule.
+- `$cap = null` – could not be matched to any documented rule.
+- `$trade = null` – could not be matched to any documented rule.
+- `if $menu.view == 1 OR $menu.view == 2 OR $menu.view == 3` – could not be matched to any documented rule.
+- `if not $dc` – could not be matched to any documented rule.
+- `$menu.view = 7` – could not be matched to any documented rule.
+- `* Build Menu Body` – could not be matched to any documented rule.
+- `if $menu.view == 1` – could not be matched to any documented rule.
+- `else if $menu.view == 2` – could not be matched to any documented rule.
+- `else if $menu.view == 4` – could not be matched to any documented rule.
+- `else if $menu.view == 5` – could not be matched to any documented rule.
+- `else if $menu.view == 6` – could not be matched to any documented rule.
+- `else if $menu.view == 7` – could not be matched to any documented rule.
+- `$al.Settings[5] = $menu.view` – could not be matched to any documented rule.
+- `* Call Menu View for Footer` – could not be matched to any documented rule.
+- `* Start of return` – could not be matched to any documented rule.
+- `if $return == -1` – could not be matched to any documented rule.
+- `$al.Settings[5] = null` – could not be matched to any documented rule.
+- `else if not $dc` – could not be matched to any documented rule.
+- `if $menu.view == 3` – could not be matched to any documented rule.
+- `$menu.view = 2` – could not be matched to any documented rule.
+- `$menu.view = $called.by` – could not be matched to any documented rule.
+- `else if is datatype[$return] == [DATATYPE_ARRAY]` – could not be matched to any documented rule.
+- `$command = $return[0]` – could not be matched to any documented rule.
+- `if $command == 'remote.cap'` – could not be matched to any documented rule.
+- `$menu.view = 6` – could not be matched to any documented rule.
+- `$ware = $return[2]` – could not be matched to any documented rule.
+- `$cap = [TRUE]` – could not be matched to any documented rule.
+- `else if $command == 'maintain.cap'` – could not be matched to any documented rule.
+- `else if $command == 'can.buy'` – could not be matched to any documented rule.
+- `else if $command == 'surplus'` – could not be matched to any documented rule.
+- `else if $command == 'buy.at'` – could not be matched to any documented rule.
+- `$trade = [TRUE]` – could not be matched to any documented rule.
+- `else if $command == 'sell.cap'` – could not be matched to any documented rule.
+- `else if $command == 'sell.at'` – could not be matched to any documented rule.
+- `else if $command == 'move.ware'` – could not be matched to any documented rule.
+- `else if $command == 'to.physical'` – could not be matched to any documented rule.
+- `else if $command == 'to.virtual'` – could not be matched to any documented rule.
+- `else if $command == 'remove.ware'` – could not be matched to any documented rule.
+- `else if $command == 'add.ware'` – could not be matched to any documented rule.
+- `else if $command == 'open.factory'` – could not be matched to any documented rule.
+- `$menu.view = 4` – could not be matched to any documented rule.
+- `else if $command == 'add.dc'` – could not be matched to any documented rule.
+- `$al.Settings[2] = $value` – could not be matched to any documented rule.
+- `else if $command == 'change.dc'` – could not be matched to any documented rule.
+- `else if $command == 'open.dock'` – could not be matched to any documented rule.
+- `$menu.view = 5` – could not be matched to any documented rule.
+- `else if $command == 'open.ware'` – could not be matched to any documented rule.
+- `$called.by = $menu.view` – could not be matched to any documented rule.
+- `* these are used for TC menu - not required for AP` – could not be matched to any documented rule.
+- `else if $command == 'show.factory'` – could not be matched to any documented rule.
+- `$check = $factory.show.array[$value]` – could not be matched to any documented rule.
+- `$factory.show.array[$value] = 2` – could not be matched to any documented rule.
+- `$factory.show.array[$value] = 1` – could not be matched to any documented rule.
+- `else if $command == 'show.type.dc'` – could not be matched to any documented rule.
+- `$check = $show.type.array[$value]` – could not be matched to any documented rule.
+- `$show.type.array[$value] = 2` – could not be matched to any documented rule.
+- `$show.type.array[$value] = 1` – could not be matched to any documented rule.
+- `else if $command == 'show.type.dock'` – could not be matched to any documented rule.
+- `$check = $show.type.array[$count]` – could not be matched to any documented rule.
+- `$show.type.array[$count] = 2` – could not be matched to any documented rule.
+- `$show.type.array[$count] = 1` – could not be matched to any documented rule.
+- `else if $command == 'product'` – could not be matched to any documented rule.
+- `$settings.array[0] = null` – could not be matched to any documented rule.
+- `else if $command == 'resource'` – could not be matched to any documented rule.
+- `$settings.array[1] = null` – could not be matched to any documented rule.
+- `if $return == 'dynamic.dc'` – could not be matched to any documented rule.
+- `$is.dynamic[0] = null` – could not be matched to any documented rule.
+- `$is.dynamic[0] = 1` – could not be matched to any documented rule.
+- `else if $return == 'dynamic.dock'` – could not be matched to any documented rule.
+- `$is.dynamic[2] = null` – could not be matched to any documented rule.
+- `$is.dynamic[2] = 1` – could not be matched to any documented rule.
+- `else if $return == 'dynamic.dock.list'` – could not be matched to any documented rule.
+- `$is.dynamic[1] = null` – could not be matched to any documented rule.
+- `$is.dynamic[1] = 1` – could not be matched to any documented rule.
+- `else if $return == 'debug'` – could not be matched to any documented rule.
+- `$al.Settings[7] = null` – could not be matched to any documented rule.
+- `$al.Settings[7] = 1` – could not be matched to any documented rule.
+- `else if $return == 'auto'` – could not be matched to any documented rule.
+- `$al.Settings[9] = null` – could not be matched to any documented rule.
+- `$al.Settings[9] = 1` – could not be matched to any documented rule.
+- `else if $return == 'open.config'` – could not be matched to any documented rule.
+- `else if $return == 'product.all.on'` – could not be matched to any documented rule.
+- `$cmd.opt1 = 1` – could not be matched to any documented rule.
+- `$cmd.opt2 = 1` – could not be matched to any documented rule.
+- `else if $return == 'product.all.off'` – could not be matched to any documented rule.
+- `$cmd.opt2 = 2` – could not be matched to any documented rule.
+- `else if $return == 'resource.all.on'` – could not be matched to any documented rule.
+- `$cmd.opt1 = 2` – could not be matched to any documented rule.
+- `else if $return == 'resource.all.off'` – could not be matched to any documented rule.
+- `else if $return == 'open.dc.menu'` – could not be matched to any documented rule.
+- `else if $return == 'switch.menu'` – could not be matched to any documented rule.
+- `else if $return == 'master.reset'` – could not be matched to any documented rule.
+- `if $confirm == [TRUE]` – could not be matched to any documented rule.
+- `if $command == 'can.buy'` – could not be matched to any documented rule.
+- `if $ware.settings[3]` – could not be matched to any documented rule.
+- `$ware.settings[3] = null` – could not be matched to any documented rule.
+- `$ware.settings[3] = 1` – could not be matched to any documented rule.
+- `if $ware.settings[7]` – could not be matched to any documented rule.
+- `$ware.settings[7] = null` – could not be matched to any documented rule.
+- `$ware.settings[7] = 1` – could not be matched to any documented rule.
+- `if $cap` – could not be matched to any documented rule.
+- `if is datatype[$amount] == [DATATYPE_NULL]` – could not be matched to any documented rule.
+- `if $amount >= 0` – could not be matched to any documented rule.
+- `$ware.settings[1] = $amount` – could not be matched to any documented rule.
+- `$ware.settings[2] = $amount` – could not be matched to any documented rule.
+- `$ware.settings[5] = $amount` – could not be matched to any documented rule.
+- `$ware.settings[1] = null` – could not be matched to any documented rule.
+- `$ware.settings[2] = null` – could not be matched to any documented rule.
+- `$ware.settings[5] = null` – could not be matched to any documented rule.
+- `if $trade` – could not be matched to any documented rule.
+- `if $amount >= $min AND $amount <= $max` – could not be matched to any documented rule.
+- `if $command == 'buy.at'` – could not be matched to any documented rule.
+- `$ware.settings[4] = $amount` – could not be matched to any documented rule.
+- `$ware.settings[6] = $amount` – could not be matched to any documented rule.
+- `* Menu View 1 = DC Details` – could not be matched to any documented rule.
+- `if $is.AP == [TRUE]` – could not be matched to any documented rule.
+- `* Menu View 2 = Factory List` – could not be matched to any documented rule.
+- `* Menu View 4 = Factory Details` – could not be matched to any documented rule.
+- `* Menu View 5 = Dock Details` – could not be matched to any documented rule.
+- `* Menu View 6 = Ware Details` – could not be matched to any documented rule.
+- `if not $ware.array` – could not be matched to any documented rule.
+- `if $command == 'to.virtual'` – could not be matched to any documented rule.
+- `$virtual = $virtual + $amount` – could not be matched to any documented rule.
+- `$ware.array[0] = $virtual` – could not be matched to any documented rule.
+- `$remove = -$amount` – could not be matched to any documented rule.
+- `if $virtual <= $amount` – could not be matched to any documented rule.
+- `$ware.array[0] = 0` – could not be matched to any documented rule.
+- `$virtual = $virtual - $amount` – could not be matched to any documented rule.
+- `$factory = $factory.array[$s]` – could not be matched to any documented rule.
+- `if $cmd.opt1 == 1` – could not be matched to any documented rule.
+- `if $cmd.opt2 == 1` – could not be matched to any documented rule.
+- `$txt = $value` – could not be matched to any documented rule.
+- `$txt = $pre.txt + $txt` – could not be matched to any documented rule.
+- `if $menu.view == 1 OR $menu.view == 2 OR $menu.view == 5` – could not be matched to any documented rule.

--- a/docs/unmatched_examples.md
+++ b/docs/unmatched_examples.md
@@ -150,3 +150,23 @@
 - `* Debug Massage handling` – could not be matched to any documented rule.
 - `Debug.Sub:` – could not be matched to any documented rule.
 - `$txt = $d.time + ';' + $script + ';' + $txt.debug` – could not be matched to any documented rule.
+- `* This script is called by LI.FDN.Supply.Factory` – could not be matched to any documented rule.
+- `* It is used to buy a ware needed for production` – could not be matched to any documented rule.
+- `* - Factory` – could not be matched to any documented rule.
+- `* - Ware` – could not be matched to any documented rule.
+- `* - Amount` – could not be matched to any documented rule.
+- `* To Do - Debug` – could not be matched to any documented rule.
+- `$stock = $virtual.stock + $physical.stock` – could not be matched to any documented rule.
+- `$amount = $stock - $sell` – could not be matched to any documented rule.
+- `$txt.debug = 'Dock Virtual Stock ' + $virtual.stock + ' for ' + $ware` – could not be matched to any documented rule.
+- `$txt.debug = 'Dock Physical Stock ' + $physical.stock + ' for ' + $ware` – could not be matched to any documented rule.
+- `$txt.debug = 'Has ' + $amount + ' of ' + $ware + ' free to sell'` – could not be matched to any documented rule.
+- `if $sell.Station` – could not be matched to any documented rule.
+- `if not $relation == [Foe]` – could not be matched to any documented rule.
+- `if $amount > $drone.max` – could not be matched to any documented rule.
+- `$txt.debug = 'Drone has ' + $drone.max + ' of ' + $ware + ' to sell'` – could not be matched to any documented rule.
+- `$txt.debug = 'Drone has ' + $sell.amount + ' of ' + $ware + ' to sell'` – could not be matched to any documented rule.
+- `$amount = $amount - $sold` – could not be matched to any documented rule.
+- `$txt.debug = 'Sold ' + $sold + ' for ' + $ware` – could not be matched to any documented rule.
+- `$txt.debug = 'To sell amount is now ' + $amount + ' for ' + $ware` – could not be matched to any documented rule.
+- `$txt = $d.time + ';' + $script + ';' + $dock + ';' + $txt.debug` – could not be matched to any documented rule.

--- a/docs/unmatched_examples.md
+++ b/docs/unmatched_examples.md
@@ -75,3 +75,44 @@
 - `if $settings.array[0]` – could not be matched to any documented rule.
 - `if $settings.array[1]` – could not be matched to any documented rule.
 - `$name = $pre + $name` – could not be matched to any documented rule.
+- `* Author: Logain Abler` – could not be matched to any documented rule.
+- `* this script handles the user inputs for moving wares` – could not be matched to any documented rule.
+- `* Expected values:` – could not be matched to any documented rule.
+- `* - ware` – could not be matched to any documented rule.
+- `* - source` – could not be matched to any documented rule.
+- `* Returns values:` – could not be matched to any documented rule.
+- `* - N/A` – could not be matched to any documented rule.
+- `* Version: 1.0` – could not be matched to any documented rule.
+- `* Date: 09/06/2012` – could not be matched to any documented rule.
+- `* Tested: 09/06/2012` – could not be matched to any documented rule.
+- `* Fetch values saved in the AL Plugin global variable:` – could not be matched to any documented rule.
+- `$script = get script name` – could not be matched to any documented rule.
+- `$DebugID = 0 + $PageID` – could not be matched to any documented rule.
+- `* fetch ware details from the source` – could not be matched to any documented rule.
+- `* calculate the avialable physical, virtual and total` – could not be matched to any documented rule.
+- `if not $virtual.avialable > 0` – could not be matched to any documented rule.
+- `$virtual.avialable = 0` – could not be matched to any documented rule.
+- `$stock.avialable = $virtual.avialable + $physical.avialable` – could not be matched to any documented rule.
+- `if not $stock.avialable > 0` – could not be matched to any documented rule.
+- `* Debug` – could not be matched to any documented rule.
+- `$txt.debug = $source + ' has no free ' + $ware + ' - exit move ware'` – could not be matched to any documented rule.
+- `* USER SELECT - player owned ship or station` – could not be matched to any documented rule.
+- `if $destination == $source` – could not be matched to any documented rule.
+- `$txt.debug = 'Selected: ' + $destination` – could not be matched to any documented rule.
+- `$txt.debug = 'Selected: ' + $destination + ' is same as source - exit move ware'` – could not be matched to any documented rule.
+- `* USER INPUT - amount of ware to move` – could not be matched to any documented rule.
+- `if not is datatype[$amount] == [DATATYPE_NULL]` – could not be matched to any documented rule.
+- `if not $amount > 0` – could not be matched to any documented rule.
+- `* if not a valid amount exit` – could not be matched to any documented rule.
+- `if $amount > $stock.avialable` – could not be matched to any documented rule.
+- `* if amount greater than current stock` – could not be matched to any documented rule.
+- `$txt.debug = 'Input : ' + $amount + ' of ' + $ware + ' to be moved'` – could not be matched to any documented rule.
+- `* checks if the destination can hold the ware` – could not be matched to any documented rule.
+- `* add to destination` – could not be matched to any documented rule.
+- `if $amount.added > 0` – could not be matched to any documented rule.
+- `if $amount.added < $amount` – could not be matched to any documented rule.
+- `$amount = $amount.added` – could not be matched to any documented rule.
+- `* remove from source` – could not be matched to any documented rule.
+- `* Debug Massage handling` – could not be matched to any documented rule.
+- `Debug.Sub:` – could not be matched to any documented rule.
+- `$txt = $d.time + ';' + $script + ';' + $txt.debug` – could not be matched to any documented rule.

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -1,5 +1,11 @@
 # X3S Language Reference
 
+#### Rule: `<RetVar/IF> <RefObj> exists`
+- **Short Description:** `<RetVar/IF> <RefObj> exists`
+- **One Example:**
+  - `if $dock-> exists`
+- **Edge Cases:** _None._
+
 #### Rule: `<RetVar/IF> <RefObj> get command`
 - **Short Description:** `<RetVar/IF> <RefObj> get command`
 - **One Example:**
@@ -165,7 +171,7 @@
 #### Rule: `<RetVar/IF> wait randomly from <Var/Number> to <Var/Number> ms`
 - **Short Description:** Pauses script execution for a random duration within the specified range.
 - **One Example:**
-  - `= wait randomly from 500 to 1000 ms`
+  - `= wait randomly from 1000 to 2000 ms`
 - **Edge Cases:** _None._
 
 #### Rule: `<RefObj> destruct: show no explosion=<Var/Number>`
@@ -255,7 +261,7 @@
 #### Rule: `remove element from array <Var/Array> at index <Var/Number>`
 - **Short Description:** `remove element from array <Var/Array> at index <Var/Number>`
 - **One Example:**
-  - `remove element from array $config.Array at index $s`
+  - `remove element from array $dock.array at index $s`
 - **Edge Cases:** _None._
 
 #### Rule: `<RetVar/IF> reverse array <Value>`
@@ -291,7 +297,7 @@
 #### Rule: `<RetVar/IF/START> <RefObj> call script <Script Name> : [ arg1=<Value> arg2=<Value> ... arga=<Value> ]`
 - **Short Description:** `<RetVar/IF/START> <RefObj> call script <Script Name> : [ arg1=<Value> arg2=<Value> ... arga=<Value> ]`
 - **One Example:**
-  - `= [THIS]-> call script 'plugin.config.addscript' : argument1=$txt argument2=null argument3='plugin.LI.FDN.Main.Menu' argument4=[FALSE] argument5=$section argument6=null`
+  - `START null-> call script 'plugin.LI.FDN.Supply.Dock' : dock=$dc flag=1`
 - **Edge Cases:** _None._
 
 #### Rule: `gosub <Label Name>:`

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -59,3 +59,147 @@
 - **One Example:**
   - `[THIS]-> interrupt with script 'plugin.advjump.jump' and priority 40: arg1=$target.pos arg2=null arg3=null arg4=null`
 - **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> get global variable: name=<Var/String>`
+- **Short Description:** Retrieves the value of a named global variable.
+- **One Example:**
+  - `$al.Settings = get global variable: name='al.LI.FDN.event'`
+- **Edge Cases:** _None._
+
+#### Rule: `set global variable: name=<Var/String> value=<Value>`
+- **Short Description:** Sets or creates a global variable.
+- **One Example:**
+  - `set global variable: name=$var value=null`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> get global variables: regular expression=<Var/String>`
+- **Short Description:** `<RetVar/IF> get global variables: regular expression=<Var/String>`
+- **One Example:**
+  - `$glb.Array = get global variables: regular expression='FDND.*'`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> <RefObj> get name`
+- **Short Description:** `<RetVar/IF> <RefObj> get name`
+- **One Example:**
+  - `$name = $object-> get name`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> <RefObj> get ID code`
+- **Short Description:** `<RetVar/IF> <RefObj> get ID code`
+- **One Example:**
+  - `$id = $object-> get ID code`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar> read text: page=<Var/Number1> id=<Var/Number2>`
+- **Short Description:** `<RetVar> read text: page=<Var/Number1> id=<Var/Number2>`
+- **One Example:**
+  - `$txt = read text: page=$PageID id=103`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar> sprintf: pageid=<Var/Number> textid=<Var/Number>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
+- **Short Description:** `<RetVar> sprintf: pageid=<Var/Number> textid=<Var/Number>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
+- **One Example:**
+  - `$return = sprintf: pageid=$PageID textid=134, $name, $id, null, null, null`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar> get substring of <Var/String> offset=<Var/Number1> length=<Var/Number2>`
+- **Short Description:** `<RetVar> get substring of <Var/String> offset=<Var/Number1> length=<Var/Number2>`
+- **One Example:**
+  - `$check = get substring of $var offset=0 length=5`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar> create custom menu array: heading=<Var/String>`
+- **Short Description:** `<RetVar> create custom menu array: heading=<Var/String>`
+- **One Example:**
+  - `$menu = create custom menu array: heading=$txt`
+- **Edge Cases:** _None._
+
+#### Rule: `add custom menu info line to array <value>: text=<Var/String>`
+- **Short Description:** `add custom menu info line to array <value>: text=<Var/String>`
+- **One Example:**
+  - `add custom menu info line to array $menu: text=$temp.array`
+- **Edge Cases:** _None._
+
+#### Rule: `add custom menu heading to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
+- **Short Description:** `add custom menu heading to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
+- **One Example:**
+  - `add custom menu heading to array $menu: page=$PageID id=123`
+- **Edge Cases:** _None._
+
+#### Rule: `add custom menu info line to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
+- **Short Description:** `add custom menu info line to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
+- **One Example:**
+  - `add custom menu info line to array $menu: page=$PageID id=119`
+- **Edge Cases:** _None._
+
+#### Rule: `add custom menu item to array <Var/Array>: page=<Var/Number1> id=<Var/Number2> returnvalue=<Value>`
+- **Short Description:** `add custom menu item to array <Var/Array>: page=<Var/Number1> id=<Var/Number2> returnvalue=<Value>`
+- **One Example:**
+  - `add custom menu item to array $menu: page=$PageID id=128 returnvalue='master.reset'`
+- **Edge Cases:** _None._
+
+#### Rule: `dim <Var/Array> = <Value> [, <Value> ] [, <Value> ] ... [, <Value> ]`
+- **Short Description:** `dim <Var/Array> = <Value> [, <Value> ] [, <Value> ] ... [, <Value> ]`
+- **One Example:**
+  - `dim $return.array = 'add.dc', $dock`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> = <Var/Array>[<Var/Number>]`
+- **Short Description:** `<RetVar/IF> = <Var/Array>[<Var/Number>]`
+- **One Example:**
+  - `$PageID = $al.Settings[1]`
+- **Edge Cases:** _None._
+
+#### Rule: `<Var/Array>[<Var/Number>] = <Value>`
+- **Short Description:** `<Var/Array>[<Var/Number>] = <Value>`
+- **One Example:**
+  - `$temp.array[0] = 1`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar> array alloc: size=<Var/Number>`
+- **Short Description:** `<RetVar> array alloc: size=<Var/Number>`
+- **One Example:**
+  - `$temp.array = array alloc: size=4`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar> create new array, arguments=<Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
+- **Short Description:** `<RetVar> create new array, arguments=<Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
+- **One Example:**
+  - `$format = create new array, arguments=$temp.array, $return.array, null, null, null`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> size of array <Var/Array>`
+- **Short Description:** `<RetVar/IF> size of array <Var/Array>`
+- **One Example:**
+  - `$s = size of array $dock.array`
+- **Edge Cases:** _None._
+
+#### Rule: `dec <Var>`
+- **Short Description:** `dec <Var>`
+- **One Example:**
+  - `dec $s`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF/START> <RefObj> call script <Script Name> : [ arg1=<Value> arg2=<Value> ... arga=<Value> ]`
+- **Short Description:** `<RetVar/IF/START> <RefObj> call script <Script Name> : [ arg1=<Value> arg2=<Value> ... arga=<Value> ]`
+- **One Example:**
+  - `$txt = [THIS]-> call script 'plugin.LI.FDN.Format.Name' : object=$dc`
+- **Edge Cases:** _None._
+
+#### Rule: `gosub <Label Name>:`
+- **Short Description:** `gosub <Label Name>:`
+- **One Example:**
+  - `gosub Add.DC.Menu.Sub:`
+- **Edge Cases:** _None._
+
+#### Rule: `endsub`
+- **Short Description:** `endsub`
+- **One Example:**
+  - `endsub`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> get station array: of race <Var/Race> class/type=<value>`
+- **Short Description:** `<RetVar/IF> get station array: of race <Var/Race> class/type=<value>`
+- **One Example:**
+  - `$dock.array = get station array: of race [Player] class/type=[Dock]`
+- **Edge Cases:** _None._

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -120,6 +120,60 @@
   - `$txt = sprintf: pageid=$PageID textid=2002, $factory.count, $product.count, $resource.count, null, null`
 - **Edge Cases:** _None._
 
+#### Rule: `<RetVar/IF> find factory: buys <Var/Ware> with best price: min.price=<Var/Number1>, amount=<Var/Number2>, max.jumps=<Var/Number3>, startsector=<Var/Sector>, trader=<Var/Ship/Station>, exclude array=<Var/Array>`
+- **Short Description:** Finds the best-price factory buying a ware from a given sector, honoring jump and exclusion limits.
+- **One Example:**
+  - `$sell.Station = find factory: buys $ware with best price: min.price=$sell.at, amount=null, max.jumps=0, startsector=$sector, trader=null, exclude array=$exclude.array`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar> create ship: type=<Var/Ship Type> owner=<Var/Race> addto=<value> x=<Var/Number1> y=<Var/Number2> z=<Var/Number3>`
+- **Short Description:** Spawns a ship of the specified type, owner, and position.
+- **One Example:**
+  - `$drone = create ship: type={Argon Mercury Super Freighter XL} owner=[Player] addto=$sell.Station x=null y=null z=null`
+- **Edge Cases:** _None._
+
+#### Rule: `<RefObj> set homebase to <Var/Ship/Station>`
+- **Short Description:** Assigns a new homebase station for a ship.
+- **One Example:**
+  - `$drone-> set homebase to $dock`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> <RefObj> get relation to object <Var/Ship/Station>`
+- **Short Description:** Returns the relation standing toward another object.
+- **One Example:**
+  - `$relation = $dock-> get relation to object $sell.Station`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> <RefObj> get max amount of ware <Var/Ware> that can be stored in cargo bay`
+- **Short Description:** Retrieves the cargo capacity for a specific ware on a ship.
+- **One Example:**
+  - `$drone.max = $drone-> get max amount of ware $ware that can be stored in cargo bay`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> <RefObj> add <Var/Number> units of <Var/Ware>`
+- **Short Description:** Adds a quantity of ware to a ship's cargo bay.
+- **One Example:**
+  - `= $drone-> add $sell.amount units of $ware`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> <RefObj> sell ware <Var/Ware>`
+- **Short Description:** Commands a ship to sell a ware from its cargo.
+- **One Example:**
+  - `$sold = $drone-> sell $sell.amount units of $ware`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> wait randomly from <Var/Number> to <Var/Number> ms`
+- **Short Description:** Pauses script execution for a random duration within the specified range.
+- **One Example:**
+  - `= wait randomly from 500 to 1000 ms`
+- **Edge Cases:** _None._
+
+#### Rule: `<RefObj> destruct: show no explosion=<Var/Number>`
+- **Short Description:** Destroys an object optionally hiding the explosion.
+- **One Example:**
+  - `$drone-> destruct: show no explosion=[TRUE]`
+- **Edge Cases:** _None._
+
 #### Rule: `<RetVar> get substring of <Var/String> offset=<Var/Number1> length=<Var/Number2>`
 - **Short Description:** `<RetVar> get substring of <Var/String> offset=<Var/Number1> length=<Var/Number2>`
 - **One Example:**

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -293,3 +293,21 @@
 - **One Example:**
   - `$d.time = playing time`
 - **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> <RefObj> get tradeable ware array from station`
+- **Short Description:** `<RetVar/IF> <RefObj> get tradeable ware array from station`
+- **One Example:**
+  - `$ware.Array = $station-> get tradeable ware array from station`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar> get maintype of ware <Var/Ware>`
+- **Short Description:** `<RetVar> get maintype of ware <Var/Ware>`
+- **One Example:**
+  - `$main.t = get maintype of ware $ware`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> is equipment: ware=<Var/Ware>`
+- **Short Description:** `<RetVar/IF> is equipment: ware=<Var/Ware>`
+- **One Example:**
+  - `if not is equipment: ware=$ware`
+- **Edge Cases:** _None._

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -1,0 +1,61 @@
+# X3S Language Reference
+
+#### Rule: `<RetVar/IF> <RefObj> get command`
+- **Short Description:** `<RetVar/IF> <RefObj> get command`
+- **One Example:**
+  - `$target.command = $target-> get command`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> <RefObj> get command target`
+- **Short Description:** `<RetVar/IF> <RefObj> get command target`
+- **One Example:**
+  - `$target.pos = $target-> get command target`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> <RefObj> get position as array`
+- **Short Description:** `<RetVar/IF> <RefObj> get position as array`
+- **One Example:**
+  - `$target.pos = $target-> get position as array`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> <RefObj> get sector`
+- **Short Description:** `<RetVar/IF> <RefObj> get sector`
+- **One Example:**
+  - `$target.sector = $target-> get sector`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> <RefObj> is of class <Var/Class>`
+- **Short Description:** `<RetVar/IF> <RefObj> is of class <Var/Class>`
+- **One Example:**
+  - `if $target-> is of class [Moveable Ship]`
+- **Edge Cases:** _None._
+
+#### Rule: `append <Value> to array <Var/Array>`
+- **Short Description:** `append <Value> to array <Var/Array>`
+- **One Example:**
+  - `append $target.sector to array $target.pos`
+- **Edge Cases:** _None._
+
+#### Rule: `resize array <Var/Array> to <Var/Number>`
+- **Short Description:** `resize array <Var/Array> to <Var/Number>`
+- **One Example:**
+  - `resize array $target.pos to 0`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> get jumps from sector <Var/Sector1> to sector <Var/Sector2>`
+- **Short Description:** `<RetVar/IF> get jumps from sector <Var/Sector1> to sector <Var/Sector2>`
+- **One Example:**
+  - `$jumps.needed = get jumps from sector $this.sector to sector $target.sector`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> <RefObj> get amount of ware <Var/Ware> in cargo bay`
+- **Short Description:** `<RetVar/IF> <RefObj> get amount of ware <Var/Ware> in cargo bay`
+- **One Example:**
+  - `if [THIS]-> get amount of ware {Advanced Jumpdrive} in cargo bay`
+- **Edge Cases:** _None._
+
+#### Rule: `<RefObj> interrupt with script <Script Name> and priority <Var/Number>: arg1=<Value> arg2=<Value> arg3=<Value> arg4=<Value>`
+- **Short Description:** `<RefObj> interrupt with script <Script Name> and priority <Var/Number>: arg1=<Value> arg2=<Value> arg3=<Value> arg4=<Value>`
+- **One Example:**
+  - `[THIS]-> interrupt with script 'plugin.advjump.jump' and priority 40: arg1=$target.pos arg2=null arg3=null arg4=null`
+- **Edge Cases:** _None._

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -81,7 +81,7 @@
 #### Rule: `set global variable: name=<Var/String> value=<Value>`
 - **Short Description:** Sets or creates a global variable.
 - **One Example:**
-  - `set global variable: name=$var value=null`
+  - `set global variable: name='al.LI.FDN.event' value=$al.Settings`
 - **Edge Cases:** _None._
 
 #### Rule: `<RetVar/IF> get global variables: regular expression=<Var/String>`
@@ -105,13 +105,13 @@
 #### Rule: `<RetVar/IF> <RefObj> get local variable: name=<Var/String>`
 - **Short Description:** `<RetVar/IF> <RefObj> get local variable: name=<Var/String>`
 - **One Example:**
-  - `$settings.array = $factory-> get local variable: name=$pointer`
+  - `$ware.array = $value-> get local variable: name=$pointer`
 - **Edge Cases:** _None._
 
 #### Rule: `<RefObj> set local variable: name=<Var/String> value=<Value>`
 - **Short Description:** `<RefObj> set local variable: name=<Var/String> value=<Value>`
 - **One Example:**
-  - `$factory-> set local variable: name=$pointer value=$settings.array`
+  - `$value-> set local variable: name=$pointer value=$ware.settings`
 - **Edge Cases:** _None._
 
 #### Rule: `<RetVar> read text: page=<Var/Number1> id=<Var/Number2>`
@@ -159,7 +159,13 @@
 #### Rule: `<RetVar/IF> <RefObj> add <Var/Number> units of <Var/Ware>`
 - **Short Description:** Adds a quantity of ware to a ship's cargo bay.
 - **One Example:**
-  - `= $drone-> add $sell.amount units of $ware`
+  - `= $value-> add $remove units of $ware`
+- **Edge Cases:** _None._
+
+#### Rule: `<RefObj> remove product from factory or dock: <Var/Ware>`
+- **Short Description:** `<RefObj> remove product from factory or dock: <Var/Ware>`
+- **One Example:**
+  - `$value-> remove product from factory or dock: $ware`
 - **Edge Cases:** _None._
 
 #### Rule: `<RetVar/IF> <RefObj> sell ware <Var/Ware>`
@@ -198,6 +204,12 @@
   - `add custom menu info line to array $menu: text=$txt`
 - **Edge Cases:** _None._
 
+#### Rule: `add custom menu item to array <value>: text=<Var/String> returnvalue=<value>`
+- **Short Description:** `add custom menu item to array <value>: text=<Var/String> returnvalue=<value>`
+- **One Example:**
+  - `add custom menu item to array $menu: text=$txt returnvalue='switch.menu'`
+- **Edge Cases:** _None._
+
 #### Rule: `add custom menu heading to array <Var/Array>: title=<Var/String>`
 - **Short Description:** `add custom menu heading to array <Var/Array>: title=<Var/String>`
 - **One Example:**
@@ -207,7 +219,7 @@
 #### Rule: `add custom menu heading to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
 - **Short Description:** `add custom menu heading to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
 - **One Example:**
-  - `add custom menu heading to array $menu: page=$PageID id=157`
+  - `add custom menu heading to array $menu: page=$PageID id=110`
 - **Edge Cases:** _None._
 
 #### Rule: `add custom menu info line to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
@@ -297,13 +309,13 @@
 #### Rule: `<RetVar/IF/START> <RefObj> call script <Script Name> : [ arg1=<Value> arg2=<Value> ... arga=<Value> ]`
 - **Short Description:** `<RetVar/IF/START> <RefObj> call script <Script Name> : [ arg1=<Value> arg2=<Value> ... arga=<Value> ]`
 - **One Example:**
-  - `START null-> call script 'plugin.LI.FDN.Supply.Dock' : dock=$dc flag=1`
+  - `START null-> call script 'plugin.LI.FDN.Menu.DC.Details_D' :`
 - **Edge Cases:** _None._
 
 #### Rule: `gosub <Label Name>:`
 - **Short Description:** `gosub <Label Name>:`
 - **One Example:**
-  - `gosub Factory.Summary.Sub:`
+  - `gosub Ware.User.Input.Sub:`
 - **Edge Cases:** _None._
 
 #### Rule: `endsub`
@@ -330,10 +342,28 @@
   - `$d.time = format time: $d.time`
 - **Edge Cases:** _None._
 
+#### Rule: `<RetVar> convert number <Var/Number> to string`
+- **Short Description:** `<RetVar> convert number <Var/Number> to string`
+- **One Example:**
+  - `$min.txt = convert number $min to string`
+- **Edge Cases:** _None._
+
 #### Rule: `<RetVar/IF> <RefObj> get user input: type=<Script Reference Type>, title=<Var/String>`
 - **Short Description:** `<RetVar/IF> <RefObj> get user input: type=<Script Reference Type>, title=<Var/String>`
 - **One Example:**
-  - `$destination = null-> get user input: type=[Var/Ship/Station owned by Player], title=$txt`
+  - `$ware = null-> get user input: type=[Var/Ware], title=$txt`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> open custom info menu: title=<Var/String> description=<Var/String> option array=<Var/Array> maxoptions=<Var/Number>`
+- **Short Description:** `<RetVar/IF> open custom info menu: title=<Var/String> description=<Var/String> option array=<Var/Array> maxoptions=<Var/Number>`
+- **One Example:**
+  - `$return = open custom info menu: title=$txt description=null option array=$menu maxoptions=2`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> open custom menu: title=<Var/String> description=<Var/String> option array=<Var/Array>`
+- **Short Description:** `<RetVar/IF> open custom menu: title=<Var/String> description=<Var/String> option array=<Var/Array>`
+- **One Example:**
+  - `$return = open custom menu: title=$txt description=null option array=$menu`
 - **Edge Cases:** _None._
 
 #### Rule: `display subtitle text: text=<Var/String> duration=<Var/Number> ms`
@@ -364,6 +394,24 @@
 - **Short Description:** `<RetVar/IF> <RefObj> get tradeable ware array from station`
 - **One Example:**
   - `$ware.Array = $station-> get tradeable ware array from station`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar> get average price of ware <Var/Ware>`
+- **Short Description:** `<RetVar> get average price of ware <Var/Ware>`
+- **One Example:**
+  - `$avg = get average price of ware $ware`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar> get max price of ware <Var/Ware>`
+- **Short Description:** `<RetVar> get max price of ware <Var/Ware>`
+- **One Example:**
+  - `$max = get max price of ware $ware`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar> get min price of ware <Var/Ware>`
+- **Short Description:** `<RetVar> get min price of ware <Var/Ware>`
+- **One Example:**
+  - `$min = get min price of ware $ware`
 - **Edge Cases:** _None._
 
 #### Rule: `<RetVar> get maintype of ware <Var/Ware>`

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -70,6 +70,7 @@
 - **Short Description:** `<RefObj> interrupt with script <Script Name> and priority <Var/Number>: arg1=<Value> arg2=<Value> arg3=<Value> arg4=<Value>`
 - **One Example:**
   - `[THIS]-> interrupt with script 'plugin.advjump.jump' and priority 40: arg1=$target.pos arg2=null arg3=null arg4=null`
+- **Optional Parameter Definitions:** See [Flow Control Interrupt Optional Parameters](options/flow-control-interrupt-options.md).
 - **Edge Cases:** _None._
 
 #### Rule: `<RetVar/IF> get global variable: name=<Var/String>`
@@ -130,6 +131,7 @@
 - **Short Description:** Finds the best-price factory buying a ware from a given sector, honoring jump and exclusion limits.
 - **One Example:**
   - `$sell.Station = find factory: buys $ware with best price: min.price=$sell.at, amount=null, max.jumps=0, startsector=$sector, trader=null, exclude array=$exclude.array`
+- **Optional Parameter Definitions:** See [Station Trading Search Optional Parameters](options/station-trading-search-options.md).
 - **Edge Cases:** _None._
 
 #### Rule: `<RetVar> create ship: type=<Var/Ship Type> owner=<Var/Race> addto=<value> x=<Var/Number1> y=<Var/Number2> z=<Var/Number3>`

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -390,6 +390,18 @@
   - `$d.time = playing time`
 - **Edge Cases:** _None._
 
+#### Rule: `<RetVar/IF> <RefObj> get production cycle time: account for secondary resources=<Var/Number>`
+- **Short Description:** `<RetVar/IF> <RefObj> get production cycle time: account for secondary resources=<Var/Number>`
+- **One Example:**
+  - `$full.time = $factory-> get production cycle time: account for secondary resources=[FALSE]`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> <RefObj> get remaining production cycle time`
+- **Short Description:** `<RetVar/IF> <RefObj> get remaining production cycle time`
+- **One Example:**
+  - `$check.time = $factory-> get remaining production cycle time`
+- **Edge Cases:** _None._
+
 #### Rule: `<RetVar/IF> <RefObj> get tradeable ware array from station`
 - **Short Description:** `<RetVar/IF> <RefObj> get tradeable ware array from station`
 - **One Example:**

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -257,3 +257,39 @@
 - **One Example:**
   - `$factory.array = find station: sector=$sector class or type=[Factory] race=[Player] flags=$flags refobj=null maxdist=null maxnum=999 refpos=null`
 - **Edge Cases:** _None._
+
+#### Rule: `<RetVar> format time: <Var/Number>`
+- **Short Description:** `<RetVar> format time: <Var/Number>`
+- **One Example:**
+  - `$d.time = format time: $d.time`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> <RefObj> get user input: type=<Script Reference Type>, title=<Var/String>`
+- **Short Description:** `<RetVar/IF> <RefObj> get user input: type=<Script Reference Type>, title=<Var/String>`
+- **One Example:**
+  - `$destination = null-> get user input: type=[Var/Ship/Station owned by Player], title=$txt`
+- **Edge Cases:** _None._
+
+#### Rule: `display subtitle text: text=<Var/String> duration=<Var/Number> ms`
+- **Short Description:** `display subtitle text: text=<Var/String> duration=<Var/Number> ms`
+- **One Example:**
+  - `display subtitle text: text=$txt duration=2000 ms`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> <RefObj> get free amount of ware <Var/Ware> in cargo bay`
+- **Short Description:** `<RetVar/IF> <RefObj> get free amount of ware <Var/Ware> in cargo bay`
+- **One Example:**
+  - `if not $destination-> get free amount of ware $ware in cargo bay`
+- **Edge Cases:** _None._
+
+#### Rule: `write to log file <Var/Number> append=<Var/Number> value=<Value>`
+- **Short Description:** `write to log file <Var/Number> append=<Var/Number> value=<Value>`
+- **One Example:**
+  - `write to log file $DebugID append=[TRUE] value=$txt`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> playing time`
+- **Short Description:** `<RetVar/IF> playing time`
+- **One Example:**
+  - `$d.time = playing time`
+- **Edge Cases:** _None._

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -30,10 +30,16 @@
   - `if $target-> is of class [Moveable Ship]`
 - **Edge Cases:** _None._
 
+#### Rule: `<RetVar/IF> <RefObj> is detectable`
+- **Short Description:** `<RetVar/IF> <RefObj> is detectable`
+- **One Example:**
+  - `$detectable = $factory-> is detectable`
+- **Edge Cases:** _None._
+
 #### Rule: `append <Value> to array <Var/Array>`
 - **Short Description:** `append <Value> to array <Var/Array>`
 - **One Example:**
-  - `append $target.sector to array $target.pos`
+  - `append $format to array $menu`
 - **Edge Cases:** _None._
 
 #### Rule: `resize array <Var/Array> to <Var/Number>`
@@ -90,16 +96,28 @@
   - `$id = $object-> get ID code`
 - **Edge Cases:** _None._
 
+#### Rule: `<RetVar/IF> <RefObj> get local variable: name=<Var/String>`
+- **Short Description:** `<RetVar/IF> <RefObj> get local variable: name=<Var/String>`
+- **One Example:**
+  - `$settings.array = $factory-> get local variable: name=$pointer`
+- **Edge Cases:** _None._
+
+#### Rule: `<RefObj> set local variable: name=<Var/String> value=<Value>`
+- **Short Description:** `<RefObj> set local variable: name=<Var/String> value=<Value>`
+- **One Example:**
+  - `$factory-> set local variable: name=$pointer value=$settings.array`
+- **Edge Cases:** _None._
+
 #### Rule: `<RetVar> read text: page=<Var/Number1> id=<Var/Number2>`
 - **Short Description:** `<RetVar> read text: page=<Var/Number1> id=<Var/Number2>`
 - **One Example:**
-  - `$txt = read text: page=$PageID id=103`
+  - `$txt = read text: page=$PageID id=180`
 - **Edge Cases:** _None._
 
 #### Rule: `<RetVar> sprintf: pageid=<Var/Number> textid=<Var/Number>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
 - **Short Description:** `<RetVar> sprintf: pageid=<Var/Number> textid=<Var/Number>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
 - **One Example:**
-  - `$return = sprintf: pageid=$PageID textid=134, $name, $id, null, null, null`
+  - `$txt = sprintf: pageid=$PageID textid=2002, $factory.count, $product.count, $resource.count, null, null`
 - **Edge Cases:** _None._
 
 #### Rule: `<RetVar> get substring of <Var/String> offset=<Var/Number1> length=<Var/Number2>`
@@ -117,13 +135,19 @@
 #### Rule: `add custom menu info line to array <value>: text=<Var/String>`
 - **Short Description:** `add custom menu info line to array <value>: text=<Var/String>`
 - **One Example:**
-  - `add custom menu info line to array $menu: text=$temp.array`
+  - `add custom menu info line to array $menu: text=$txt`
+- **Edge Cases:** _None._
+
+#### Rule: `add custom menu heading to array <Var/Array>: title=<Var/String>`
+- **Short Description:** `add custom menu heading to array <Var/Array>: title=<Var/String>`
+- **One Example:**
+  - `add custom menu heading to array $menu: title=$txt`
 - **Edge Cases:** _None._
 
 #### Rule: `add custom menu heading to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
 - **Short Description:** `add custom menu heading to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
 - **One Example:**
-  - `add custom menu heading to array $menu: page=$PageID id=123`
+  - `add custom menu heading to array $menu: page=$PageID id=157`
 - **Edge Cases:** _None._
 
 #### Rule: `add custom menu info line to array <Var/Array>: page=<Var/Number1> id=<Var/Number2>`
@@ -135,31 +159,37 @@
 #### Rule: `add custom menu item to array <Var/Array>: page=<Var/Number1> id=<Var/Number2> returnvalue=<Value>`
 - **Short Description:** `add custom menu item to array <Var/Array>: page=<Var/Number1> id=<Var/Number2> returnvalue=<Value>`
 - **One Example:**
-  - `add custom menu item to array $menu: page=$PageID id=128 returnvalue='master.reset'`
+  - `add custom menu item to array $menu: page=$PageID id=158 returnvalue='product.all.on'`
+- **Edge Cases:** _None._
+
+#### Rule: `add section to custom menu: <Var/Array>`
+- **Short Description:** `add section to custom menu: <Var/Array>`
+- **One Example:**
+  - `add section to custom menu: $menu`
 - **Edge Cases:** _None._
 
 #### Rule: `dim <Var/Array> = <Value> [, <Value> ] [, <Value> ] ... [, <Value> ]`
 - **Short Description:** `dim <Var/Array> = <Value> [, <Value> ] [, <Value> ] ... [, <Value> ]`
 - **One Example:**
-  - `dim $return.array = 'add.dc', $dock`
+  - `dim $return.array = 'show.factory', $s`
 - **Edge Cases:** _None._
 
 #### Rule: `<RetVar/IF> = <Var/Array>[<Var/Number>]`
 - **Short Description:** `<RetVar/IF> = <Var/Array>[<Var/Number>]`
 - **One Example:**
-  - `$PageID = $al.Settings[1]`
+  - `$factory = $factory.array[$sf]`
 - **Edge Cases:** _None._
 
 #### Rule: `<Var/Array>[<Var/Number>] = <Value>`
 - **Short Description:** `<Var/Array>[<Var/Number>] = <Value>`
 - **One Example:**
-  - `$temp.array[0] = 1`
+  - `$settings.array[2] = 1`
 - **Edge Cases:** _None._
 
 #### Rule: `<RetVar> array alloc: size=<Var/Number>`
 - **Short Description:** `<RetVar> array alloc: size=<Var/Number>`
 - **One Example:**
-  - `$temp.array = array alloc: size=4`
+  - `$factory.show.array = array alloc: size=$s`
 - **Edge Cases:** _None._
 
 #### Rule: `<RetVar> create new array, arguments=<Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
@@ -168,10 +198,22 @@
   - `$format = create new array, arguments=$temp.array, $return.array, null, null, null`
 - **Edge Cases:** _None._
 
+#### Rule: `<RetVar/IF> reverse array <Value>`
+- **Short Description:** `<RetVar/IF> reverse array <Value>`
+- **One Example:**
+  - `$factory.array = reverse array $factory.array`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar> sort array <Value>`
+- **Short Description:** `<RetVar> sort array <Value>`
+- **One Example:**
+  - `$factory.array = sort array $factory.array`
+- **Edge Cases:** _None._
+
 #### Rule: `<RetVar/IF> size of array <Var/Array>`
 - **Short Description:** `<RetVar/IF> size of array <Var/Array>`
 - **One Example:**
-  - `$s = size of array $dock.array`
+  - `$s = size of array $sector.array`
 - **Edge Cases:** _None._
 
 #### Rule: `dec <Var>`
@@ -180,16 +222,22 @@
   - `dec $s`
 - **Edge Cases:** _None._
 
+#### Rule: `inc <Var>`
+- **Short Description:** `inc <Var>`
+- **One Example:**
+  - `inc $sector.count`
+- **Edge Cases:** _None._
+
 #### Rule: `<RetVar/IF/START> <RefObj> call script <Script Name> : [ arg1=<Value> arg2=<Value> ... arga=<Value> ]`
 - **Short Description:** `<RetVar/IF/START> <RefObj> call script <Script Name> : [ arg1=<Value> arg2=<Value> ... arga=<Value> ]`
 - **One Example:**
-  - `$txt = [THIS]-> call script 'plugin.LI.FDN.Format.Name' : object=$dc`
+  - `$sector.array = null-> call script 'plugin.LI.FDN.Sector.Array' : search=4`
 - **Edge Cases:** _None._
 
 #### Rule: `gosub <Label Name>:`
 - **Short Description:** `gosub <Label Name>:`
 - **One Example:**
-  - `gosub Add.DC.Menu.Sub:`
+  - `gosub Factory.Summary.Sub:`
 - **Edge Cases:** _None._
 
 #### Rule: `endsub`
@@ -202,4 +250,10 @@
 - **Short Description:** `<RetVar/IF> get station array: of race <Var/Race> class/type=<value>`
 - **One Example:**
   - `$dock.array = get station array: of race [Player] class/type=[Dock]`
+- **Edge Cases:** _None._
+
+#### Rule: `<RetVar/IF> find station: sector=<Var/Sector> class or type=<value> race=<Var/Race> flags=<Var/Number> refobj=<value> maxdist=<Var/Number2> maxnum=<Var/Number> refpos=<Var/Array>`
+- **Short Description:** `<RetVar/IF> find station: sector=<Var/Sector> class or type=<value> race=<Var/Race> flags=<Var/Number> refobj=<value> maxdist=<Var/Number2> maxnum=<Var/Number> refpos=<Var/Array>`
+- **One Example:**
+  - `$factory.array = find station: sector=$sector class or type=[Factory] race=[Player] flags=$flags refobj=null maxdist=null maxnum=999 refpos=null`
 - **Edge Cases:** _None._

--- a/docs/x3s-language.md
+++ b/docs/x3s-language.md
@@ -69,7 +69,7 @@
 #### Rule: `<RetVar/IF> get global variable: name=<Var/String>`
 - **Short Description:** Retrieves the value of a named global variable.
 - **One Example:**
-  - `$al.Settings = get global variable: name='al.LI.FDN.event'`
+  - `$config.Array = get global variable: name='config.scripts'`
 - **Edge Cases:** _None._
 
 #### Rule: `set global variable: name=<Var/String> value=<Value>`
@@ -111,7 +111,7 @@
 #### Rule: `<RetVar> read text: page=<Var/Number1> id=<Var/Number2>`
 - **Short Description:** `<RetVar> read text: page=<Var/Number1> id=<Var/Number2>`
 - **One Example:**
-  - `$txt = read text: page=$PageID id=180`
+  - `$section = read text: page=$PageID id=101`
 - **Edge Cases:** _None._
 
 #### Rule: `<RetVar> sprintf: pageid=<Var/Number> textid=<Var/Number>, <Value0>, <Value1>, <Value2>, <Value3>, <Value4>`
@@ -231,7 +231,7 @@
 #### Rule: `<RetVar/IF> = <Var/Array>[<Var/Number>]`
 - **Short Description:** `<RetVar/IF> = <Var/Array>[<Var/Number>]`
 - **One Example:**
-  - `$factory = $factory.array[$sf]`
+  - `$script = $script.Array[0]`
 - **Edge Cases:** _None._
 
 #### Rule: `<Var/Array>[<Var/Number>] = <Value>`
@@ -252,6 +252,12 @@
   - `$format = create new array, arguments=$temp.array, $return.array, null, null, null`
 - **Edge Cases:** _None._
 
+#### Rule: `remove element from array <Var/Array> at index <Var/Number>`
+- **Short Description:** `remove element from array <Var/Array> at index <Var/Number>`
+- **One Example:**
+  - `remove element from array $config.Array at index $s`
+- **Edge Cases:** _None._
+
 #### Rule: `<RetVar/IF> reverse array <Value>`
 - **Short Description:** `<RetVar/IF> reverse array <Value>`
 - **One Example:**
@@ -267,7 +273,7 @@
 #### Rule: `<RetVar/IF> size of array <Var/Array>`
 - **Short Description:** `<RetVar/IF> size of array <Var/Array>`
 - **One Example:**
-  - `$s = size of array $sector.array`
+  - `$s = size of array $config.Array`
 - **Edge Cases:** _None._
 
 #### Rule: `dec <Var>`
@@ -285,7 +291,7 @@
 #### Rule: `<RetVar/IF/START> <RefObj> call script <Script Name> : [ arg1=<Value> arg2=<Value> ... arga=<Value> ]`
 - **Short Description:** `<RetVar/IF/START> <RefObj> call script <Script Name> : [ arg1=<Value> arg2=<Value> ... arga=<Value> ]`
 - **One Example:**
-  - `$sector.array = null-> call script 'plugin.LI.FDN.Sector.Array' : search=4`
+  - `= [THIS]-> call script 'plugin.config.addscript' : argument1=$txt argument2=null argument3='plugin.LI.FDN.Main.Menu' argument4=[FALSE] argument5=$section argument6=null`
 - **Edge Cases:** _None._
 
 #### Rule: `gosub <Label Name>:`
@@ -339,7 +345,7 @@
 #### Rule: `write to log file <Var/Number> append=<Var/Number> value=<Value>`
 - **Short Description:** `write to log file <Var/Number> append=<Var/Number> value=<Value>`
 - **One Example:**
-  - `write to log file $DebugID append=[TRUE] value=$txt`
+  - `write to log file $DebugID append=[FALSE] value=$txt`
 - **Edge Cases:** _None._
 
 #### Rule: `<RetVar/IF> playing time`

--- a/scripts/provided/plugin.advjump.targeting.x3s
+++ b/scripts/provided/plugin.advjump.targeting.x3s
@@ -1,0 +1,41 @@
+* Third-party script snippet: advanced jumpdrive targeting routine
+
+if not $target.class == [Sector (X3TC)]
+if $target-> is of class [Moveable Ship]
+$target.command = $target-> get command
+$target.pos = $target-> get command target
+$target.sector = $target-> get sector
+$target.pos = $target-> get position as array
+append $target.sector to array $target.pos
+else
+$target.sector = $target-> get sector
+$target.pos = $target-> get position as array
+append $target.sector to array $target.pos
+end
+
+* target is a sector
+else
+resize array $target.pos to 0
+append 0 to array $target.pos
+append 0 to array $target.pos
+append 0 to array $target.pos
+append $target to array $target.pos
+$target.sector = $target
+end
+
+$this.sector = [THIS]-> get sector
+if $target.sector != $this.sector
+$jumps.needed = get jumps from sector $this.sector to sector $target.sector
+if $jumps.needed > 1
+if [THIS]-> get amount of ware {Advanced Jumpdrive} in cargo bay
+if [THIS]-> get amount of ware {FTL Jumpdrive Extension} in cargo bay
+[THIS]-> interrupt with script 'plugin.advjump.jump' and priority 40: arg1=$target.pos arg2=null arg3=null arg4=null
+else
+[THIS]-> interrupt with script 'plugin.advjump.jump' and priority 40: arg1=$target.sector arg2=null arg3=null arg4=null
+end
+end
+end
+end
+end
+
+return null


### PR DESCRIPTION
## Summary
- attach jump targeting script lines to the relevant object, array, flow control, and trading command rules
- record unmatched constructs from the script for future rule coverage
- generate an aggregated x3s-language reference that highlights the newly documented rules

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68ce06c861e883268f2031ca0dde5725