### PR TITLE
Fix SetLastReason call and menu sprintf formatting

### DIFF
--- a/docs/language/gotchas.md
+++ b/docs/language/gotchas.md
@@ -21,6 +21,7 @@ This reference collects common pitfalls encountered when writing X3S scripts.
   - `= null-> call script 'lib.slx.query' : function='SetStationWareConfig', station=$station, ware=$ware, cfg=$cfg`
   - `= null-> call script 'lib.slx.query' : function='SetLastReason', station=$station, ware=$ware, code='BAL_OK'`
 - **Edge Cases:** When you need the return value, assign it to a variable as usual (for example, `$result = [THIS]-> call script 'lib.slx.util' : ...`).
+  - Even when ignoring the result, add the `=` prefix to setter helpers such as `= null-> call script 'lib.slx.query' : function='SetLastReason', station=$station, ware=$ware, code=$code`; without it the call is skipped entirely.
 
 - #### Rule: `Quote script names and keep argument labels identifier-safe`
 - **Full Description:** Script names passed to `call script` must be wrapped in single quotes, and named arguments cannot contain spaces or punctuation that would break identifier parsing. Use camelCase or underscores for multi-word labels.
@@ -47,4 +48,11 @@ This reference collects common pitfalls encountered when writing X3S scripts.
 - **Examples:**
   - `$txt = sprintf: fmt='%s (Auto)', $txt, null, null, null, null`
 - **Edge Cases:** When formatting more than one value, supply each argument in order and continue padding the remaining slots with `null`.
+
+- #### Rule: `Limit 'sprintf: pageid' to five substitution values`
+- **Full Description:** The `sprintf: pageid=<...> textid=<...>` command accepts at most five value arguments. Provide no more than five placeholders in the target text resource and coalesce extra fields before calling `sprintf`.
+- **Examples:**
+  - `$chunkReason = sprintf: fmt='%s %s', $chunkPct, $reasonTxt, null, null, null`
+  - `$row = sprintf: pageid=$PageId textid=214, $ware, $role, $minPct, $maxPct, $chunkReason`
+- **Edge Cases:** Build composite strings (such as chunk + reason) with the `fmt=` variant before passing them to the localized `sprintf` call.
 

--- a/scripts/plugin.slx.manager.tick.x3s
+++ b/scripts/plugin.slx.manager.tick.x3s
@@ -855,7 +855,7 @@ StoreReasons:
       $code = sprintf: fmt='A_%s', $code, null, null, null, null
     end
     $stationRef = $entry[$IDX_STATION]
-    null -> call script 'lib.slx.query' : function='SetLastReason', station=$stationRef, ware=$currentWare, code=$code
+    = null -> call script 'lib.slx.query' : function='SetLastReason', station=$stationRef, ware=$currentWare, code=$code
     = wait 1 ms
   end
   return null

--- a/scripts/plugin.slx.station.menu.x3s
+++ b/scripts/plugin.slx.station.menu.x3s
@@ -48,7 +48,8 @@ while [TRUE]
     $cfgChunkPct = $cfg[$CHUNK_PCT]
     $reasonCode = null -> call script 'lib.slx.query' : function='GetLastReason', station=$station, ware=$ware
     $reasonTxt = null -> call script 'lib.slx.ui' : function='FormatReason', code=$reasonCode
-    $row = sprintf: pageid=$PageId textid=214, $ware, $cfgRole, $cfgMinPct, $cfgMaxPct, $cfgChunkPct, $reasonTxt
+    $chunkAndReason = sprintf: fmt='%s %s', $cfgChunkPct, $reasonTxt, null, null, null
+    $row = sprintf: pageid=$PageId textid=214, $ware, $cfgRole, $cfgMinPct, $cfgMaxPct, $chunkAndReason
     add custom menu item to array $menu: text=$row returnvalue=$ware
     = wait 1 ms
   end

--- a/t/89055-L044.xml
+++ b/t/89055-L044.xml
@@ -16,7 +16,7 @@
     <t id="211">Min %</t>
     <t id="212">Max %</t>
     <t id="213">Chunk %</t>
-    <t id="214">%s | %s %s %s %s %s</t>
+    <t id="214">%s | %s %s %s %s</t>
     <t id="215">Enroll Station</t>
     <t id="216">Unenroll Station</t>
     <t id="217">Store balanced</t>


### PR DESCRIPTION
## Summary
- ensure SetLastReason calls discard return values with the `=` prefix so they execute
- rework station menu row formatting to stay within the five-argument `sprintf` limit and update the text entry
- document both gotchas for future reference in the language guide

## Testing
- python tools/test_x3s.py *(fails: file not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb0168b648326814a02b497bfae2d