### PR TITLE
Remove unsupported AL plugin start text setter

### DIFF
--- a/scripts/plugin.slx.station.menu.x3s
+++ b/scripts/plugin.slx.station.menu.x3s
@@ -76,8 +76,8 @@ while [TRUE]
           continue
         end
         $cfg = null -> call script 'lib.slx.query' : function='GetStationWareConfig', station=$station, ware=$ware
-        null -> call script 'lib.slx.query' : function='SetStationWareConfig', station=$station, ware=$ware, cfg=$cfg
-        null -> call script 'lib.slx.query' : function='SetLastReason', station=$station, ware=$ware, code='BAL_OK'
+        = null -> call script 'lib.slx.query' : function='SetStationWareConfig', station=$station, ware=$ware, cfg=$cfg
+        = null -> call script 'lib.slx.query' : function='SetLastReason', station=$station, ware=$ware, code='BAL_OK'
         = wait 1 ms
       end
     end
@@ -143,8 +143,8 @@ while [TRUE]
   $cfg[$MAX_PCT] = $maxValue
   $cfg[$CHUNK_PCT] = $chunkValue
 
-  null -> call script 'lib.slx.query' : function='SetStationWareConfig', station=$station, ware=$ware, cfg=$cfg
-  null -> call script 'lib.slx.query' : function='SetLastReason', station=$station, ware=$ware, code='BAL_OK'
+  = null -> call script 'lib.slx.query' : function='SetStationWareConfig', station=$station, ware=$ware, cfg=$cfg
+  = null -> call script 'lib.slx.query' : function='SetLastReason', station=$station, ware=$ware, code='BAL_OK'
 
   = wait 10 ms
 end

--- a/scripts/setup.plugin.slx.x3s
+++ b/scripts/setup.plugin.slx.x3s
@@ -22,14 +22,10 @@ end
 set global variable: name='g.slx.manager.running' value=null
 
 $pluginTitle = read text: page=$PageId id=101
-$pluginMenu = read text: page=$PageId id=102
 
 al engine: register script='al.plugin.slx'
 if $pluginTitle
   al engine: set plugin 'al.plugin.slx' description to $pluginTitle
-end
-if $pluginMenu
-  al engine: set plugin 'al.plugin.slx' start text to $pluginMenu
 end
 al engine: set plugin 'al.plugin.slx' timer interval to 30 s
 


### PR DESCRIPTION
## Summary
- ensure the station menu toggles and save actions use the `=` prefix when calling setter helpers
- this allows SetStationWareConfig and SetLastReason invocations to run instead of being skipped by the X3S parser
- drop the undocumented AL plugin start text setter invocation so setup only uses supported commands

## Testing
- python tools/test_x3s.py *(fails: file not found in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb3101eb88326bade70e791fd64de