### PR TITLE
Ensure SLX config text loads and menu opens

### DIFF
--- a/scripts/plugin.slx.init.x3s
+++ b/scripts/plugin.slx.init.x3s
@@ -10,11 +10,21 @@ load text: id=$PageId
 $section = read text: page=$PageId id=101
 if not $section
   $section = 'SLX'
+else
+  $prefix = get substring of $section offset=0 length=8
+  if $prefix == 'ReadText'
+    $section = 'SLX'
+  end
 end
 
 $menuTitle = read text: page=$PageId id=102
 if not $menuTitle
   $menuTitle = 'Open SLX'
+else
+  $prefix = get substring of $menuTitle offset=0 length=8
+  if $prefix == 'ReadText'
+    $menuTitle = 'Open SLX'
+  end
 end
 
 = [THIS] -> call script 'plugin.config.addscript' : PluginName=$menuTitle, Author=null, ScriptName='plugin.slx.station.menu', DisplayAuthor=[FALSE], AddToSection=$section, Menu=null

--- a/scripts/plugin.slx.station.menu.x3s
+++ b/scripts/plugin.slx.station.menu.x3s
@@ -6,6 +6,8 @@
 
 $PageId = 89055
 
+load text: id=$PageId
+
 $ROLE = 0
 $MIN_PCT = 1
 $MAX_PCT = 2

--- a/scripts/setup.plugin.slx.x3s
+++ b/scripts/setup.plugin.slx.x3s
@@ -22,6 +22,12 @@ end
 set global variable: name='g.slx.manager.running' value=null
 
 $pluginTitle = read text: page=$PageId id=101
+if $pluginTitle
+  $prefix = get substring of $pluginTitle offset=0 length=8
+  if $prefix == 'ReadText'
+    $pluginTitle = null
+  end
+end
 
 al engine: register script='al.plugin.slx'
 if $pluginTitle


### PR DESCRIPTION
## Plan
- Guard against missing 89055 text by falling back to default strings when localization fails.
- Make sure the station configuration menu loads its text resources before building UI rows.

## Summary
- Fall back to hardcoded section and menu titles whenever the read text command yields a ReadText placeholder.
- Prevent the AL plugin description from using placeholder text by clearing unresolved localization values.
- Load the SLX text page inside the station menu script so the UI always has the localized strings available.

## Testing
- python tools/test_x3s.py *(fails: tools/test_x3s.py is not present in this repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbbc60c488326a79301e427a8e208