### PR TITLE
Add station command shortcut for SLX menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It ignores NPC trading and focuses purely on balancing your own production netwo
 3. Start or reload your game; the setup script will register SLX.
 
 ## How it works
-- Enroll a station via Plugin Config > SLX > Station Logistics.
+- Enroll a station via Plugin Config > SLX > Station Logistics or by running **Configure SLX Logistics** under a station's Additional Commands.
 - Each ware can be set as **Producer**, **Consumer**, or **Store** with Min/Max/Chunk limits.
 - A manager task runs roughly every 10 seconds and transfers wares in priority order:
     1. Producer -> Store when above Max%.

--- a/docs/language/ids.md
+++ b/docs/language/ids.md
@@ -3,10 +3,12 @@
 | Type | ID | Notes |
 |------|----|-------|
 | Text Page | 89055 | Core SLX strings |
+| Text ID | 103 | Station command label |
 | Text ID | 203 | Filled to Max reason |
 | Text ID | 217 | Store balanced reason |
 | Text ID | 218 | Exported to peer store reason |
 | Text ID | 219 | Imported from peer store reason |
 | Text ID | 220 | No peer store reason |
 | Text ID | 221 | Balance OK reason |
+| Command Slot | COMMAND_TYPE_STATION_51 | Station logistics command |
 

--- a/scripts/plugin.slx.station.command.x3s
+++ b/scripts/plugin.slx.station.command.x3s
@@ -1,0 +1,28 @@
+* ******************************************************************************
+* SCRIPT NAME: plugin.slx.station.command
+* DESCRIPTION: Station command entry point for SLX logistics menu
+* AUTHOR:      SLX Team                DATE: 21 October 2025
+* ******************************************************************************
+
+$station = [THIS]
+if not $station
+  return null
+end
+
+if not $station -> is of class [Station]
+  return null
+end
+
+$owner = $station -> get owner race
+if $owner != [Player]
+  return null
+end
+
+$enabled = get global variable: name='g.slx.enabled'
+if not $enabled
+  return null
+end
+
+= null -> call script 'plugin.slx.station.menu' : station=$station
+
+return null

--- a/scripts/setup.plugin.slx.x3s
+++ b/scripts/setup.plugin.slx.x3s
@@ -29,6 +29,18 @@ if $pluginTitle
 end
 al engine: set plugin 'al.plugin.slx' timer interval to 30 s
 
+* Register station command shortcut for the configuration menu
+$cmdTitle = read text: page=$PageId id=103
+if not $cmdTitle
+  $cmdTitle = 'Configure SLX Logistics'
+end
+
+$commandId = COMMAND_TYPE_STATION_51
+set script command: command=$commandId script='plugin.slx.station.command'
+set script command description: command=$commandId text=$cmdTitle
+set script command upgrade: command=$commandId upgrade=null
+global script map: set: key=$commandId class=Station race=Player script='plugin.slx.station.command'
+
 = [THIS] -> call script 'plugin.slx.init' :
 
 return null

--- a/t/89055-L044.xml
+++ b/t/89055-L044.xml
@@ -3,6 +3,7 @@
   <page id="89055" title="SLX" desc="" voice="no">
     <t id="101">SLX</t>
     <t id="102">Open SLX</t>
+    <t id="103">Configure SLX Logistics</t>
     <t id="201">At minimum threshold</t>
     <t id="202">No partner available</t>
     <t id="203">At maximum threshold</t>


### PR DESCRIPTION
## Summary
- add a station command wrapper that forwards directly into the SLX configuration menu
- register the new command slot, text id, and document the allocation for translation tracking
- document the new station command entry point for players in the README

## Testing
- `python tools/test_x3s.py` *(fails: script not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e007276c708326affb89797beb9e16